### PR TITLE
Replace ngx simplebar

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,1 +1,4 @@
 config
+.venv
+.vscode
+build

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,6 @@
         "@angular/router": "~13.3.3",
         "ngx-cookie": "^6.0.0",
         "rxjs": "~7.5.5",
-        "simplebar-angular": "^2.3.6",
         "tslib": "^2.3.1",
         "zone.js": "~0.11.5"
       },
@@ -2405,11 +2404,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
-    },
     "node_modules/@ngtools/webpack": {
       "version": "13.3.3",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-13.3.3.tgz",
@@ -3700,11 +3694,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001332",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
@@ -4157,6 +4146,7 @@
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
       "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
+      "dev": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -7420,17 +7410,8 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -10432,37 +10413,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simplebar": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.6.tgz",
-      "integrity": "sha512-FJUMbV+hNDd/m+1/fvD41TXKd5mSdlI5zgBygkaQIV3SffNbcLhSbJT6ufTs8ZNRLJ6i+qc/KCFMqWmvlGWMhA==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.3.1",
-        "can-use-dom": "^0.1.0",
-        "core-js": "^3.0.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.memoize": "^4.1.2",
-        "lodash.throttle": "^4.1.1"
-      }
-    },
-    "node_modules/simplebar-angular": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/simplebar-angular/-/simplebar-angular-2.3.6.tgz",
-      "integrity": "sha512-chSUdCYCLOdajbCA73oL/OU+H/YFNGGdAYkcYx76YDY81C3sj3vMePjuW8cPgZZHwSCGI+opcl6xoBsCK56fJA==",
-      "dependencies": {
-        "simplebar": "^5.3.6",
-        "tslib": "^1.9.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^8.1.3",
-        "@angular/core": "^8.1.3"
-      }
-    },
-    "node_modules/simplebar-angular/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/slash": {
       "version": "4.0.0",
@@ -13475,11 +13425,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@juggle/resize-observer": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
-    },
     "@ngtools/webpack": {
       "version": "13.3.3",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-13.3.3.tgz",
@@ -14533,11 +14478,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
-    },
     "caniuse-lite": {
       "version": "1.0.30001332",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
@@ -14877,7 +14817,8 @@
     "core-js": {
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
-      "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag=="
+      "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.21.1",
@@ -17232,17 +17173,8 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -19461,35 +19393,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "simplebar": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-5.3.6.tgz",
-      "integrity": "sha512-FJUMbV+hNDd/m+1/fvD41TXKd5mSdlI5zgBygkaQIV3SffNbcLhSbJT6ufTs8ZNRLJ6i+qc/KCFMqWmvlGWMhA==",
-      "requires": {
-        "@juggle/resize-observer": "^3.3.1",
-        "can-use-dom": "^0.1.0",
-        "core-js": "^3.0.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.memoize": "^4.1.2",
-        "lodash.throttle": "^4.1.1"
-      }
-    },
-    "simplebar-angular": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/simplebar-angular/-/simplebar-angular-2.3.6.tgz",
-      "integrity": "sha512-chSUdCYCLOdajbCA73oL/OU+H/YFNGGdAYkcYx76YDY81C3sj3vMePjuW8cPgZZHwSCGI+opcl6xoBsCK56fJA==",
-      "requires": {
-        "simplebar": "^5.3.6",
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
     },
     "slash": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "@angular/router": "~13.3.3",
     "ngx-cookie": "^6.0.0",
     "rxjs": "~7.5.5",
-    "simplebar-angular": "^2.3.6",
     "tslib": "^2.3.1",
     "zone.js": "~0.11.5"
   },

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -51,7 +51,6 @@ import { RepositorySyncSettingsComponent } from './settings/admin-settings/repos
 import { T4CRepoSettingsComponent } from './settings/repository-manager-settings/repository-settings/model-source/t4c-repo-settings/t4c-repo-settings.component';
 import { RepositoryUserSettingsComponent } from './settings/repository-manager-settings/repository-settings/repository-user-settings/repository-user-settings.component';
 import { ProjectDeletionDialogComponent } from './settings/repository-manager-settings/repository-settings/model-source/t4c-repo-settings/project-deletion-dialog/project-deletion-dialog.component';
