### PR TITLE
Allow to abort a running model creation

### DIFF
--- a/backend/capellacollab/core/authentication/database/__init__.py
+++ b/backend/capellacollab/core/authentication/database/__init__.py
@@ -6,7 +6,6 @@ import sqlalchemy.orm.session
 from fastapi import Depends, HTTPException
 
 import capellacollab.projects.users.crud as repository_users
-import capellacollab.users.crud as get_user
 from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.database import get_db

--- a/frontend/src/app/projects/create-project/create-project.component.html
+++ b/frontend/src/app/projects/create-project/create-project.component.html
@@ -71,16 +71,34 @@
       </div>
     </mat-step>
     <mat-step label="Add models">
-      <app-create-model #model_creator></app-create-model>
+      <app-create-model
+        (currentStep)="modelCreationStep = $event"
+        [redirectAfterCompletion]="false"
+        #model_creator
+      ></app-create-model>
       <div class="flex-center">
         <mat-card class="section-card">
           <div class="flex-center">
             <a
               mat-flat-button
-              [routerLink]="['/project', projectService.project]"
+              [routerLink]="['/project', projectService.project?.slug]"
+              [color]="getColorByModelCreationStep()"
             >
-              Finish project creation
-              <mat-icon class="mat-icon-position right">check</mat-icon>
+              <span *ngIf="modelCreationStep == 'create-model'">
+                Skip model creation and finish project creation
+              </span>
+              <span
+                *ngIf="
+                  modelCreationStep != 'create-model' &&
+                  modelCreationStep != 'complete'
+                "
+              >
+                Abort model initialization and finish project creation
+              </span>
+              <span *ngIf="modelCreationStep == 'complete'">
+                Finish project creation
+              </span>
+              <app-mat-icon class="mat-icon-position right">check</app-mat-icon>
             </a>
           </div>
         </mat-card>

--- a/frontend/src/app/projects/create-project/create-project.component.html
+++ b/frontend/src/app/projects/create-project/create-project.component.html
@@ -98,7 +98,7 @@
               <span *ngIf="modelCreationStep == 'complete'">
                 Finish project creation
               </span>
-              <app-mat-icon class="mat-icon-position right">check</app-mat-icon>
+              <mat-icon class="mat-icon-position right">check</mat-icon>
             </a>
           </div>
         </mat-card>

--- a/frontend/src/app/projects/create-project/create-project.component.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.ts
@@ -25,7 +25,10 @@ import {
   tap,
 } from 'rxjs';
 import slugify from 'slugify';
