### PR TITLE
Set admins by default as t4c-repository-admins during project creation

### DIFF
--- a/backend/config/config_template.yaml
+++ b/backend/config/config_template.yaml
@@ -83,7 +83,7 @@ modelsources:
   t4c: 
 
     usageAPI: http://localhost:8080/mock
-    restAPI: http://localhost:8080/mock/api/v1.0
+    restAPI: http://localhost:7000/mock/api/v1.0
 
     username: sampleuser
     password: samplepassword

--- a/backend/t4cclient/core/authentication/database/__init__.py
+++ b/backend/t4cclient/core/authentication/database/__init__.py
@@ -3,6 +3,7 @@
 
 import sqlalchemy.orm.session
 from fastapi import Depends, HTTPException
+
 from t4cclient.core.authentication.helper import get_username
 from t4cclient.core.authentication.jwt_bearer import JWTBearer
 from t4cclient.core.database import get_db, repository_users

--- a/backend/t4cclient/extensions/backups/ease/routes.py
+++ b/backend/t4cclient/extensions/backups/ease/routes.py
@@ -6,18 +6,18 @@ import typing as t
 import uuid
 
 import requests
-import t4cclient.core.authentication.database as auth
 from fastapi import APIRouter, Depends
 from requests import Session
+
+import t4cclient.core.authentication.database as auth
+from . import crud, helper, models
 from t4cclient.config import config
 from t4cclient.core import credentials
 from t4cclient.core.authentication.jwt_bearer import JWTBearer
 from t4cclient.core.database import get_db
-from t4cclient.sessions.operators import OPERATOR
-from t4cclient.extensions.modelsources import git, t4c
 from t4cclient.core.oauth.responses import AUTHENTICATION_RESPONSES
