### PR TITLE
Rename helm chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,26 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-name: t4c-access-manager
-description: T4C Access Manager with OnDemand Capella / T4C Client
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+name: collab-manager
+description: Capella Collaboration Manager
+home: "https://github.com/DSD-DBS/capella-collab-manager"
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+version: 0.0.0 # The version is not used. The version is managed via Git tags.
 appVersion: "1.0.0"


### PR DESCRIPTION
# Description

This renames the helm chart to `collab-manager`, which is the name of the platform for a while now. I don't expect any breaking changes. There were no issues when upgrading a existing application with the old name. 