-import { CreateModelComponent } from 'src/app/projects/models/create-model/create-model.component';
+import {
+  CreateModelComponent,
+  CreateModelStep,
+} from 'src/app/projects/models/create-model/create-model.component';
 import { NavBarService } from 'src/app/general/navbar/service/nav-bar.service';
 import {
   Project,
@@ -44,6 +47,8 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
   private projectDetails = false;
   private slugsSubscription?: Subscription;
   public _reload = false;
+
+  public modelCreationStep: CreateModelStep = 'create-model';
 
   form = new FormGroup({
     name: new FormControl('', [
@@ -152,5 +157,15 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
       }
     }
     return null;
+  }
+
+  getColorByModelCreationStep(): string {
+    switch (this.modelCreationStep) {
+      case 'create-model':
+      case 'complete':
+        return 'primary';
+      default:
+        return 'warn';
+    }
   }
 }

--- a/frontend/src/app/projects/models/choose-init/choose-init.component.html
+++ b/frontend/src/app/projects/models/choose-init/choose-init.component.html
@@ -8,7 +8,7 @@
     <button
       mat-raised-button
       disabled
-      (click)="optionClick.emit('source-fetch')"
+      (click)="modelInitSelection.emit('source-fetch')"
     >
       <div class="button-content-wrapper">
         <p class="option-title">Use the model of the source</p>
@@ -19,7 +19,7 @@
       </div>
     </button>
     <div class="field-separator"></div>
-    <button mat-raised-button (click)="optionClick.emit('create-empty')">
+    <button mat-raised-button (click)="modelInitSelection.emit('create-empty')">
       <div class="button-content-wrapper">
         <p class="option-title">Create empty model</p>
         <app-mat-icon size="70px">create_new_folder</app-mat-icon>
@@ -29,7 +29,7 @@
     <button
       mat-raised-button
       disabled
-      (click)="optionClick.emit('upload-offline')"
+      (click)="modelInitSelection.emit('upload-offline')"
     >
       <div class="button-content-wrapper flex-center">
         <p class="option-title">Upload offline model</p>

--- a/frontend/src/app/projects/models/choose-init/choose-init.component.ts
+++ b/frontend/src/app/projects/models/choose-init/choose-init.component.ts
@@ -13,7 +13,7 @@ import { ModelService } from 'src/app/services/model/model.service';
   styleUrls: ['./choose-init.component.css'],
 })
 export class ChooseInitComponent implements OnInit {
-  @Output() optionClick = new EventEmitter<string>();
+  @Output() modelInitSelection = new EventEmitter<string>();
 
   constructor(
     public projectService: ProjectService,

--- a/frontend/src/app/projects/models/choose-source/choose-source.component.html
+++ b/frontend/src/app/projects/models/choose-source/choose-source.component.html
@@ -6,7 +6,7 @@
 <div *ngIf="projectService.project && modelService.model">
   <h2 class="title text-center">Git sources</h2>
   <div class="options-list flex-center">
-    <button mat-raised-button (click)="optionClick.emit('git-add')">
+    <button mat-raised-button (click)="modelSourceSelection.emit('git-add')">
       <div class="button-content-wrapper">
         <p class="option-title">Use existing repository</p>
         <img
@@ -16,7 +16,11 @@
       </div>
     </button>
     <div class="field-separator"></div>
-    <button mat-raised-button disabled (click)="optionClick.emit('git-create')">
+    <button
+      mat-raised-button
+      disabled
+      (click)="modelSourceSelection.emit('git-create')"
+    >
       <div class="button-content-wrapper">
         <p class="option-title">Create repository</p>
         <img

--- a/frontend/src/app/projects/models/choose-source/choose-source.component.ts
+++ b/frontend/src/app/projects/models/choose-source/choose-source.component.ts
@@ -13,7 +13,7 @@ import { ModelService } from 'src/app/services/model/model.service';
   styleUrls: ['./choose-source.component.css'],
 })
 export class ChooseSourceComponent implements OnInit {
-  @Output() optionClick = new EventEmitter<string>();
+  @Output() modelSourceSelection = new EventEmitter<string>();
 
   constructor(
     public projectService: ProjectService,

--- a/frontend/src/app/projects/models/create-model/create-model.component.html
+++ b/frontend/src/app/projects/models/create-model/create-model.component.html
@@ -4,12 +4,15 @@
  -->
 
 <div class="wrapper">
-  <mat-horizontal-stepper linear #stepper>
+  <mat-horizontal-stepper
+    (selectionChange)="onStepChange($event)"
+    linear
+    #stepper
+  >
     <mat-step completed="false" label="Create model">
       <app-create-model-base
         [asStepper]="asStepper"
         (create)="afterModelCreated($event)"
-        (finish)="complete.emit(false)"
       ></app-create-model-base>
     </mat-step>
 

--- a/frontend/src/app/projects/models/create-model/create-model.component.html
+++ b/frontend/src/app/projects/models/create-model/create-model.component.html
@@ -15,7 +15,7 @@
 
     <mat-step completed="false" label="Choose primary source">
       <app-choose-source
-        (optionClick)="onSourceClick($event)"
+        (modelSourceSelection)="onSourceClick($event)"
       ></app-choose-source>
     </mat-step>
 
@@ -26,7 +26,9 @@
     </mat-step>
 
     <mat-step label="Choose initialization">
-      <app-choose-init (optionClick)="onInitClick($event)"></app-choose-init>
+      <app-choose-init
+        (modelInitSelection)="onInitClick($event)"
+      ></app-choose-init>
     </mat-step>
 
     <mat-step label="Metadata">

--- a/frontend/src/app/projects/models/init-model/init-model.component.html
+++ b/frontend/src/app/projects/models/init-model/init-model.component.html
@@ -8,7 +8,7 @@
     <form id="new-model-form" [formGroup]="form">
       <fieldset>
         <mat-form-field appearance="fill">
-          <mat-label>Modelling tool</mat-label>
+          <mat-label>Modeling tool</mat-label>
           <input matInput [value]="getTool().name" disabled />
         </mat-form-field>
         <div class="field-separator"></div>

--- a/frontend/src/app/projects/models/init-model/init-model.component.html
+++ b/frontend/src/app/projects/models/init-model/init-model.component.html
@@ -48,7 +48,7 @@
       <button
         mat-raised-button
         color="primary"
-        [disabled]="!form.valid"
+        [disabled]="!form.valid || buttonDisabled"
         (click)="onSubmit()"
       >
         Finish

--- a/frontend/src/app/projects/models/init-model/init-model.component.ts
+++ b/frontend/src/app/projects/models/init-model/init-model.component.ts
@@ -18,8 +18,10 @@ import { filter } from 'rxjs';
   styleUrls: ['./init-model.component.css'],
 })
 export class InitModelComponent implements OnInit {
-  @Output() create = new EventEmitter<{ created: boolean; again?: boolean }>();
+  @Output() create = new EventEmitter<{ created: boolean }>();
   @Input() asStepper?: boolean;
+
+  buttonDisabled: boolean = false;
 
   constructor(
     public projectService: ProjectService,
@@ -58,6 +60,7 @@ export class InitModelComponent implements OnInit {
         )
         .subscribe((_) => {
           this.create.emit({ created: true });
+          this.buttonDisabled;
         });
     }
   }

--- a/frontend/src/app/projects/models/init-model/init-model.component.ts
+++ b/frontend/src/app/projects/models/init-model/init-model.component.ts
@@ -60,7 +60,7 @@ export class InitModelComponent implements OnInit {
         )
         .subscribe((_) => {
           this.create.emit({ created: true });
-          this.buttonDisabled;
+          this.buttonDisabled = true;
         });
     }
   }


### PR DESCRIPTION
# Description

- Allow to abort a running model creation during the project creation. 
- Redirect to project after model creation when called from the project creation context. 
- Some small fixes.

#264 has a higher importance, this PR can be reviewed after #264.