-
-from . import crud, helper, models
+from t4cclient.extensions.modelsources import git, t4c
+from t4cclient.sessions.operators import OPERATOR
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ def create_backup(
 
     username = "techuser-" + str(uuid.uuid4())
     password = credentials.generate_password()
-    t4c.connection.add_user_to_repository(project, username, password)
+    t4c.connection.add_user_to_repository(project, username, password, is_admin=False)
 
     reference = OPERATOR.create_cronjob(
         image=config["docker"]["images"]["backup"],

--- a/backend/t4cclient/extensions/modelsources/t4c/connection.py
+++ b/backend/t4cclient/extensions/modelsources/t4c/connection.py
@@ -1,13 +1,17 @@
 # Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard library:
 import json
 import logging
 import typing as t
 from socket import timeout
 
+# 3rd party:
 import requests
 from requests.auth import HTTPBasicAuth
+
+# local:
 from t4cclient.config import config
 from t4cclient.core.credentials import generate_password
 
@@ -84,14 +88,14 @@ def add_user_to_repository(
     repository: str,
     username: str,
     password: str = generate_password(),
-    isAdmin: bool = False,
+    is_admin: bool = False,
 ):
     r = requests.post(
         config["modelsources"]["t4c"]["restAPI"] + "/users",
         params={"repositoryName": repository},
         json={
             "id": username,
-            "isAdmin": isAdmin,
+            "isAdmin": is_admin,
             "password": password,
         },
         auth=T4C_BACKEND_AUTHENTICATION,

--- a/backend/t4cclient/extensions/modelsources/t4c/connection.py
+++ b/backend/t4cclient/extensions/modelsources/t4c/connection.py
@@ -81,14 +81,17 @@ def fetch_last_seen(mac_addr: str):
 
 
 def add_user_to_repository(
-    repository: str, username: str, password: str = generate_password()
+    repository: str,
+    username: str,
+    password: str = generate_password(),
+    isAdmin: bool = False,
 ):
     r = requests.post(
         config["modelsources"]["t4c"]["restAPI"] + "/users",
         params={"repositoryName": repository},
         json={
             "id": username,
-            "isAdmin": False,
+            "isAdmin": isAdmin,
             "password": password,
         },
         auth=T4C_BACKEND_AUTHENTICATION,

--- a/backend/t4cclient/routes/repositories/__init__.py
+++ b/backend/t4cclient/routes/repositories/__init__.py
@@ -6,9 +6,11 @@ import logging
 import typing as t
 from importlib import metadata
 
-import t4cclient.core.services.repositories as repository_service
 from fastapi import APIRouter, Depends
 from requests import Session
+
+import t4cclient.core.services.repositories as repository_service
+from . import users as router_users
 from t4cclient.core.authentication.database import (
     is_admin,
     verify_admin,
@@ -16,18 +18,16 @@ from t4cclient.core.authentication.database import (
 )
 from t4cclient.core.authentication.helper import get_username
 from t4cclient.core.authentication.jwt_bearer import JWTBearer
-from t4cclient.core.database import get_db, repositories, repository_users
+from t4cclient.core.database import get_db, repositories
 from t4cclient.core.database import users as database_users
-from t4cclient.extensions.modelsources.t4c import connection
 from t4cclient.core.oauth.responses import AUTHENTICATION_RESPONSES
+from t4cclient.extensions.modelsources.t4c import connection
 from t4cclient.schemas.repositories import (
     GetRepositoryUserResponse,
     PostRepositoryRequest,
     RepositoryUserPermission,
     RepositoryUserRole,
 )
-
-from . import users as router_users
 
 log = logging.getLogger(__name__)
 router = APIRouter()

--- a/backend/t4cclient/routes/repositories/__init__.py
+++ b/backend/t4cclient/routes/repositories/__init__.py
@@ -83,7 +83,7 @@ def create_repository(
 ):
     verify_admin(token, db)
     connection.create_repository(body.name)
-    connection.add_user_to_repository(body.name, get_username(token), isAdmin=True)
+    connection.add_user_to_repository(body.name, get_username(token), is_admin=True)
     connection.create_repository(body.name)
     return repositories.create_repository(db, body.name)
 

--- a/backend/t4cclient/routes/repositories/__init__.py
+++ b/backend/t4cclient/routes/repositories/__init__.py
@@ -16,7 +16,7 @@ from t4cclient.core.authentication.database import (
 )
 from t4cclient.core.authentication.helper import get_username
 from t4cclient.core.authentication.jwt_bearer import JWTBearer
-from t4cclient.core.database import get_db, repositories
+from t4cclient.core.database import get_db, repositories, repository_users
 from t4cclient.core.database import users as database_users
 from t4cclient.extensions.modelsources.t4c import connection
 from t4cclient.core.oauth.responses import AUTHENTICATION_RESPONSES
@@ -82,6 +82,7 @@ def create_repository(
     token=Depends(JWTBearer()),
 ):
     verify_admin(token, db)
+    connection.add_user_to_repository(body.name, get_username(token), isAdmin=True)
     connection.create_repository(body.name)
     return repositories.create_repository(db, body.name)
 

--- a/backend/t4cclient/routes/repositories/__init__.py
+++ b/backend/t4cclient/routes/repositories/__init__.py
@@ -82,6 +82,7 @@ def create_repository(
     token=Depends(JWTBearer()),
 ):
     verify_admin(token, db)
+    connection.create_repository(body.name)
     connection.add_user_to_repository(body.name, get_username(token), isAdmin=True)
     connection.create_repository(body.name)
     return repositories.create_repository(db, body.name)

--- a/backend/t4cclient/routes/repositories/users.py
+++ b/backend/t4cclient/routes/repositories/users.py
@@ -116,7 +116,7 @@ def patch_repository_user(
                 raise HTTPException(
                     status_code=500,
                     detail="Invalid response from T4C Server",
-                )
+                ) from err
 
     if body.permission:
         verify_repository_role(

--- a/backend/t4cclient/routes/repositories/users.py
+++ b/backend/t4cclient/routes/repositories/users.py
@@ -3,10 +3,11 @@
 
 import typing as t
 
-import t4cclient.extensions.modelsources.t4c.connection as t4c_manager
-import t4cclient.schemas.repositories as schema_repositories
 from fastapi import APIRouter, Depends, HTTPException
 from requests import HTTPError, Session
+
+import t4cclient.extensions.modelsources.t4c.connection as t4c_manager
+import t4cclient.schemas.repositories as schema_repositories
 from t4cclient.core.authentication.database import (
     check_username_not_admin,
     check_username_not_in_repository,
@@ -58,7 +59,7 @@ def add_user_to_repository(
     if body.role == schema_repositories.RepositoryUserRole.MANAGER:
         body.permission == schema_repositories.RepositoryUserPermission.WRITE
     if body.permission == schema_repositories.RepositoryUserPermission.WRITE:
-        t4c_manager.add_user_to_repository(project, body.username)
+        t4c_manager.add_user_to_repository(project, body.username, is_admin=False)
     return repository_users.add_user_to_repository(
         db, project, body.role, body.username, body.permission
     )
@@ -101,7 +102,9 @@ def patch_repository_user(
             db=db,
         )
         verify_write_permission(project, token, db)
-        if not is_admin(token, db) and get_username(token) != username:
+
+        admin = is_admin(token, db)
+        if not admin and get_username(token) != username:
             raise HTTPException(
                 status_code=403,
                 detail="The username does not match with your user. You have to be administrator to edit other users.",
@@ -111,7 +114,9 @@ def patch_repository_user(
             t4c_manager.update_password_of_user(project, username, body.password)
         except HTTPError as err:
             if err.response.status_code == 404:
-                t4c_manager.add_user_to_repository(project, username, body.password)
+                t4c_manager.add_user_to_repository(
+                    project, username, body.password, is_admin=admin
+                )
             else:
                 raise HTTPException(
                     status_code=500,

--- a/mocks/t4c-server/mock/users.py
+++ b/mocks/t4c-server/mock/users.py
@@ -2,13 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fastapi import APIRouter
+from pydantic import BaseModel
+
 
 router = APIRouter()
 
 
+class PostServerRequest(BaseModel):
+    id: str
+    isAdmin: bool
+    password: str
+
+
 @router.post("/")
-def add_user():
-    return {}
+def add_user(body: PostServerRequest, repositoryName: str):
+    print(body)
+    return body
 
 
 @router.delete("/{userName}")

--- a/mocks/t4c-server/mock/users.py
+++ b/mocks/t4c-server/mock/users.py
@@ -8,15 +8,14 @@ from pydantic import BaseModel
 router = APIRouter()
 
 
-class PostServerRequest(BaseModel):
+class PostUserRequest(BaseModel):
     id: str
     isAdmin: bool
     password: str
 
 
 @router.post("/")
-def add_user(body: PostServerRequest, repositoryName: str):
-    print(body)
+def add_user(body: PostUserRequest, repositoryName: str):
     return body
 
 

--- a/mocks/t4c-server/mock/users.py
+++ b/mocks/t4c-server/mock/users.py
@@ -1,11 +1,13 @@
 # Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-
 router = APIRouter()
+logger = logging.getLogger()
 
 
 class PostUserRequest(BaseModel):
@@ -16,14 +18,17 @@ class PostUserRequest(BaseModel):
 
 @router.post("/")
 def add_user(body: PostUserRequest, repositoryName: str):
+    logger.info("Added user with body %s.", body)
     return body
 
 
 @router.delete("/{userName}")
-def remove_user():
+def remove_user(userName: str):
+    logger.info("Removed user %s.", userName)
     return {}
 
 
 @router.put("/{userName}")
-def update_user():
+def update_user(userName: str):
+    logger.info("Updated user %s.")
     return {}


### PR DESCRIPTION
This PR relates to issue #36. Here, application admins are set by default as t4c repository admins during project creation.

