### PR TITLE
Disable proxy buffering for ingress

### DIFF
--- a/helm/templates/routing/nginx.ingress.yaml
+++ b/helm/templates/routing/nginx.ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{ else }}
     kubernetes.io/ingress.class: nginx
     {{ end }}
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 spec:
   rules:
     - host: {{ .Values.general.host }}

--- a/helm/templates/routing/nginx.ingress.yaml
+++ b/helm/templates/routing/nginx.ingress.yaml
@@ -11,13 +11,12 @@ metadata:
   annotations:
     {{ if eq .Values.target "local" }}
     ingress.kubernetes.io/ssl-redirect: "false"
-    {{ else }}
-    kubernetes.io/ingress.class: nginx
     {{ end }}
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 spec:
+  ingressClassName: nginx
   rules:
     - host: {{ .Values.general.host }}
       http:

--- a/helm/templates/routing/nginx.ingress.yaml
+++ b/helm/templates/routing/nginx.ingress.yaml
@@ -16,7 +16,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 spec:
+  {{ if ne .Values.target "local" }}
   ingressClassName: nginx
+  {{ end }}
   rules:
     - host: {{ .Values.general.host }}
       http:


### PR DESCRIPTION
# Description

We got many reports that performance is degraded when using Guacamole to connect to the session containers (e.g. #122). 

This PR adds annotations to the nginx ingress to disable proxy buffering. 

For deployments using OpenShits routes, there doesn't seem to be a good solution - I didn't find a configuration option to disable buffering for [HAProxy](http://www.haproxy.org/). When the changes from this PR have an effect, we should recommend using Ingress instead of Routes on OpenShift clusters.