### PR TITLE
Rename legacy repositories to projects

### DIFF
--- a/backend/capellacollab/core/authentication/database/__init__.py
+++ b/backend/capellacollab/core/authentication/database/__init__.py
@@ -5,13 +5,13 @@
 import sqlalchemy.orm.session
 from fastapi import Depends, HTTPException
 
-import capellacollab.projects.users.crud as repository_users
+import capellacollab.projects.users.crud as project_users
 from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.database import get_db
 from capellacollab.projects.users.models import (
-    RepositoryUserPermission,
-    RepositoryUserRole,
+    ProjectUserPermission,
+    ProjectUserRole,
 )
 from capellacollab.sessions.database import get_session_by_id
 from capellacollab.settings.modelsources.git import crud
@@ -34,24 +34,24 @@ def is_admin(token=Depends(JWTBearer()), db=Depends(get_db)) -> bool:
 
 
 def verify_project_role(
-    repository: str,
+    project: str,
     token: JWTBearer,
     db: sqlalchemy.orm.session.Session,
     allowed_roles=["user", "manager", "administrator"],
 ):
     if not check_project_role(
-        repository=repository, allowed_roles=allowed_roles, token=token, db=db
+        project=project, allowed_roles=allowed_roles, token=token, db=db
     ):
         raise HTTPException(
             status_code=403,
             detail={
-                "reason": f"One of the roles '{allowed_roles}' in the repository '{repository}' is required.",
+                "reason": f"One of the roles '{allowed_roles}' in the project '{project}' is required.",
             },
         )
 
 
 def check_project_role(
-    repository: str,
+    project: str,
     token: JWTBearer,
     db: sqlalchemy.orm.session.Session,
     allowed_roles=["user", "manager", "administrator"],
@@ -62,13 +62,12 @@ def check_project_role(
         (
             "user" in allowed_roles
             and any(
-                project.projects_name == repository
-                for project in user.projects
+                project.projects_name == project for project in user.projects
             ),
             "manager" in allowed_roles
             and any(
-                project.projects_name == repository
-                and project.role == RepositoryUserRole.MANAGER
+                project.projects_name == project
+                and project.role == ProjectUserRole.MANAGER
                 for project in user.projects
             ),
             "administrator" in allowed_roles and user.role == Role.ADMIN,
@@ -85,44 +84,42 @@ def check_username_not_admin(username: str, db):
 
 
 def verify_write_permission(
-    repository: str,
+    project: str,
     token: JWTBearer,
     db: sqlalchemy.orm.session.Session,
 ):
-    if not check_write_permission(repository, token, db):
+    if not check_write_permission(project, token, db):
         raise HTTPException(
             status_code=403,
             detail={
-                "reason": "You need to have 'write'-access in the repository!",
+                "reason": "You need to have 'write'-access in the project!",
             },
         )
 
 
 def check_write_permission(
-    repository: str,
+    project: str,
     token: JWTBearer,
     db: sqlalchemy.orm.session.Session,
 ) -> bool:
 
-    user = repository_users.get_user_of_repository(
-        db, repository, get_username(token)
-    )
+    user = project_users.get_user_of_project(db, project, get_username(token))
     if not user:
         return get_user(db=db, username=get_username(token)).role == Role.ADMIN
-    return RepositoryUserPermission.WRITE == user.permission
+    return ProjectUserPermission.WRITE == user.permission
 
 
-def check_username_not_in_repository(
-    repository: str,
+def check_username_not_in_project(
+    project: str,
     username: str,
     db: sqlalchemy.orm.session.Session,
 ):
-    user = repository_users.get_user_of_repository(db, repository, username)
+    user = project_users.get_user_of_project(db, project, username)
     if user:
         raise HTTPException(
             status_code=409,
             detail={
-                "reason": "The user already exists in this repository.",
+                "reason": "The user already exists in this project.",
             },
         )
 

--- a/backend/capellacollab/core/authentication/database/git_models.py
+++ b/backend/capellacollab/core/authentication/database/git_models.py
@@ -5,16 +5,19 @@
 from fastapi import HTTPException
 
 import capellacollab.extensions.modelsources.git.crud as crud_git_models
+import capellacollab.projects.models as crud_git_models
 
 
-def verify_gitmodel_permission(repository: str, git_model_id: int, db):
+def verify_gitmodel_permission(
+    project: str, model_id: str, git_model_id: int, db
+):
+
+    # FIXME: Validate if the gitmodel is part of a specific model and the model is part of the project
     if (
-        crud_git_models.get_model_by_id(
-            db, repository, git_model_id
-        ).repository_name
-        != repository
+        crud_git_models.get_gitmodel_by_id(db, git_model_id).model_id
+        != model_id
     ):
         raise HTTPException(
             status_code=403,
-            detail="The Git Model is not part of the specified repository!",
+            detail="The Git repository is not part of the specified model and project!",
         )

--- a/backend/capellacollab/core/authentication/responses.py
+++ b/backend/capellacollab/core/authentication/responses.py
@@ -23,7 +23,11 @@ AUTHENTICATION_RESPONSES = {
             "application/json": {
                 "example": {
                     "error": {
-                        "detail": "One of the roles '[user, manager, administrator]' in the repository test is required."
+                        "detail": {
+                            "reason": {
+                                "One of the roles '[user, manager, administrator]' in the project test is required."
+                            }
+                        }
                     }
                 }
             }

--- a/backend/capellacollab/core/services/repositories.py
+++ b/backend/capellacollab/core/services/repositories.py
@@ -8,21 +8,21 @@ from sqlalchemy.orm.session import Session
 
 import capellacollab.extensions.modelsources.git.crud as git_model_crud
 import capellacollab.extensions.modelsources.t4c.connection as t4c_ext
-import capellacollab.projects.models as repository_schema
+import capellacollab.projects.models as project_models
 import capellacollab.projects.users.models as users_schema
-from capellacollab.projects.users.models import RepositoryUserPermission
+from capellacollab.projects.users.models import ProjectUserPermission
 
 
 def get_permission(
-    repo_permission: RepositoryUserPermission,
-    repository_name: str,
+    repo_permission: ProjectUserPermission,
+    project: str,
     db: Session,
-) -> t.List[RepositoryUserPermission]:
-    allowed_permissions: t.List[RepositoryUserPermission] = []
+) -> t.List[ProjectUserPermission]:
+    allowed_permissions: t.List[ProjectUserPermission] = []
 
-    if git_model_crud.get_primary_model_of_repository(db, repository_name):
-        allowed_permissions.append(RepositoryUserPermission.READ)
+    if git_model_crud.get_primary_gitmodel_of_capellamodels(db, project):
+        allowed_permissions.append(ProjectUserPermission.READ)
 
-    if repo_permission == RepositoryUserPermission.WRITE:
-        allowed_permissions.append(RepositoryUserPermission.WRITE)
+    if repo_permission == ProjectUserPermission.WRITE:
+        allowed_permissions.append(ProjectUserPermission.WRITE)
     return allowed_permissions

--- a/backend/capellacollab/extensions/modelsources/git/routes.py
+++ b/backend/capellacollab/extensions/modelsources/git/routes.py
@@ -142,7 +142,6 @@ def patch_model(
 
 @router.get(
     "/primary/revisions",
-    tags=["Repositories"],
     responses=AUTHENTICATION_RESPONSES,
 )
 def get_revisions(

--- a/backend/capellacollab/projects/capellamodels/routes.py
+++ b/backend/capellacollab/projects/capellamodels/routes.py
@@ -93,7 +93,7 @@ def create_new(
             },
         )
     verify_project_role(
-        repository=project.name,
+        project=project.name,
         token=token,
         db=db,
         allowed_roles=["manager", "administrator"],

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -101,7 +101,7 @@ def get_repository_by_name(project: str, db: Session = Depends(get_db)):
 
 
 @router.get("/details/", tags=["projects"], response_model=Project)
-def get(
+def get_project_details(
     slug: str,
     db: Session = Depends(get_db),
 ):
@@ -110,7 +110,7 @@ def get(
 
 
 @router.post("/", tags=["projects"], responses=AUTHENTICATION_RESPONSES)
-def create_repository(
+def create_project(
     body: PostRepositoryRequest,
     db: Session = Depends(get_db),
     token: JWTBearer = Depends(JWTBearer()),

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -34,8 +34,8 @@ from capellacollab.projects.models import (
 )
 from capellacollab.projects.users.models import (
     ProjectUserAssociation,
-    RepositoryUserPermission,
-    RepositoryUserRole,
+    ProjectUserPermission,
+    ProjectUserRole,
 )
 
 from .capellamodels.routes import router as router_models
@@ -94,13 +94,13 @@ def update_project(
 
 
 @router.get(
-    "/{project}", tags=["Repositories"], responses=AUTHENTICATION_RESPONSES
+    "/{project}", tags=["projects"], responses=AUTHENTICATION_RESPONSES
 )
 def get_repository_by_name(project: str, db: Session = Depends(get_db)):
     return convert_project(crud.get_project(db, project))
 
 
-@router.get("/details/", response_model=Project)
+@router.get("/details/", tags=["projects"], response_model=Project)
 def get(
     slug: str,
     db: Session = Depends(get_db),
@@ -109,7 +109,7 @@ def get(
     return convert_project(project)
 
 
-@router.post("/", tags=["Repositories"], responses=AUTHENTICATION_RESPONSES)
+@router.post("/", tags=["projects"], responses=AUTHENTICATION_RESPONSES)
 def create_repository(
     body: PostRepositoryRequest,
     db: Session = Depends(get_db),
@@ -125,23 +125,23 @@ def create_repository(
                 "technical": "Slug already used",
             },
         ) from e
-    users_crud.add_user_to_repository(
+    users_crud.add_user_to_project(
         db,
         project.name,
-        RepositoryUserRole.MANAGER,
+        ProjectUserRole.MANAGER,
         get_username(token),
-        RepositoryUserPermission.WRITE,
+        ProjectUserPermission.WRITE,
     )
     return convert_project(project)
 
 
 @router.delete(
     "/{project}",
-    tags=["Repositories"],
+    tags=["projects"],
     status_code=204,
     responses=AUTHENTICATION_RESPONSES,
 )
-def delete_repository(
+def delete_project(
     project: str, db: Session = Depends(get_db), token=Depends(JWTBearer())
 ):
     verify_admin(token, db)
@@ -158,23 +158,23 @@ def convert_project(project: DatabaseProject) -> Project:
                 [
                     user
                     for user in project.users
-                    if user.role == RepositoryUserRole.MANAGER
+                    if user.role == ProjectUserRole.MANAGER
                 ]
             ),
             contributors=len(
                 [
                     user
                     for user in project.users
-                    if user.role == RepositoryUserRole.USER
-                    and user.permission == RepositoryUserPermission.WRITE
+                    if user.role == ProjectUserRole.USER
+                    and user.permission == ProjectUserPermission.WRITE
                 ]
             ),
             subscribers=len(
                 [
                     user
                     for user in project.users
-                    if user.role == RepositoryUserRole.USER
-                    and user.permission == RepositoryUserPermission.READ
+                    if user.role == ProjectUserRole.USER
+                    and user.permission == ProjectUserPermission.READ
                 ]
             ),
         ),

--- a/backend/capellacollab/projects/users/crud.py
+++ b/backend/capellacollab/projects/users/crud.py
@@ -6,12 +6,12 @@ from sqlalchemy.orm import Session
 
 from capellacollab.projects.users.models import (
     ProjectUserAssociation,
-    RepositoryUserPermission,
-    RepositoryUserRole,
+    ProjectUserPermission,
+    ProjectUserRole,
 )
 
 
-def get_users_of_repository(db: Session, projects_name: str):
+def get_users_of_project(db: Session, projects_name: str):
     return (
         db.query(ProjectUserAssociation)
         .filter(ProjectUserAssociation.projects_name == projects_name)
@@ -19,7 +19,7 @@ def get_users_of_repository(db: Session, projects_name: str):
     )
 
 
-def get_user_of_repository(db: Session, projects_name: str, username: str):
+def get_user_of_project(db: Session, projects_name: str, username: str):
     return (
         db.query(ProjectUserAssociation)
         .filter(ProjectUserAssociation.projects_name == projects_name)
@@ -28,12 +28,12 @@ def get_user_of_repository(db: Session, projects_name: str, username: str):
     )
 
 
-def add_user_to_repository(
+def add_user_to_project(
     db: Session,
     projects_name: str,
-    role: RepositoryUserRole,
+    role: ProjectUserRole,
     username: str,
-    permission: RepositoryUserPermission,
+    permission: ProjectUserPermission,
 ):
     association = ProjectUserAssociation(
         projects_name=projects_name,
@@ -47,27 +47,27 @@ def add_user_to_repository(
     return association
 
 
-def change_role_of_user_in_repository(
-    db: Session, projects_name: str, role: RepositoryUserRole, username: str
+def change_role_of_user_in_project(
+    db: Session, projects_name: str, role: ProjectUserRole, username: str
 ):
-    repo_user = (
+    project_user = (
         db.query(ProjectUserAssociation)
         .filter(ProjectUserAssociation.projects_name == projects_name)
         .filter(ProjectUserAssociation.username == username)
         .first()
     )
-    if role == RepositoryUserRole.MANAGER:
-        repo_user.permission = RepositoryUserPermission.WRITE
-    repo_user.role = role
+    if role == ProjectUserRole.MANAGER:
+        project_user.permission = ProjectUserPermission.WRITE
+    project_user.role = role
     db.commit()
-    db.refresh(repo_user)
-    return repo_user
+    db.refresh(project_user)
+    return project_user
 
 
-def change_permission_of_user_in_repository(
+def change_permission_of_user_in_project(
     db: Session,
     projects_name: str,
-    permission: RepositoryUserPermission,
+    permission: ProjectUserPermission,
     username: str,
 ):
     repo_user = (
@@ -82,16 +82,14 @@ def change_permission_of_user_in_repository(
     return repo_user
 
 
-def delete_user_from_repository(
-    db: Session, projects_name: str, username: str
-):
+def delete_user_from_project(db: Session, projects_name: str, username: str):
     db.query(ProjectUserAssociation).filter(
         ProjectUserAssociation.username == username
     ).filter(ProjectUserAssociation.projects_name == projects_name).delete()
     db.commit()
 
 
-def delete_all_repositories_for_user(db: Session, username: str):
+def delete_all_projects_for_user(db: Session, username: str):
     db.query(ProjectUserAssociation).filter(
         ProjectUserAssociation.username == username
     ).delete()

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -12,30 +12,30 @@ from sqlalchemy.orm import relationship
 from capellacollab.core.database import Base
 
 
-class RepositoryUserRole(enum.Enum):
+class ProjectUserRole(enum.Enum):
     USER = "user"
     MANAGER = "manager"
     ADMIN = "administrator"
 
 
-class RepositoryUserPermission(enum.Enum):
+class ProjectUserPermission(enum.Enum):
     READ = "read"
     WRITE = "write"
 
 
-class RepositoryUser(BaseModel):
+class ProjectUser(BaseModel):
     username: str
-    role: RepositoryUserRole
-    permission: RepositoryUserPermission
+    role: ProjectUserRole
+    permission: ProjectUserPermission
 
     class Config:
         orm_mode = True
 
 
-class PatchRepositoryUser(BaseModel):
-    role: t.Optional[RepositoryUserRole]
+class PatchProjectUser(BaseModel):
+    role: t.Optional[ProjectUserRole]
     password: t.Optional[str]
-    permission: t.Optional[RepositoryUserPermission]
+    permission: t.Optional[ProjectUserPermission]
 
 
 class ProjectUserAssociation(Base):
@@ -45,5 +45,5 @@ class ProjectUserAssociation(Base):
     projects_name = Column(ForeignKey("projects.name"), primary_key=True)
     user = relationship("DatabaseUser", back_populates="projects")
     projects = relationship("DatabaseProject", back_populates="users")
-    permission = Column(Enum(RepositoryUserPermission), nullable=False)
-    role = Column(Enum(RepositoryUserRole))
+    permission = Column(Enum(ProjectUserPermission), nullable=False)
+    role = Column(Enum(ProjectUserRole))

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -11,8 +11,6 @@ from sqlalchemy.orm import Session
 
 import capellacollab.extensions.modelsources.git.crud as git_models_crud
 import capellacollab.extensions.modelsources.t4c.connection as t4c_manager
-import capellacollab.projects.crud as repositories_crud
-import capellacollab.projects.users.models as users_models
 import capellacollab.users.crud as users
 from capellacollab.core.authentication.database import (
     is_admin,
@@ -25,10 +23,10 @@ from capellacollab.core.authentication.responses import (
 )
 from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
-from capellacollab.projects.users.crud import RepositoryUserRole
+from capellacollab.projects.users.crud import ProjectUserRole
 from capellacollab.sessions import database, guacamole
 from capellacollab.sessions.models import DatabaseSession
-from capellacollab.sessions.operators import OPERATOR, Operator, get_operator
+from capellacollab.sessions.operators import Operator, get_operator
 from capellacollab.sessions.schema import (
     AdvancedSessionResponse,
     DepthType,
@@ -58,8 +56,8 @@ def get_current_sessions(
 
     db_user = users.get_user(db=db, username=get_username(token))
     if not any(
-        repo_user.role == RepositoryUserRole.MANAGER
-        for repo_user in db_user.repositories
+        project_user.role == ProjectUserRole.MANAGER
+        for project_user in db_user.projects
     ):
         raise HTTPException(
             status_code=403,
@@ -71,11 +69,11 @@ def get_current_sessions(
         list(
             itertools.chain.from_iterable(
                 [
-                    database.get_sessions_for_repository(db, repository)
-                    for repository in [
-                        r.repository_name
-                        for r in db_user.repositories
-                        if r.role == RepositoryUserRole.MANAGER
+                    database.get_sessions_for_repository(db, project)
+                    for project in [
+                        p.name
+                        for p in db_user.projects
+                        if p.role == ProjectUserRole.MANAGER
                     ]
                 ]
             )

--- a/backend/capellacollab/users/routes.py
+++ b/backend/capellacollab/users/routes.py
@@ -7,7 +7,7 @@ import typing as t
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-import capellacollab.projects.users.crud as repository_users
+import capellacollab.projects.users.crud as project_users
 import capellacollab.users.crud as users
 from capellacollab.core.authentication.database import is_admin, verify_admin
 from capellacollab.core.authentication.helper import get_username
@@ -69,7 +69,7 @@ def delete_user(
     username: str, db: Session = Depends(get_db), token=Depends(JWTBearer())
 ):
     verify_admin(token, db)
-    repository_users.delete_all_repositories_for_user(db, username)
+    project_users.delete_all_projects_for_user(db, username)
     users.delete_user(db=db, username=username)
 
 
@@ -83,7 +83,7 @@ def update_role_of_user(
     verify_admin(token, db)
     users.find_or_create_user(db, username)
     if body.role == Role.ADMIN:
-        repository_users.delete_all_repositories_for_user(db, username)
+        project_users.delete_all_projects_for_user(db, username)
     return users.update_role_of_user(db, username, body.role)
 
 

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -4,10 +4,10 @@
 from uuid import uuid1
 
 from capellacollab.projects.crud import create_project
-from capellacollab.projects.users.crud import add_user_to_repository
+from capellacollab.projects.users.crud import add_user_to_project
 from capellacollab.projects.users.models import (
-    RepositoryUserPermission,
-    RepositoryUserRole,
+    ProjectUserPermission,
+    ProjectUserRole,
 )
 from capellacollab.users.crud import create_user
 from capellacollab.users.models import Role
@@ -32,12 +32,12 @@ def test_get_projects_as_user_with_project(client, db, username):
     project_name = str(uuid1())
     create_user(db, username, Role.USER)
     create_project(db, name=project_name)
-    add_user_to_repository(
+    add_user_to_project(
         db,
         projects_name=project_name,
-        role=RepositoryUserRole.MANAGER,
+        role=ProjectUserRole.MANAGER,
         username=username,
-        permission=RepositoryUserPermission.WRITE,
+        permission=ProjectUserPermission.WRITE,
     )
 
     response = client.get("/api/v1/projects")


### PR DESCRIPTION
In v1, repositories had another meaning than in v2 and the repositories in v1 are now called projects in v2. Therefore, we need to rename all references.