### PR TITLE
Validate in backend that an user is not added twice 

### DIFF
--- a/backend/t4cclient/core/authentication/database/__init__.py
+++ b/backend/t4cclient/core/authentication/database/__init__.py
@@ -84,3 +84,16 @@ def check_write_permission(
     if not user:
         return get_user(db=db, username=get_username(token)).role == Role.ADMIN
     return RepositoryUserPermission.WRITE == user.permission
+
+
+def check_username_not_in_repository(
+    repository: str,
+    username: str,
+    db=Depends(get_db),
+):
+    user = repository_users.get_user_of_repository(db, repository, username)
+    if user:
+        raise HTTPException(
+            status_code=409,
+            detail="The user already exists for this repository.",
+        )

--- a/backend/t4cclient/routes/repositories/users.py
+++ b/backend/t4cclient/routes/repositories/users.py
@@ -1,5 +1,6 @@
 import typing as t
 
+# from backend.t4cclient.core.authentication.database import check_username_exists
 import t4cclient.extensions.modelsources.t4c.connection as t4c_manager
 import t4cclient.schemas.repositories as schema_repositories
 from fastapi import APIRouter, Depends, HTTPException
@@ -9,6 +10,7 @@ from t4cclient.core.authentication.database import (
     is_admin,
     verify_repository_role,
     verify_write_permission,
+    check_username_not_in_repository,
 )
 from t4cclient.core.authentication.helper import get_username
 from t4cclient.core.authentication.jwt_bearer import JWTBearer
@@ -46,6 +48,9 @@ def add_user_to_repository(
     verify_repository_role(
         project, allowed_roles=["manager", "administrator"], token=token, db=db
     )
+
+    check_username_not_in_repository(project, body.username, db=db)
+
     users.find_or_create_user(db, body.username)
     check_username_not_admin(body.username, db)
     if body.role == schema_repositories.RepositoryUserRole.MANAGER:

--- a/backend/t4cclient/routes/repositories/users.py
+++ b/backend/t4cclient/routes/repositories/users.py
@@ -1,16 +1,15 @@
 import typing as t
 
-# from backend.t4cclient.core.authentication.database import check_username_exists
 import t4cclient.extensions.modelsources.t4c.connection as t4c_manager
 import t4cclient.schemas.repositories as schema_repositories
 from fastapi import APIRouter, Depends, HTTPException
 from requests import HTTPError, Session
 from t4cclient.core.authentication.database import (
     check_username_not_admin,
+    check_username_not_in_repository,
     is_admin,
     verify_repository_role,
     verify_write_permission,
-    check_username_not_in_repository,
 )
 from t4cclient.core.authentication.helper import get_username
 from t4cclient.core.authentication.jwt_bearer import JWTBearer

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -46,3 +46,5 @@ Thumbs.db
 
 /src/environments/environment.prod.ts
 /src/environments/environment.dev.ts
+
+.angular


### PR DESCRIPTION
This PR fixes #19. In the `backend` function `add_user_to_repository` it is checked that an user is not added a second time. Otherwise a `HTTPException` is raised. 