### PR TITLE
handling oauth errors

### DIFF
--- a/frontend/src/app/auth/auth-redirect/auth-redirect.component.ts
+++ b/frontend/src/app/auth/auth-redirect/auth-redirect.component.ts
@@ -27,6 +27,16 @@ export class AuthRedirectComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((params) => {
+      if (params['error']) {
+        const test = Object.keys(params).map(key => {
+          key
+        })
+        const redirect_url = '/auth?' + Object.keys(params).map(key => 
+          ['error', 'error_description', 'error_uri'].includes(key) ? [key, params[key]].join('=') : ""
+        ).join('&')
+        this.router.navigateByUrl(redirect_url)
+        return
+      }
       this.authService
         .getAccessToken(params['code'], params['state'])
         .subscribe((res) => {

--- a/frontend/src/app/auth/auth-redirect/auth-redirect.component.ts
+++ b/frontend/src/app/auth/auth-redirect/auth-redirect.component.ts
@@ -23,16 +23,13 @@ export class AuthRedirectComponent implements OnInit {
     private router: Router,
     private repositoryService: RepositoryService,
     private cookieService: CookieService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((params) => {
       if (params['error']) {
-        const test = Object.keys(params).map(key => {
-          key
-        })
-        const redirect_url = '/auth?' + Object.keys(params).map(key => 
-          ['error', 'error_description', 'error_uri'].includes(key) ? [key, params[key]].join('=') : ""
+        const redirect_url = '/auth?' + Object.keys(params).map(key =>
+          ['error', 'error_description', 'error_uri'].includes(key) ? [key, params[key]].join('=') : ""
         ).join('&')
         this.router.navigateByUrl(redirect_url)
         return

--- a/frontend/src/app/auth/auth/auth.component.css
+++ b/frontend/src/app/auth/auth/auth.component.css
@@ -24,3 +24,14 @@ button {
   max-width: 400px;
   margin-bottom: 20px;
 }
+
+#oauth-error {
+  max-width: 400px;
+  margin: auto;
+  color: white;
+  background-color: #dc3545;
+}
+
+#oauth-error a {
+  color: whitesmoke
+}

--- a/frontend/src/app/auth/auth/auth.component.html
+++ b/frontend/src/app/auth/auth/auth.component.html
@@ -10,6 +10,13 @@
     This service enables co-working on Capella MBSE projects. <br />
     To continue to the service you need an invite from an existing user. <br />
   </div>
+  <mat-card *ngIf="params.has('error')" id="oauth-error">
+    <p>The OAuth2 server raised the following error:<br>
+      <b>{{ params.get('error') }}</b>
+    </p>
+    <p *ngIf="params.has('error_description')">{{ params.get('error_description') }} </p>
+    <p *ngIf="params.has('error_uri')">More informations: <a href="{{ params.get('error_uri') }}">{{ params.get('error_uri') }}</a></p>
+  </mat-card>
   <div id="oauth-login">
     <button mat-flat-button color="primary" (click)="webSSO()">
       Login with {{ authProvider }}

--- a/frontend/src/app/auth/auth/auth.component.ts
+++ b/frontend/src/app/auth/auth/auth.component.ts
@@ -8,6 +8,7 @@ import {
   OnInit,
   SimpleChanges,
 } from '@angular/core';
+import { ActivatedRoute, ParamMap } from '@angular/router';
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { environment } from 'src/environments/environment';
 
@@ -25,10 +26,18 @@ export class AuthComponent implements OnInit {
   }
 
   authProvider = environment.authentication;
+  public params = {} as ParamMap;
 
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    public route: ActivatedRoute,
+  ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.route.queryParamMap.subscribe(res => {
+      this.params = res;
+    })
+  }
 
   webSSO() {
     this.authService.getRedirectURL().subscribe((res) => {

--- a/frontend/src/app/auth/auth/auth.component.ts
+++ b/frontend/src/app/auth/auth/auth.component.ts
@@ -30,8 +30,8 @@ export class AuthComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
-    public route: ActivatedRoute,
-  ) {}
+    private route: ActivatedRoute,
+  ) { }
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe(res => {


### PR DESCRIPTION
# Description

When the OAuth2 redirects to the callback with an error, the user is redirected to the login page, and is shown an error message. The parameters taken in account are _error_, _error_description_ and _error_uri_, as specified in [the OAuth2 specification](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2).

Resolves #65

# Testing

Following [this link](http://localhost:4200/oauth2/callback?error=access_denied&error_description=OAuth2%20token%20access%20for%20this%20resource%20is%20prohibited.&error_uri=https:%2F%2Fmock.oauth.de%2Faccess_denied%0D%0A) should redirect to the login page and show an error message containing the error, its description (if any) and its uri (if any)

# Checklist

- [ ] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I updated the documentation with the new functionality
- [ ] I went through the code and removed all print statements, breakpoints and unused code
- [ ] Error handling for all possible scenarios has been implemented
- [ ] I've add logging for all relevant operations
- [ ] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
