### PR TITLE
Support read-only sessions

### DIFF
--- a/backend/capellacollab/alembic/versions/7617cde6fbb1_link_sessions_to_projects.py
+++ b/backend/capellacollab/alembic/versions/7617cde6fbb1_link_sessions_to_projects.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""link sessions to projects
+
+Revision ID: 7617cde6fbb1
+Revises: ab01ad045341
+Create Date: 2022-11-10 13:13:25.041000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7617cde6fbb1"
+down_revision = "ab01ad045341"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "sessions", sa.Column("project_id", sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(None, "sessions", "projects", ["project_id"], ["id"])
+    op.drop_column("sessions", "repository")
+
+
+def downgrade():
+    op.add_column(
+        "sessions",
+        sa.Column(
+            "repository", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.drop_constraint(
+        "sessions_project_id_fkey", "sessions", type_="foreignkey"
+    )
+    op.drop_column("sessions", "project_id")

--- a/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
+++ b/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
@@ -28,5 +28,4 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table("tools") as batch_op:
-        batch_op.drop_column("readonly_docker_image_template")
+    op.drop_column("tools", "readonly_docker_image_template")

--- a/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
+++ b/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""add readonly docker image
+
+Revision ID: ab01ad045341
+Revises: 24fd3c70bacf
+Create Date: 2022-10-13 10:51:57.631309
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ab01ad045341"
+down_revision = "24fd3c70bacf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("tools") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "readonly_docker_image_template", sa.String(), nullable=True
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("tools") as batch_op:
+        batch_op.drop_column("readonly_docker_image_template")

--- a/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
+++ b/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
@@ -4,7 +4,7 @@
 """add readonly docker image
 
 Revision ID: ab01ad045341
-Revises: 8eceebe9b3ea
+Revises: fdff657f3cc1
 Create Date: 2022-10-13 10:51:57.631309
 
 """
@@ -13,18 +13,18 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "ab01ad045341"
-down_revision = "8eceebe9b3ea"
+down_revision = "fdff657f3cc1"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table("tools") as batch_op:
-        batch_op.add_column(
-            sa.Column(
-                "readonly_docker_image_template", sa.String(), nullable=True
-            )
-        )
+    op.add_column(
+        "tools",
+        sa.Column(
+            "readonly_docker_image_template", sa.String(), nullable=True
+        ),
+    )
 
 
 def downgrade():

--- a/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
+++ b/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
@@ -4,7 +4,7 @@
 """add readonly docker image
 
 Revision ID: ab01ad045341
-Revises: 24fd3c70bacf
+Revises: 8eceebe9b3ea
 Create Date: 2022-10-13 10:51:57.631309
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "ab01ad045341"
-down_revision = "24fd3c70bacf"
+down_revision = "8eceebe9b3ea"
 branch_labels = None
 depends_on = None
 

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -76,7 +76,7 @@ def create_tools(db):
     capella = Tool(
         name="Capella",
         docker_image_template=f"{registry}/t4c/client/remote/$version:prod",
-        readonly_docker_image_template=f"{registry}/t4c/client/readonly/$version:prod",
+        readonly_docker_image_template=f"{registry}/capella/readonly/$version:prod",
     )
     papyrus = Tool(
         name="Papyrus",

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -76,6 +76,7 @@ def create_tools(db):
     capella = Tool(
         name="Capella",
         docker_image_template=f"{registry}/t4c/client/remote/$version:prod",
+        readonly_docker_image_template=f"{registry}/t4c/client/readonly/$version:prod",
     )
     papyrus = Tool(
         name="Papyrus",

--- a/backend/capellacollab/projects/capellamodels/crud.py
+++ b/backend/capellacollab/projects/capellamodels/crud.py
@@ -12,7 +12,7 @@ from capellacollab.projects.capellamodels.models import (
     DatabaseCapellaModel,
 )
 from capellacollab.projects.models import DatabaseProject
-from capellacollab.tools.models import Nature, Tool, Version, Nature
+from capellacollab.tools.models import Nature, Tool, Version
 
 
 def get_all_models_in_project(

--- a/backend/capellacollab/projects/capellamodels/crud.py
+++ b/backend/capellacollab/projects/capellamodels/crud.py
@@ -12,7 +12,7 @@ from capellacollab.projects.capellamodels.models import (
     DatabaseCapellaModel,
 )
 from capellacollab.projects.models import DatabaseProject
-from capellacollab.tools.models import Nature, Tool, Version
+from capellacollab.tools.models import Nature, Tool, Version, Nature
 
 
 def get_all_models_in_project(
@@ -79,7 +79,12 @@ def get_model_by_slug(
 
 
 def create_new_model(
-    db: Session, project: DatabaseProject, new_model: CapellaModel, tool: Tool
+    db: Session,
+    project: DatabaseProject,
+    new_model: CapellaModel,
+    tool: Tool,
+    version: Version | None = None,
+    nature: Nature | None = None,
 ) -> DatabaseCapellaModel:
     model = DatabaseCapellaModel(
         name=new_model.name,
@@ -87,6 +92,8 @@ def create_new_model(
         description=new_model.description,
         project=project,
         tool=tool,
+        version=version,
+        nature=nature,
     )
     db.add(model)
     db.commit()

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -21,6 +21,11 @@ from capellacollab.projects.users.models import (
     ProjectUserRole,
 )
 
+if t.TYPE_CHECKING:
+    from capellacollab.projects.capellamodels.models import (
+        DatabaseCapellaModel,
+    )
+
 
 class UserMetadata(BaseModel):
     leads: int
@@ -91,6 +96,6 @@ class DatabaseProject(Base):
         "ProjectUserAssociation",
         back_populates="projects",
     )
-    models: DatabaseCapellaModel = relationship(
+    models: list[DatabaseCapellaModel] = relationship(
         "DatabaseCapellaModel", back_populates="project"
     )

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import enum
 import typing as t
 
 from pydantic import BaseModel, validator

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -31,6 +31,7 @@ from capellacollab.projects.users.models import (
     ProjectUserPermission,
     ProjectUserRole,
 )
+from capellacollab.sessions.routes import project_router as router_sessions
 from capellacollab.users.injectables import get_own_user
 from capellacollab.users.models import DatabaseUser, Role
 
@@ -139,6 +140,11 @@ router.include_router(
 )
 router.include_router(
     router_models, prefix="/{project_slug}/models", tags=["Projects - Models"]
+)
+router.include_router(
+    router_sessions,
+    prefix="/{project_slug}/sessions",
+    tags=["Projects - Sessions"],
 )
 
 # Load backup extension routes

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from capellacollab.core.database import Base
+from capellacollab.projects.models import DatabaseProject
 from capellacollab.sessions.schema import WorkspaceType
 
 
@@ -31,5 +32,6 @@ class DatabaseSession(Base):
     guacamole_connection_id = Column(String)
     host = Column(String)
     type = Column(Enum(WorkspaceType), nullable=False)
-    repository = Column(String)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True)
+    project = relationship(DatabaseProject)
     mac = Column(String)

--- a/backend/capellacollab/sessions/operators/abc.py
+++ b/backend/capellacollab/sessions/operators/abc.py
@@ -48,6 +48,7 @@ class Operator(abc.ABC):
         entrypoint: str,
         git_username: str,
         git_password: str,
+        git_depth: int,
     ) -> t.Dict[str, t.Any]:
         """Start / Create a session
 

--- a/backend/capellacollab/sessions/operators/abc.py
+++ b/backend/capellacollab/sessions/operators/abc.py
@@ -43,12 +43,7 @@ class Operator(abc.ABC):
         self,
         password: str,
         docker_image: str,
-        git_url: str,
-        git_revision: str,
-        entrypoint: str,
-        git_username: str,
-        git_password: str,
-        git_depth: int,
+        git_repos_json: t.List[t.Dict[str, str | int]],
     ) -> t.Dict[str, t.Any]:
         """Start / Create a session
 
@@ -58,10 +53,8 @@ class Operator(abc.ABC):
             Password for the remote connection
         docker_image
             Image to run for this session
-        git_url
-            Git URL of the model that should be cloned
-        git_branch
-            Git Branch of the model that should be cloned
+        git_repos_json
+            A list of repository metadata
 
         Returns
         ------

--- a/backend/capellacollab/sessions/operators/abc.py
+++ b/backend/capellacollab/sessions/operators/abc.py
@@ -42,6 +42,7 @@ class Operator(abc.ABC):
     def start_readonly_session(
         self,
         password: str,
+        docker_image: str,
         git_url: str,
         git_revision: str,
         entrypoint: str,
@@ -54,6 +55,8 @@ class Operator(abc.ABC):
         ---------
         password
             Password for the remote connection
+        docker_image
+            Image to run for this session
         git_url
             Git URL of the model that should be cloned
         git_branch

--- a/backend/capellacollab/sessions/operators/docker.py
+++ b/backend/capellacollab/sessions/operators/docker.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-
+import json
 import logging
 import pathlib
 import shutil
@@ -60,21 +60,13 @@ class DockerOperator(Operator):
         self,
         password: str,
         docker_image: str,
-        git_url: str,
-        git_revision: str,
-        entrypoint: str,
-        git_username: str,
-        git_password: str,
+        git_repos_json: t.List[t.Dict[str, str | int]],
     ) -> t.Dict[str, t.Any]:
         con = self.client.containers.run(
             image=docker_image,
             ports={"3389/tcp": cfg["portRange"]},
             environment={
-                "GIT_USERNAME": git_username,
-                "GIT_PASSWORD": git_password,
-                "GIT_URL": git_url,
-                "GIT_REVISION": git_revision,
-                "GIT_ENTRYPOINT": entrypoint,
+                "GIT_REPOS_JSON": json.dumps(git_repos_json),
                 "RMT_PASSWORD": password,
             },
             detach=True,

--- a/backend/capellacollab/sessions/operators/docker.py
+++ b/backend/capellacollab/sessions/operators/docker.py
@@ -59,6 +59,7 @@ class DockerOperator(Operator):
     def start_readonly_session(
         self,
         password: str,
+        docker_image: str,
         git_url: str,
         git_revision: str,
         entrypoint: str,
@@ -66,7 +67,7 @@ class DockerOperator(Operator):
         git_password: str,
     ) -> t.Dict[str, t.Any]:
         con = self.client.containers.run(
-            image=config["docker"]["images"]["workspaces"]["readonly"],
+            image=docker_image,
             ports={"3389/tcp": cfg["portRange"]},
             environment={
                 "GIT_USERNAME": git_username,

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -123,12 +123,7 @@ class KubernetesOperator(Operator):
         self,
         password: str,
         docker_image: str,
-        git_url: str,
-        git_revision: str,
-        entrypoint: str,
-        git_username: str,
-        git_password: str,
-        git_depth: int,
+        git_repos_json: t.List[t.Dict[str, str | int]],
     ) -> t.Dict[str, t.Any]:
         id = self._generate_id()
 
@@ -136,12 +131,7 @@ class KubernetesOperator(Operator):
             docker_image,
             id,
             {
-                "GIT_USERNAME": git_username,
-                "GIT_PASSWORD": git_password,
-                "GIT_URL": git_url,
-                "GIT_REVISION": git_revision,
-                "GIT_ENTRYPOINT": entrypoint,
-                "GIT_DEPTH": git_depth,
+                "GIT_REPOS_JSON": json.dumps(git_repos_json),
                 "RMT_PASSWORD": password,
             },
         )

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -122,6 +122,7 @@ class KubernetesOperator(Operator):
     def start_readonly_session(
         self,
         password: str,
+        docker_image: str,
         git_url: str,
         git_revision: str,
         entrypoint: str,
@@ -132,7 +133,7 @@ class KubernetesOperator(Operator):
         id = self._generate_id()
 
         deployment = self._create_deployment(
-            config["docker"]["images"]["workspaces"]["readonly"],
+            docker_image,
             id,
             {
                 "GIT_USERNAME": git_username,

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -123,7 +123,7 @@ def request_session(
     models = [
         m
         for m in project.models
-        if m.git_models and m.version_id == body.version
+        if m.git_models and m.version_id == body.tool_version
     ]
     if not models:
         raise HTTPException(
@@ -134,7 +134,7 @@ def request_session(
             },
         )
 
-    docker_image = get_readonly_image_for_version(db, body.version)
+    docker_image = get_readonly_image_for_version(db, body.tool_version)
 
     git_model = models[0].git_models[0]
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -20,6 +20,7 @@ from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
+from capellacollab.projects.crud import get_project_by_slug
 from capellacollab.projects.users.crud import ProjectUserRole
 from capellacollab.sessions import database, guacamole
 from capellacollab.sessions.files import routes as files

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -11,8 +11,6 @@ import typing as t
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-import capellacollab.projects.capellamodels.modelsources.git.crud as git_models_crud
-import capellacollab.projects.capellamodels.modelsources.t4c.connection as t4c_manager
 from capellacollab.config import config
 from capellacollab.core.authentication.database import (
     ProjectRoleVerification,
@@ -23,7 +21,6 @@ from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
-from capellacollab.projects.capellamodels.crud import get_model_by_slug
 from capellacollab.projects.capellamodels.injectables import (
     get_existing_capella_model,
     get_existing_project,
@@ -32,7 +29,6 @@ from capellacollab.projects.capellamodels.models import DatabaseCapellaModel
 from capellacollab.projects.capellamodels.modelsources.git.models import (
     DB_GitModel,
 )
-from capellacollab.projects.crud import get_project_by_slug
 from capellacollab.projects.models import DatabaseProject
 from capellacollab.projects.users.crud import ProjectUserRole
 from capellacollab.sessions import database, guacamole
@@ -126,7 +122,7 @@ def request_session(
 ):
     log.info("Starting persistent session creation for user %s", db_user.name)
 
-    model = get_existing_capella_model(db, project.slug, body.model_slug)
+    model = get_existing_capella_model(project.slug, body.model_slug, db)
     models = [
         m
         for m in project.models

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -145,7 +145,7 @@ def request_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "err_code": "git_model_not_found",
-                "reason": "The Project has no connected Git Model. Please contact a project manager or admininistrator",
+                "reason": "The selected model has no connected Git repository. Please contact a project manager or administrator",
             },
         )
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -229,7 +229,7 @@ def request_persistent_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "err_code": "existing_session",
-                "reason": "You already have a open Persistent Session. Please navigate to 'Active Sessions' to Reconnect",
+                "reason": "You already have a open persistent session. Please navigate to 'Active Sessions' to reconnect",
             },
         )
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -22,11 +22,15 @@ from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
+from capellacollab.projects.capellamodels.injectables import (
+    get_existing_project,
+)
 from capellacollab.projects.capellamodels.models import DatabaseCapellaModel
 from capellacollab.projects.capellamodels.modelsources.git.models import (
     DB_GitModel,
 )
 from capellacollab.projects.crud import get_project_by_slug
+from capellacollab.projects.models import DatabaseProject
 from capellacollab.projects.users.crud import ProjectUserRole
 from capellacollab.sessions import database, guacamole
 from capellacollab.sessions.files import routes as files
@@ -45,17 +49,16 @@ from capellacollab.sessions.sessions import inject_attrs_in_sessions
 from capellacollab.settings.modelsources.t4c.repositories.crud import (
     get_user_t4c_repositories,
 )
-from capellacollab.tools.crud import get_image_for_tool_version, get_readonly_image_for_version
+from capellacollab.tools.crud import (
+    get_image_for_tool_version,
+    get_readonly_image_for_version,
+)
 from capellacollab.tools.injectables import (
     get_exisiting_tool_version,
     get_existing_tool,
 )
 from capellacollab.users.injectables import get_own_user
 from capellacollab.users.models import DatabaseUser, Role
-from capellacollab.projects.models import DatabaseProject
-from capellacollab.projects.capellamodels.injectables import (
-    get_existing_project,
-)
 
 router = APIRouter(
     dependencies=[Depends(RoleVerification(required_role=Role.USER))]

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -25,6 +25,7 @@ from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
 from capellacollab.projects.capellamodels.crud import get_model_by_slug
 from capellacollab.projects.capellamodels.injectables import (
+    get_existing_capella_model,
     get_existing_project,
 )
 from capellacollab.projects.capellamodels.models import DatabaseCapellaModel
@@ -125,16 +126,7 @@ def request_session(
 ):
     log.info("Starting persistent session creation for user %s", db_user.name)
 
-    model = get_model_by_slug(db, project.slug, body.model_slug)
-    if not model:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND,
-            {
-                "reason": f"The model with name {body.model_slug} was not found.",
-                "technical": f"No model {body.model_slug} found.",
-            },
-        )
-
+    model = get_existing_capella_model(db, project.slug, body.model_slug)
     models = [
         m
         for m in project.models

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -146,6 +146,7 @@ def request_session(
         )
     session = operator.start_readonly_session(
         password=rdp_password,
+        docker_image=config["docker"]["images"]["workspaces"]["readonly"],
         git_url=git_model.path,
         git_revision=revision,
         entrypoint=git_model.entrypoint,

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -175,6 +175,7 @@ def request_session(
     return create_database_and_guacamole_session(
         WorkspaceType.READONLY,
         session,
+        project,
         owner,
         rdp_password,
         db,
@@ -268,12 +269,12 @@ def request_persistent_session(
     )
 
     return create_database_and_guacamole_session(
-        WorkspaceType.PERSISTENT, session, owner, rdp_password, db
+        WorkspaceType.PERSISTENT, session, None, owner, rdp_password, db
     )
 
 
 def create_database_and_guacamole_session(
-    type: WorkspaceType, session, owner, rdp_password, db, repository=""
+    type: WorkspaceType, session, project, owner, rdp_password, db
 ):
     guacamole_username = generate_password()
     guacamole_password = generate_password(length=64)
@@ -300,7 +301,7 @@ def create_database_and_guacamole_session(
         rdp_password=rdp_password,
         guacamole_connection_id=guacamole_identifier,
         owner_name=owner,
-        repository=repository,
+        project=project,
         type=type,
         **session,
     )

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -198,7 +198,7 @@ def git_model_as_json(git_model: DB_GitModel) -> dict[str, str | int]:
         "revision": git_model.revision,
         "depth": 1,
         "entrypoint": git_model.entrypoint,
-        "nature": "project",
+        "nature": git_model.model.nature.name,
     }
     if git_model.username:
         json["username"] = git_model.username

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -155,7 +155,7 @@ def request_session(
             status_code=status.HTTP_409_CONFLICT,
             detail={
                 "err_code": "image_not_found",
-                "reason": "The model has no associated read-only docker image configured. Please contact a project manager or admininistrator",
+                "reason": "The tool has no read-only support. Please contact an admininistrator",
             },
         )
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -178,14 +178,9 @@ def request_session(
 
 
 def models_as_json(models: t.List[DatabaseCapellaModel], version: Version):
-    for m in models:
-        if m.version.id == version.id:
-            yield from model_as_json(m)
-
-
-def model_as_json(model: DatabaseCapellaModel):
-    for git_model in model.git_models:
-        yield git_model_as_json(git_model)
+    for model in models:
+        for git_model in model.git_models:
+            yield git_model_as_json(git_model)
 
 
 def git_model_as_json(git_model: DB_GitModel) -> dict[str, str | int]:

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -170,7 +170,6 @@ def request_session(
         owner,
         rdp_password,
         db,
-        repository=[],
     )
 
 

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -55,9 +55,21 @@ class PostSessionRequest(BaseModel):
         orm_mode = True
 
 
+class PostReadonlySessionRequest(BaseModel):
+    project_slug: str
+    tool: int
+    version: int
+
+    class Config:
+        orm_mode = True
+
+
 class PostPersistentSessionRequest(BaseModel):
     tool_id: int
     version_id: int
+
+    class Config:
+        orm_mode = True
 
 
 class GetSessionUsageResponse(BaseModel):

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -56,7 +56,6 @@ class PostSessionRequest(BaseModel):
 
 
 class PostReadonlySessionRequest(BaseModel):
-    project_slug: str
     model_slug: str
 
     class Config:

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -57,8 +57,7 @@ class PostSessionRequest(BaseModel):
 
 class PostReadonlySessionRequest(BaseModel):
     project_slug: str
-    tool: int
-    version: int
+    tool_version: int
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -57,7 +57,7 @@ class PostSessionRequest(BaseModel):
 
 class PostReadonlySessionRequest(BaseModel):
     project_slug: str
-    tool_version: int
+    model_slug: str
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -140,8 +140,7 @@ def get_image_for_tool_version(db: Session, version_id: int) -> str:
     return version.tool.docker_image_template.replace("$version", version.name)
 
 
-def get_readonly_image_for_version(db: Session, version_id: int):
-    version = get_version_by_id(version_id, db)
+def get_readonly_image_for_version(version: Version):
     return version.tool.readonly_docker_image_template.replace(
         "$version", version.name
     )

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -138,3 +138,10 @@ def create_nature(db: Session, tool_id: int, name: str) -> Nature:
 def get_image_for_tool_version(db: Session, version_id: int) -> str:
     version = get_version_by_id(version_id, db)
     return version.tool.docker_image_template.replace("$version", version.name)
+
+
+def get_readonly_image_for_version(db: Session, version_id: int):
+    version = get_version_by_id(version_id, db)
+    return version.tool.readonly_docker_image_template.replace(
+        "$version", version.name
+    )

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -40,7 +40,7 @@ def update_tool(
         tool.name = patch_tool.name
     elif patch_tool.persistent:
         tool.docker_image_template = patch_tool.persistent
-        # FIXME: Set readonly image
+        tool.readonly_docker_image_template = patch_tool.readonly
     db.add(tool)
     db.commit()
     return tool

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
 
 import typing as t
 
@@ -92,7 +93,7 @@ def get_nature_for_tool(tool_id: int, nature_id: int, db: Session) -> Nature:
 
 def create_version(
     db: Session,
-    tool_id: Tool,
+    tool_id: int,
     name: str,
     is_recommended: bool = False,
     is_deprecated: bool = False,
@@ -140,7 +141,6 @@ def get_image_for_tool_version(db: Session, version_id: int) -> str:
     return version.tool.docker_image_template.replace("$version", version.name)
 
 
-def get_readonly_image_for_version(version: Version):
-    return version.tool.readonly_docker_image_template.replace(
-        "$version", version.name
-    )
+def get_readonly_image_for_version(version: Version) -> str | None:
+    template = version.tool.readonly_docker_image_template
+    return template.replace("$version", version.name) if template else None

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -26,6 +27,7 @@ class Tool(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     docker_image_template = Column(String)
+    readonly_docker_image_template = Column(String)
 
     versions = relationship("Version", back_populates="tool")
     natures = relationship("Nature", back_populates="tool")

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
-# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -73,7 +73,7 @@ class ToolDockerimage(BaseModel):
     def from_orm(cls, obj: Tool) -> ToolDockerimage:
         return ToolDockerimage(
             persistent=obj.docker_image_template,
-            readonly=obj.docker_image_template,
+            readonly=obj.readonly_docker_image_template,
         )
 
     class Config:

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -17,6 +17,12 @@ from capellacollab.projects.capellamodels.modelsources.git.crud import (
 from capellacollab.projects.capellamodels.modelsources.git.models import PostGitModel
 from capellacollab.projects.capellamodels.crud import create_new_model
 from capellacollab.projects.capellamodels.models import CapellaModel
+from capellacollab.projects.capellamodels.modelsources.git.crud import (
+    add_gitmodel_to_capellamodel,
+)
+from capellacollab.projects.capellamodels.modelsources.git.models import (
+    PostGitModel,
+)
 from capellacollab.projects.crud import create_project
 from capellacollab.projects.users.crud import add_user_to_project
 from capellacollab.projects.users.models import (
@@ -224,7 +230,7 @@ def test_create_readonly_session_as_user(client, db, username, kubernetes):
     assert kubernetes.sessions
     assert (
         kubernetes.sessions[0]["docker_image"]
-        == "k3d-myregistry.localhost:12345/t4c/client/readonly/5.0:prod"
+        == "k3d-myregistry.localhost:12345/capella/readonly/5.0:prod"
     )
 
 

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -86,6 +86,7 @@ class MockOperator(Operator):
     def start_readonly_session(
         self,
         password: str,
+        docker_image: str,
         git_url: str,
         git_revision: str,
         entrypoint: str,

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -1,4 +1,4 @@
-tests/test_sessions_routes.py# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -198,7 +198,7 @@ def test_create_readonly_session_as_user(client, db, username, kubernetes):
         tool=tool,
         version=version,
     )
-    git_model = add_gitmodel_to_capellamodel(
+    add_gitmodel_to_capellamodel(
         db,
         model,
         PostGitModel(
@@ -210,8 +210,7 @@ def test_create_readonly_session_as_user(client, db, username, kubernetes):
         "/api/v1/sessions/readonly",
         json={
             "project_slug": project.slug,
-            "tool": tool.id,
-            "version": version.id,
+            "tool_version": version.id,
         },
     )
 

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -105,14 +105,11 @@ class MockOperator(Operator):
         cls,
         password: str,
         docker_image: str,
-        git_url: str,
-        git_revision: str,
-        entrypoint: str,
-        git_username: str,
-        git_password: str,
-        git_depth: int,
+        git_repos_json: t.List[t.Dict[str, str | int]],
     ) -> t.Dict[str, t.Any]:
-        cls.sessions.append({"docker_image": docker_image})
+        cls.sessions.append(
+            {"docker_image": docker_image, "git_repos_json": git_repos_json}
+        )
         return {
             "id": str(uuid1()),
             "host": "test",
@@ -204,11 +201,12 @@ def test_create_readonly_session_as_user(client, db, username, kubernetes):
         tool=tool,
         version=version,
     )
+    git_path = str(uuid1())
     add_gitmodel_to_capellamodel(
         db,
         model,
         PostGitModel(
-            path="", entrypoint="", revision="", username="", password=""
+            path=git_path, entrypoint="", revision="", username="", password=""
         ),
     )
 
@@ -232,6 +230,7 @@ def test_create_readonly_session_as_user(client, db, username, kubernetes):
         kubernetes.sessions[0]["docker_image"]
         == "k3d-myregistry.localhost:12345/capella/readonly/5.0:prod"
     )
+    assert kubernetes.sessions[0]["git_repos_json"][0]["url"] == git_path
 
 
 def test_create_persistent_session_as_user(client, db, username, kubernetes):

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -208,9 +208,8 @@ def test_create_readonly_session_as_user(client, db, user, kubernetes):
     model = setup_git_model_for_user(db, user, version)
 
     response = client.post(
-        "/api/v1/sessions/readonly",
+        f"/api/v1/projects/{model.project.slug}/sessions/readonly",
         json={
-            "project_slug": model.project.slug,
             "model_slug": model.slug,
         },
     )
@@ -240,9 +239,8 @@ def test_no_readonly_session_as_user(client, db, user, kubernetes):
     model = setup_git_model_for_user(db, user, version)
 
     response = client.post(
-        "/api/v1/sessions/readonly",
+        f"/api/v1/projects/{model.project.slug}/sessions/readonly",
         json={
-            "project_slug": model.project.slug,
             "model_slug": model.slug,
         },
     )

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -222,7 +222,7 @@ def test_create_readonly_session_as_user(client, db, user, kubernetes):
         "/api/v1/sessions/readonly",
         json={
             "project_slug": project.slug,
-            "tool_version": version.id,
+            "model_slug": model.slug,
         },
     )
 

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -11,10 +11,6 @@ import pytest
 
 import capellacollab.sessions.guacamole
 from capellacollab.__main__ import app
-from capellacollab.projects.capellamodels.modelsources.git.crud import (
-    add_gitmodel_to_capellamodel,
-)
-from capellacollab.projects.capellamodels.modelsources.git.models import PostGitModel
 from capellacollab.projects.capellamodels.crud import create_new_model
 from capellacollab.projects.capellamodels.models import CapellaModel
 from capellacollab.projects.capellamodels.modelsources.git.crud import (

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -257,6 +257,7 @@ def test_no_readonly_session_as_user(client, db, user, kubernetes):
 
 def setup_git_model_for_user(db, user, version):
     project = create_project(db, name=str(uuid1()))
+    nature = get_natures(db)[0]
     add_user_to_project(
         db,
         project,
@@ -272,6 +273,7 @@ def setup_git_model_for_user(db, user, version):
         ),
         tool=version.tool,
         version=version,
+        nature=nature,
     )
     git_path = str(uuid1())
     add_gitmodel_to_capellamodel(

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.css
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.css
@@ -13,8 +13,13 @@
   align-items: center;
 }
 
+.models-title > h2 {
+  margin: 0;
+}
+
 .models-title {
   display: flex;
+  align-items: center;
 }
 
 #settings-icon {

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -9,14 +9,6 @@
     <a mat-button [routerLink]="['/project', project.slug, 'models', 'create']">
       <mat-icon id="add-icon">add</mat-icon>
     </a>
-    <button
-      mat-button
-      *ngIf="models"
-      matTooltip="Open readonly session"
-      (click)="requestSession()"
-    >
-      <mat-icon>remove_red_eye</mat-icon>
-    </button>
   </h2>
   <mat-card *ngFor="let model of models">
     <div class="header">
@@ -85,13 +77,14 @@
           >
             <mat-icon>screen_share</mat-icon>
           </a>
-          <a
+          <button
             mat-mini-fab
             *ngIf="model.git_models"
             matTooltip="Open readonly session"
+            (click)="requestSession(model)"
           >
             <mat-icon>remove_red_eye</mat-icon>
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -4,12 +4,17 @@
  -->
 
 <div class="models" *ngIf="models">
-  <h2>
-    Models
-    <a mat-button [routerLink]="['/project', project.slug, 'models', 'create']">
-      <mat-icon id="add-icon">add</mat-icon>
-    </a>
-  </h2>
+  <div class="models-title">
+    <h2>
+      Models
+      <a
+        mat-button
+        [routerLink]="['/project', project.slug, 'models', 'create']"
+      >
+        <mat-icon id="add-icon">add</mat-icon>
+      </a>
+    </h2>
+  </div>
   <mat-card *ngFor="let model of models">
     <div class="header">
       <div class="header-text">

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -4,12 +4,15 @@
  -->
 
 <div class="models" *ngIf="models">
-  <div class="models-title">
-    <h2 id="title">Models</h2>
+  <h2>
+    Models
     <a mat-button [routerLink]="['/project', project.slug, 'models', 'create']">
       <mat-icon id="add-icon">add</mat-icon>
     </a>
-  </div>
+    <a mat-mini-fab *ngIf="models" matTooltip="Open readonly session">
+      <mat-icon>remove_red_eye</mat-icon>
+    </a>
+  </h2>
   <mat-card *ngFor="let model of models">
     <div class="header">
       <div class="header-text">
@@ -75,7 +78,7 @@
             mat-mini-fab
             matTooltip="Request persistent session"
           >
-            <mat-icon> screen_share</mat-icon>
+            <mat-icon>screen_share</mat-icon>
           </a>
           <a
             mat-mini-fab

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -9,9 +9,14 @@
     <a mat-button [routerLink]="['/project', project.slug, 'models', 'create']">
       <mat-icon id="add-icon">add</mat-icon>
     </a>
-    <a mat-mini-fab *ngIf="models" matTooltip="Open readonly session">
+    <button
+      mat-button
+      *ngIf="models"
+      matTooltip="Open readonly session"
+      (click)="requestSession()"
+    >
       <mat-icon>remove_red_eye</mat-icon>
-    </a>
+    </button>
   </h2>
   <mat-card *ngFor="let model of models">
     <div class="header">

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -41,15 +41,12 @@ export class ModelOverviewComponent implements OnInit {
     return 'Unset';
   }
 
-  requestSession() {
-    console.log("How 'bout a session?");
-    if (!this.models) {
-      console.log('no models?', this.models);
+  requestSession(model: Model) {
+    if (!model.version) {
       return;
     }
-    // let model = this.models[0];
-
-    console.log('create session:');
-    this.sessionService.createReadonlySession('default', 2).subscribe();
+    this.sessionService
+      .createReadonlySession(this.project.slug, model.version.id)
+      .subscribe();
   }
 }

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -4,6 +4,8 @@
  */
 
 import { Component, Input, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+
 import { Model, ModelService } from 'src/app/services/model/model.service';
 import {
   Project,
@@ -23,7 +25,8 @@ export class ModelOverviewComponent implements OnInit {
   constructor(
     public projectService: ProjectService,
     public modelService: ModelService,
-    public sessionService: SessionService
+    public sessionService: SessionService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -47,6 +50,8 @@ export class ModelOverviewComponent implements OnInit {
     }
     this.sessionService
       .createReadonlySession(this.project.slug, model.version.id)
-      .subscribe();
+      .subscribe(() => {
+        this.router.navigateByUrl('/');
+      });
   }
 }

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -49,7 +49,7 @@ export class ModelOverviewComponent implements OnInit {
       return;
     }
     this.sessionService
-      .createReadonlySession(this.project.slug, model.version.id)
+      .createReadonlySession(this.project.slug, model.slug)
       .subscribe(() => {
         this.router.navigateByUrl('/');
       });

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -44,7 +44,7 @@ export class ModelOverviewComponent implements OnInit {
     return 'Unset';
   }
 
-  requestSession(model: Model) {
+  requestSession(model: Model): void {
     if (!model.version) {
       return;
     }

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -11,7 +11,7 @@ import {
   Project,
   ProjectService,
 } from 'src/app/services/project/project.service';
-import { SessionService } from '../../../services/session/session.service';
+import { SessionService } from 'src/app/services/session/session.service';
 
 @Component({
   selector: 'app-model-overview',

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -9,6 +9,7 @@ import {
   Project,
   ProjectService,
 } from 'src/app/services/project/project.service';
+import { SessionService } from '../../../services/session/session.service';
 
 @Component({
   selector: 'app-model-overview',
@@ -21,7 +22,8 @@ export class ModelOverviewComponent implements OnInit {
 
   constructor(
     public projectService: ProjectService,
-    public modelService: ModelService
+    public modelService: ModelService,
+    public sessionService: SessionService
   ) {}
 
   ngOnInit(): void {
@@ -37,5 +39,17 @@ export class ModelOverviewComponent implements OnInit {
       return 'Git';
     }
     return 'Unset';
+  }
+
+  requestSession() {
+    console.log("How 'bout a session?");
+    if (!this.models) {
+      console.log('no models?', this.models);
+      return;
+    }
+    // let model = this.models[0];
+
+    console.log('create session:');
+    this.sessionService.createReadonlySession('default', 2).subscribe();
   }
 }

--- a/frontend/src/app/services/model/model.service.ts
+++ b/frontend/src/app/services/model/model.service.ts
@@ -15,13 +15,13 @@ import {
 import { environment } from 'src/environments/environment';
 import { GitModel } from '../source/source.service';
 
-export interface NewModel {
+export type NewModel = {
   name: string;
   description: string;
   tool_id: number;
-}
+};
 
-export interface Model {
+export type Model = {
   id: number;
   project_slug: string;
   slug: string;

--- a/frontend/src/app/services/model/model.service.ts
+++ b/frontend/src/app/services/model/model.service.ts
@@ -7,13 +7,13 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { T4CModel } from 'src/app/services/modelsources/t4c-model/t4c-model.service';
+import { GitModel } from 'src/app/services/source/source.service';
 import {
   Tool,
   ToolNature,
   ToolVersion,
 } from 'src/app/settings/core/tools-settings/tool.service';
 import { environment } from 'src/environments/environment';
-import { GitModel } from '../source/source.service';
 
 export type NewModel = {
   name: string;
@@ -32,7 +32,7 @@ export type Model = {
   nature?: ToolNature;
   t4c_models: T4CModel[];
   git_models: GitModel[];
-}
+};
 
 @Injectable({
   providedIn: 'root',

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -20,6 +20,16 @@ export class SessionService {
     return this.http.get<Session[]>(this.BACKEND_URL_PREFIX);
   }
 
+  createReadonlySession(
+    project_slug: string,
+    version_id: number
+  ): Observable<Session> {
+    return this.http.post<Session>(`${this.BACKEND_URL_PREFIX}readonly`, {
+      project_slug,
+      version_id,
+    });
+  }
+
   createPersistentSession(
     toolId: number,
     versionId: number

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -25,8 +25,8 @@ export class SessionService {
     version_id: number
   ): Observable<Session> {
     return this.http.post<Session>(`${this.BACKEND_URL_PREFIX}readonly`, {
-      project_slug,
-      version_id,
+      project_slug: project_slug,
+      tool_version: version_id,
     });
   }
 

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -22,11 +22,11 @@ export class SessionService {
 
   createReadonlySession(
     project_slug: string,
-    version_id: number
+    model_slug: string
   ): Observable<Session> {
     return this.http.post<Session>(`${this.BACKEND_URL_PREFIX}readonly`, {
       project_slug: project_slug,
-      tool_version: version_id,
+      model_slug: model_slug,
     });
   }
 

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -24,10 +24,12 @@ export class SessionService {
     project_slug: string,
     model_slug: string
   ): Observable<Session> {
-    return this.http.post<Session>(`${this.BACKEND_URL_PREFIX}readonly`, {
-      project_slug: project_slug,
-      model_slug: model_slug,
-    });
+    return this.http.post<Session>(
+      `${environment.backend_url}/projects/${project_slug}/sessions/readonly`,
+      {
+        model_slug: model_slug,
+      }
+    );
   }
 
   createPersistentSession(

--- a/frontend/src/app/sessions/active-sessions/active-sessions.component.css
+++ b/frontend/src/app/sessions/active-sessions/active-sessions.component.css
@@ -24,6 +24,11 @@
   text-align: center;
 }
 
+.mat-card-content h3 {
+  margin: 2px 4px;
+  text-align: center;
+}
+
 .sessionContent {
   margin-bottom: 5px;
 }

--- a/frontend/src/app/sessions/active-sessions/active-sessions.component.ts
+++ b/frontend/src/app/sessions/active-sessions/active-sessions.component.ts
@@ -14,8 +14,6 @@ import { SessionService } from '../../services/session/session.service';
 import { DeleteSessionDialogComponent } from '../delete-session-dialog/delete-session-dialog.component';
 import { ReconnectDialogComponent } from './reconnect-dialog/reconnect-dialog.component';
 import { UploadDialogComponent } from './upload-dialog/upload-dialog.component';
-import { Subscription, timer } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-active-sessions',

--- a/frontend/src/app/sessions/active-sessions/active-sessions.component.ts
+++ b/frontend/src/app/sessions/active-sessions/active-sessions.component.ts
@@ -14,6 +14,8 @@ import { SessionService } from '../../services/session/session.service';
 import { DeleteSessionDialogComponent } from '../delete-session-dialog/delete-session-dialog.component';
 import { ReconnectDialogComponent } from './reconnect-dialog/reconnect-dialog.component';
 import { UploadDialogComponent } from './upload-dialog/upload-dialog.component';
+import { Subscription, timer } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-active-sessions',

--- a/frontend/src/app/workspaces/home.component.html
+++ b/frontend/src/app/workspaces/home.component.html
@@ -8,6 +8,7 @@
   <h1>Capella Collaboration Manager</h1>
 </mat-card>
 
-<app-active-sessions></app-active-sessions>
-
-<app-workspace></app-workspace>
+<div class="flexbox">
+  <app-workspace></app-workspace>
+  <app-active-sessions></app-active-sessions>
+</div>

--- a/frontend/src/app/workspaces/home.component.html
+++ b/frontend/src/app/workspaces/home.component.html
@@ -8,7 +8,6 @@
   <h1>Capella Collaboration Manager</h1>
 </mat-card>
 
-<div class="flexbox">
-  <app-workspace></app-workspace>
-  <app-active-sessions></app-active-sessions>
-</div>
+<app-active-sessions></app-active-sessions>
+
+<app-workspace></app-workspace>


### PR DESCRIPTION
# Description

* A button to start a new read-only session is placed in the model card
* The button will load all models that match the project and tool (version) of the loaded model

NB. Read-only models only apply to models available from a git repository.

Resolves #issue

# Testing

How were the changes tested?

# Checklist

- [x] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I updated the documentation with the new functionality
- [x] I went through the code and removed all print statements, breakpoints and unused code
- [x] Error handling for all possible scenarios has been implemented
- [x] I've add logging for all relevant operations
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)


# Current state (13.10.2022)

* Backend is working with limitations. It works only with one model: the first model that matches the requested tool/version.
* The frontend is working with fixed data: project is "default" and the tool is Capella 5.2.

What needs to be done still:

- [x] Update the "readonly" docker image to support multiple repositories
- [x] It's now clear that, when the "create session" button is hit something's happening. It needs some feedback
- [x] With me, the state keeps hanging in a "prepare" state. Not sure what happens there.