### PR TITLE
Do not set cookie as HTTP only

### DIFF
--- a/frontend/src/app/services/auth/auth.service.ts
+++ b/frontend/src/app/services/auth/auth.service.ts
@@ -92,7 +92,6 @@ export class AuthService {
     }
     this.cookieService.put('access_token', accessToken, {
       path: '/prometheus',
-      httpOnly: true,
       sameSite: 'strict',
     });
   }


### PR DESCRIPTION
# Description

* This commit should've been part of #234. httpOnly cookies can't be set from Javascript.

# Testing

Try open Prometheus as admin.

# Checklist

- [x] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I updated the documentation with the new functionality
- [x] I went through the code and removed all print statements, breakpoints and unused code
- [x] Error handling for all possible scenarios has been implemented
- [x] I've add logging for all relevant operations
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
