### PR TITLE
Add configuration diff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,8 @@ Run the following steps:
    *Hint*: If you already have the k8d cluster running and the if you have the
    application deployed, then no configuration values need to be adjusted.
 
+   *Hint*: You can run `python -m t4cclient.config.diff` after each update to check if your config is up to date.
+
 4. This step is only **necessary, if you use the self signed certificate** option for the oauth mock.
 
    If you don't have the certificate in your local certificate store, please execute the following command:

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -26,10 +26,11 @@ install_requires =
 
 [options.extras_require]
 dev = 
-    pytest
     black
-    pylint
+    deepdiff
     mypy
+    pylint
+    pytest
 
 [options.entry_points]
 capellacollab.extensions.backups =

--- a/backend/t4cclient/config/__init__.py
+++ b/backend/t4cclient/config/__init__.py
@@ -11,6 +11,8 @@ import typing as t
 import appdirs
 import yaml
 
+from . import loader
+
 log = logging.getLogger(__name__)
 
 
@@ -126,19 +128,8 @@ class ConfigList(list):
     __imul__ = _unsupported
 
 
-config = ConfigDict({})
-
-locations: list[pathlib.Path] = [
-    pathlib.Path(__file__).parents[1] / "config" / "config.yaml",
-    pathlib.Path(appdirs.user_config_dir("capellacollab", "db")) / "config.yaml",
-    pathlib.Path("/etc/capellacollab/config.yaml"),
-]
-
-log.debug("Searching for configuration files...")
-for l in locations:
-    log.debug("Looking at location %s", str(l))
-    if l.exists():
-        config = ConfigDict(yaml.safe_load(l.open()))
-        break
+config_tmp = loader.load_yaml()
+if config_tmp:
+    config = ConfigDict(config_tmp)
 else:
-    log.info("Found no configuration file. Only environment variables will be used.")
+    config = ConfigDict({})

--- a/backend/t4cclient/config/diff.py
+++ b/backend/t4cclient/config/diff.py
@@ -1,0 +1,59 @@
+# Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import pathlib
+
+import deepdiff
+import yaml
+
+from . import loader
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+
+
+print("Start comparison of configuration files")
+
+config_template = yaml.safe_load(
+    (pathlib.Path(__file__).parents[2] / "config" / "config_template.yaml").open()
+)
+
+config = loader.load_yaml()
+
+diff = deepdiff.DeepDiff(
+    config, config_template, ignore_order=True, report_repetition=True
+)
+
+for key, value in (
+    diff.get("type_changes", {}) | diff.get("values_changed", {})
+).items():
+    new_value = value["new_value"]
+    print(
+        f"{bcolors.OKBLUE}"
+        f"Your configuration differs to the template. Key {key} has a different value. Expected value '{new_value}'. If you changed the value on purpose, you can ignore this message."
+        f"{bcolors.ENDC}"
+    )
+
+for key in diff.get("dictionary_item_removed", {}):
+    print(
+        f"{bcolors.WARNING}"
+        f"Found unknown configuration option {key}!"
+        f"{bcolors.ENDC}"
+    )
+
+for key in diff.get("dictionary_item_added", ""):
+    print(
+        f"{bcolors.FAIL}"
+        f"Missing configuration option {key}. Please add the key to your configuration file."
+        f"{bcolors.ENDC}"
+    )
+
+if not diff:
+    print("Your configuration file is up to date!")

--- a/backend/t4cclient/config/loader.py
+++ b/backend/t4cclient/config/loader.py
@@ -1,0 +1,30 @@
+# Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import appdirs
+import yaml
+
+log = logging.getLogger(__name__)
+
+locations: list[pathlib.Path] = [
+    pathlib.Path(__file__).parents[2] / "config" / "config.yaml",
+    pathlib.Path(appdirs.user_config_dir("capellacollab", "db")) / "config.yaml",
+    pathlib.Path("/etc/capellacollab/config.yaml"),
+]
+
+
+def load_yaml() -> None | dict:
+    log.debug("Searching for configuration files...")
+    for l in locations:
+        if l.exists():
+            log.info("Found configuration file at location %s", str(l))
+            return yaml.safe_load(l.open())
+        else:
+            log.debug("Didn't find a configuration file at location %s", str(l))
+
+    return None


### PR DESCRIPTION
Our configuration file changes pretty often, e.g. when introducing new configuration values.
We require the users to have an up to date configuration file.
In the usual workflow, it is hard to see if a value or key changed in the template.
This PR automates the comparision.
A developer can now see directly when a value is changed by running `python -m t4cclient.config.diff`