### PR TITLE
frontend-settings: improve user search

### DIFF
--- a/frontend/src/app/settings/admin-settings/admin-user-settings/admin-user-settings.component.ts
+++ b/frontend/src/app/settings/admin-settings/admin-user-settings/admin-user-settings.component.ts
@@ -72,7 +72,8 @@ export class AdminUserSettingsComponent implements OnInit {
 
   getUsersByRole(role: 'administrator' | 'user'): Array<User> {
     return this.users.filter(
-      (u) => u.role == role && u.name.includes(this.search.toLowerCase())
+      (u) => u.role == role
+      && u.name.toLowerCase().includes(this.search.toLowerCase())
     );
   }
 }


### PR DESCRIPTION
This PR fixes the problem that during search for specific users they were not suggested if theirs names contained capital letters. 
It may also fix #45.