-import { SimplebarAngularModule } from 'simplebar-angular';
 import { GitModelDeletionDialogComponent } from './settings/repository-manager-settings/repository-settings/model-source/git-model-settings/git-model-deletion-dialog/git-model-deletion-dialog.component';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { WarningComponent } from './home/request-session/warning/warning.component';
@@ -145,7 +144,6 @@ import { CookieModule } from 'ngx-cookie';
     MatCheckboxModule,
     MatSnackBarModule,
     FormsModule,
-    SimplebarAngularModule,
     OverlayModule,
     MatSlideToggleModule,
     MatMenuModule,

--- a/frontend/src/app/settings/admin-settings/admin-user-settings/admin-user-settings.component.css
+++ b/frontend/src/app/settings/admin-settings/admin-user-settings/admin-user-settings.component.css
@@ -40,3 +40,8 @@ button {
   padding-bottom: 0px;
   width: 400px;
 }
+
+.scrollable {
+  max-height: 40vh;
+  overflow-y: auto;
+}

--- a/frontend/src/app/settings/admin-settings/admin-user-settings/admin-user-settings.component.html
+++ b/frontend/src/app/settings/admin-settings/admin-user-settings/admin-user-settings.component.html
@@ -16,28 +16,26 @@
       />
       <mat-icon matSuffix>search</mat-icon>
     </mat-form-field>
-    <ngx-simplebar class="user-selection">
-      <mat-selection-list #adminusers [multiple]="false">
-        <div mat-subheader>Administrators</div>
-        <mat-list-option
-          *ngFor="let user of getUsersByRole('administrator')"
-          [value]="user"
-        >
-          <mat-icon mat-list-icon>account_circle</mat-icon>
-          <div mat-line>{{ user.name }}</div>
-          <div mat-line>{{ repoUserService.ADVANCED_ROLES[user.role] }}</div>
-        </mat-list-option>
-        <div mat-subheader>Users</div>
-        <mat-list-option
-          *ngFor="let user of getUsersByRole('user')"
-          [value]="user"
-        >
-          <mat-icon mat-list-icon>account_circle</mat-icon>
-          <div mat-line>{{ user.name }}</div>
-          <div mat-line>{{ repoUserService.ADVANCED_ROLES[user.role] }}</div>
-        </mat-list-option>
-      </mat-selection-list>
-    </ngx-simplebar>
+    <mat-selection-list #adminusers [multiple]="false" class="scrollable simple-scroll">
+      <div mat-subheader>Administrators</div>
+      <mat-list-option
+        *ngFor="let user of getUsersByRole('administrator')"
+        [value]="user"
+      >
+        <mat-icon mat-list-icon>account_circle</mat-icon>
+        <div mat-line>{{ user.name }}</div>
+        <div mat-line>{{ repoUserService.ADVANCED_ROLES[user.role] }}</div>
+      </mat-list-option>
+      <div mat-subheader>Users</div>
+      <mat-list-option
+        *ngFor="let user of getUsersByRole('user')"
+        [value]="user"
+      >
+        <mat-icon mat-list-icon>account_circle</mat-icon>
+        <div mat-line>{{ user.name }}</div>
+        <div mat-line>{{ repoUserService.ADVANCED_ROLES[user.role] }}</div>
+      </mat-list-option>
+    </mat-selection-list>
 
     <div *ngIf="adminusers.selectedOptions.selected.length">
       <button

--- a/frontend/src/app/settings/repository-manager-settings/repository-settings/repository-user-settings/repository-user-settings.component.css
+++ b/frontend/src/app/settings/repository-manager-settings/repository-settings/repository-user-settings/repository-user-settings.component.css
@@ -20,3 +20,8 @@ button {
   padding-bottom: 0px;
   width: 400px;
 }
+
+.scrollable {
+  max-height: 40vh;
+  overflow-y: scroll;
+}

