### PR TITLE
dics: Fix broken hyperlink to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ A web platform for collaboration on [Capella](https://www.eclipse.org/capella/)
 (MBSE) projects
 
 **Copyright 2021, 2022 [DB Netz AG](https://fahrweg.dbnetze.com/),
-licensed under Apache 2.0 License (see full text in [LICENSE](./LICENSE) file)**
+licensed under Apache 2.0 License (see full text [here](./LICENSES/Apache-2.0.txt))**
+
+
 
 Turn your local Capella experience into a browser-based collaboration platform for
 model-based projects. Designed to enable co-working across multiple organizations.


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

see commit msg

# Testing

Using the (n)vim [MarkdownPreview plugin](https://github.com/iamcco/markdown-preview.nvim) 

# Checklist

- [x] I updated the documentation with the new functionality
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
