### PR TITLE
Fix unknown state in sessions

### DIFF
--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -43,6 +43,7 @@ def get_last_seen(sid: str) -> str:
             url,
             timeout=config["requests"]["timeout"],
         )
+        response.raise_for_status()
         for session in response.json()["data"]["result"]:
             if sid == session["metric"]["app"]:
                 return _get_last_seen(float(session["value"][1]))

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -52,7 +52,7 @@ export class SessionService {
     return this.http.get<SessionUsage>(this.BACKEND_URL_PREFIX + 'usage');
   }
 
-  beatifyState(state: string | undefined): SessionState {
+  beautifyState(state: string | undefined): SessionState {
     /* Possible states are (and a few more states):
     https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/events/event.go */
 

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -58,6 +58,7 @@ export class SessionService {
 
     let text = state;
     let css = 'warning';
+    let success = false;
     switch (state) {
       case 'Created':
         text = 'Created session';
@@ -66,6 +67,7 @@ export class SessionService {
       case 'Started':
         text = 'Started session';
         css = 'success';
+        success = true;
         break;
       case 'Failed':
       case 'FailedCreatePodContainer':
@@ -116,6 +118,17 @@ export class SessionService {
         css = 'warning';
         break;
 
+      // Pod phases (that are not handled before)
+      case 'Pending':
+        text = 'Your session is scheduled';
+        css = 'warning';
+        break;
+      case 'Running':
+        text = 'Session is running';
+        css = 'success';
+        success = true;
+        break;
+
       // Cases for readonly containers
       case 'START_LOAD_MODEL':
         text = 'Modelloading started';
@@ -144,8 +157,10 @@ export class SessionService {
       case 'START_SESSION':
         text = 'Session started';
         css = 'success';
+        success = true;
         break;
       case 'unknown':
+      case 'Unknown':
         text = 'Unknown State';
         css = 'primary';
         break;
@@ -153,7 +168,8 @@ export class SessionService {
 
     return {
       text: text || '',
-      css,
+      css: css,
+      success: success,
     };
   }
 }
@@ -161,6 +177,7 @@ export class SessionService {
 export interface SessionState {
   text: string;
   css: string;
+  success: boolean;
 }
 
 export enum DepthType {

--- a/frontend/src/app/sessions/active-sessions/active-sessions.component.html
+++ b/frontend/src/app/sessions/active-sessions/active-sessions.component.html
@@ -24,9 +24,9 @@
   <mat-card-content class="sessionContent">
     <h3
       class="state"
-      [ngClass]="sessionService.beatifyState(session.state).css"
+      [ngClass]="sessionService.beautifyState(session.state).css"
     >
-      {{ sessionService.beatifyState(session.state).text }}
+      {{ sessionService.beautifyState(session.state).text }}
     </h3>
     <p id="creationTime">
       The session was created
@@ -41,7 +41,7 @@
       mat-flat-button
       color="primary"
       (click)="openReconnectDialog(session)"
-      [disabled]="!sessionService.beatifyState(session.state).success"
+      [disabled]="!sessionService.beautifyState(session.state).success"
     >
       Reconnect
     </button>
@@ -50,7 +50,7 @@
       mat-flat-button
       color="primary"
       (click)="uploadFileDialog(session)"
-      [disabled]="!sessionService.beatifyState(session.state).success"
+      [disabled]="!sessionService.beautifyState(session.state).success"
     >
       Upload
     </button>

--- a/frontend/src/app/sessions/active-sessions/active-sessions.component.html
+++ b/frontend/src/app/sessions/active-sessions/active-sessions.component.html
@@ -37,26 +37,20 @@
     <button mat-button color="primary" (click)="openDeletionDialog([session])">
       Terminate
     </button>
-
     <button
-      mat-button
+      mat-flat-button
       color="primary"
       (click)="openReconnectDialog(session)"
-      [disabled]="
-        !(session.state === 'Started' || session.state === 'START_SESSION')
-      "
+      [disabled]="!sessionService.beatifyState(session.state).success"
     >
-      Connect
+      Reconnect
     </button>
 
     <button
-      mat-button
+      mat-flat-button
       color="primary"
       (click)="uploadFileDialog(session)"
-      [disabled]="
-        !(session.state === 'Started' || session.state === 'START_SESSION')
-      "
-      content
+      [disabled]="!sessionService.beatifyState(session.state).success"
     >
       Upload
     </button>


### PR DESCRIPTION
# Description

This PR fixes the issue with "Unknown" session states. Usually, we fetch the events from kubernetes to determine a detailed state for a Pod. With events, we can get information like "Image pull failed", etc. 

However, events are only stored for a limited time. Therefore, after a specific time, the sessions goes into state "unknown".
I added a fallback to the Pod phase, which should be set always: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
It has less information (e.g. just "Failed", not the reason for the failure), but it's better than nothing and should be pretty stable.