--- a/frontend/src/app/settings/repository-manager-settings/repository-settings/repository-user-settings/repository-user-settings.component.html
+++ b/frontend/src/app/settings/repository-manager-settings/repository-settings/repository-user-settings/repository-user-settings.component.html
@@ -15,34 +15,32 @@
     />
     <mat-icon matSuffix>search</mat-icon> </mat-form-field
   >.
-  <ngx-simplebar class="user-selection">
-    <mat-selection-list #users [multiple]="false">
-      <div mat-subheader>Managers</div>
-      <mat-list-option
-        *ngFor="let user of getRepositoryUsersByRole('manager')"
-        [value]="user"
-      >
-        <mat-icon mat-list-icon>account_circle</mat-icon>
-        <div mat-line>{{ user.username }}</div>
-        <div mat-line>
-          {{ repoUserService.ADVANCED_ROLES[user.role] }},
-          {{ repoUserService.PERMISSIONS[user.permission] }}
-        </div>
-      </mat-list-option>
-      <div mat-subheader>Users</div>
-      <mat-list-option
-        *ngFor="let user of getRepositoryUsersByRole('user')"
-        [value]="user"
-      >
-        <mat-icon mat-list-icon>account_circle</mat-icon>
-        <div mat-line>{{ user.username }}</div>
-        <div mat-line>
-          {{ repoUserService.ADVANCED_ROLES[user.role] }},
-          {{ repoUserService.PERMISSIONS[user.permission] }}
-        </div>
-      </mat-list-option>
-    </mat-selection-list>
-  </ngx-simplebar>
+  <mat-selection-list #users [multiple]="false" class="scrollable simple-scroll">
+    <div mat-subheader>Managers</div>
+    <mat-list-option
+      *ngFor="let user of getRepositoryUsersByRole('manager')"
+      [value]="user"
+    >
+      <mat-icon mat-list-icon>account_circle</mat-icon>
+      <div mat-line>{{ user.username }}</div>
+      <div mat-line>
+        {{ repoUserService.ADVANCED_ROLES[user.role] }},
+        {{ repoUserService.PERMISSIONS[user.permission] }}
+      </div>
+    </mat-list-option>
+    <div mat-subheader>Users</div>
+    <mat-list-option
+      *ngFor="let user of getRepositoryUsersByRole('user')"
+      [value]="user"
+    >
+      <mat-icon mat-list-icon>account_circle</mat-icon>
+      <div mat-line>{{ user.username }}</div>
+      <div mat-line>
+        {{ repoUserService.ADVANCED_ROLES[user.role] }},
+        {{ repoUserService.PERMISSIONS[user.permission] }}
+      </div>
+    </mat-list-option>
+  </mat-selection-list>
 
   <div
     *ngIf="

--- a/frontend/src/custom-theme.scss
+++ b/frontend/src/custom-theme.scss
@@ -46,3 +46,19 @@ $theme: mat.define-light-theme(
 );
 
 @include mat.all-component-themes($theme);
+
+/* width */
+.simple-scroll::-webkit-scrollbar {
+  width: 10px;
+}
+
+/* Handle */
+.simple-scroll::-webkit-scrollbar-thumb {
+  background: grey;
+  border-radius: 10px;
+}
+
+.simple-scroll::-webkit-scrollbar-thumb:hover {
+  background: lightgrey;
+  border-radius: 10px;
+}


### PR DESCRIPTION
# Description

The ngx-simplebar wrapper was removed from the project and its two occurrences were replaced. Now it uses .simple-scroll class and relies on ::webkit-scrollbar for the style. The new style is accessible with the .simple-scroll class for all scrollable blocks.

![image](https://user-images.githubusercontent.com/45000485/172812863-4ac2cf1e-a706-4ba3-94e3-02f19056b0d4.png)

There is no transition between the normal and hovered effect, as it's not possible without ~~a sorcery~~ a significant complexity overhead that for the sake of reusability I prefer not using.

Resolves #83 

# Testing

# Checklist

- [ ] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I updated the documentation with the new functionality
- [ ] I went through the code and removed all print statements, breakpoints and unused code
- [ ] Error handling for all possible scenarios has been implemented
- [ ] I've add logging for all relevant operations
- [ ] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
