### PR TITLE
Rework modelloading

### DIFF
--- a/backend/t4cclient/__main__.py
+++ b/backend/t4cclient/__main__.py
@@ -19,15 +19,6 @@ from t4cclient.config import config
 from t4cclient.core.database import __main__ as database
 from t4cclient.routes import router, status
 
-# Load extension models
-eps = (
-    metadata.entry_points()["capellacollab.extensions.backups"]
-    + metadata.entry_points()["capellacollab.extensions.modelsources"]
-)
-for ep in eps:
-    log.info("Import models of extension %s", ep.name)
-    ep.load().models
-
 database.migrate_db()
 
 

--- a/backend/t4cclient/alembic/env.py
+++ b/backend/t4cclient/alembic/env.py
@@ -19,11 +19,14 @@ config = context.config
 # with the path given in the config of the main code
 config.set_main_option("sqlalchemy.url", cfg["database"]["url"])
 
-
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.attributes.get("configure_logger", True):
     fileConfig(config.config_file_name)
+
+# Import models
+import t4cclient.sql_models  # isort:skip
+from t4cclient.sql_models import extensions  # isort:skip
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/backend/t4cclient/extensions/backups/ease/__init__.py
+++ b/backend/t4cclient/extensions/backups/ease/__init__.py
@@ -1,4 +1,2 @@
 # Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
-
-from . import crud, models, routes

--- a/backend/t4cclient/extensions/backups/jenkins/__init__.py
+++ b/backend/t4cclient/extensions/backups/jenkins/__init__.py
@@ -13,8 +13,6 @@ import t4cclient.extensions.modelsources.git.crud as crud_git_models
 import t4cclient.extensions.modelsources.git.models as database_git_models
 from t4cclient.config import config
 
-from . import crud, models, routes
-
 cfg = config["backups"]["jenkins"]
 JENKINS_AUTH = (cfg["username"], cfg["password"])
 

--- a/backend/t4cclient/extensions/modelsources/git/__init__.py
+++ b/backend/t4cclient/extensions/modelsources/git/__init__.py
@@ -1,4 +1,2 @@
 # Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
-
-from . import crud, models, routes

--- a/backend/t4cclient/extensions/modelsources/t4c/__init__.py
+++ b/backend/t4cclient/extensions/modelsources/t4c/__init__.py
@@ -1,4 +1,2 @@
 # Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
-
-from . import connection, crud, models, routes

--- a/backend/t4cclient/routes/repositories/__init__.py
+++ b/backend/t4cclient/routes/repositories/__init__.py
@@ -1,6 +1,7 @@
 # Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import logging
 import typing as t
 from importlib import metadata
@@ -109,7 +110,7 @@ eps = metadata.entry_points()["capellacollab.extensions.backups"]
 for ep in eps:
     log.info("Add routes of backup extension %s", ep.name)
     router.include_router(
-        ep.load().routes.router,
+        importlib.import_module(".routes", ep.module).router,
         prefix="/{project}/extensions/backups/" + ep.name,
         tags=[ep.name],
     )
@@ -119,7 +120,7 @@ eps = metadata.entry_points()["capellacollab.extensions.modelsources"]
 for ep in eps:
     log.info("Add routes of modelsource %s", ep.name)
     router.include_router(
-        ep.load().routes.router,
+        importlib.import_module(".routes", ep.module).router,
         prefix="/{project}/extensions/modelsources/" + ep.name,
         tags=[ep.name],
     )

--- a/backend/t4cclient/sql_models/extensions.py
+++ b/backend/t4cclient/sql_models/extensions.py
@@ -1,0 +1,16 @@
+# Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+import importlib
+import logging
+from importlib import metadata
+
+log = logging.getLogger(__name__)
+
+# Load extension models
+eps = (
+    metadata.entry_points()["capellacollab.extensions.backups"]
+    + metadata.entry_points()["capellacollab.extensions.modelsources"]
+)
+for ep in eps:
+    log.info("Import models of extension %s", ep.name)
+    importlib.import_module(".models", ep.module)


### PR DESCRIPTION
alembic didn't find the models, because they were not loaded corretly in the `env.py`.
Also, the new extensions were not loaded correctly.
The way of loading resulted in a circular import, because for each extension all submodules were loaded.
This is now fixed.