### PR TITLE
Add t4c server mock in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ Do not use it in production!
   source.venv/bin/activate
   pip install -U pip setuptools
   pip install -e '.[options]'
+  ```
 
 1. Launch the server :
   The port must match the key modelsources.t4c.usageAPI in the backend
@@ -110,7 +111,7 @@ Run the following steps:
    make create-cluster
    ```
 
-1. In order to use Guacamole, the cluster must be deployed :
+1. In order to use Guacamole, the cluster must be deployed:
   ```sh
   make deploy
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,24 @@ Do not use it in production!
 4. Verify that the server runs, e.g. by navigating to
    [Well Known](https://localhost:8083/default/.well-known/openid-configuration)
 
+## t4cserver
+
+1. Navigate to `mocks/t4cserver/`.
+1. Setup a local python environment
+  ```sh
+  python3 -m venv .venv
+  source.venv/bin/activate
+  pip install -U pip setuptools
+  pip install -e '.[options]'
+
+1. Launch the server :
+  The port must match the key modelsources.t4c.usageAPI in the backend
+  config. Change it to 7000 for example.
+  ```sh
+  source .venv/bin/activate # if not sourced before
+  uvicorn mock:app --host 0.0.0.0 --port 7000 --reload
+  ```
+
 ## Backend
 
 Requirements:
@@ -92,16 +110,21 @@ Run the following steps:
    make create-cluster
    ```
 
+1. In order to use Guacamole, the cluster must be deployed :
+  ```sh
+  make deploy
+  ```
+
 1. Navigate to the `backend` directory of your cloned repository.
 1. We recommend that you develop inside of a virtual environment. To set it up,
    run the following commands:
 
-   ```sh
-   python3 -m venv .venv
-   source .venv/bin/activate
-   pip install -U pip setuptools
-   pip install -e '.[dev]'
-   ```
+  ```sh
+  python3 -m venv .venv
+  source .venv/bin/activate
+  pip install -U pip setuptools
+  pip install -e '.[dev]'
+  ```
 
 1. The backend uses various configuration settings. You can find them in the `config`
    directory.


### PR DESCRIPTION
# Description

This PR adds the instructions to launch a t4cserver in the CONTRIBUTING file, and specify that the cluster must be runned to use Guacamole.

# Testing

Please @jamilraichouni follow this tutorial to be sure that the good instructions are provided.

# Checklist

- [ ] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I updated the documentation with the new functionality
- [ ] I went through the code and removed all print statements, breakpoints and unused code
- [ ] Error handling for all possible scenarios has been implemented
- [ ] I've add logging for all relevant operations
- [ ] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
