### PR TITLE
fix: Use user ID for project creation

### DIFF
--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -37,6 +37,8 @@ from capellacollab.projects.users.models import (
     ProjectUserPermission,
     ProjectUserRole,
 )
+from capellacollab.users.injectables import get_own_user
+from capellacollab.users.models import DatabaseUser
 
 from .capellamodels.routes import router as router_models
 from .users.routes import router as router_users
@@ -104,7 +106,7 @@ def get_project_by_slug(slug: str, db: Session = Depends(get_db)):
 def create_project(
     body: PostProjectRequest,
     db: Session = Depends(get_db),
-    token: JWTBearer = Depends(JWTBearer()),
+    user: DatabaseUser = Depends(get_own_user),
 ):
     try:
         project = crud.create_project(db, body.name, body.description)
@@ -120,7 +122,7 @@ def create_project(
         db,
         project.name,
         ProjectUserRole.MANAGER,
-        get_username(token),
+        user.id,
         ProjectUserPermission.WRITE,
     )
     return convert_project(project)

--- a/backend/capellacollab/users/injectables.py
+++ b/backend/capellacollab/users/injectables.py
@@ -25,7 +25,7 @@ def get_user(
     user_id: t.Union[int, t.Literal["current"]],
     db=Depends(get_db),
     token=Depends(JWTBearer()),
-):
+) -> DatabaseUser:
     if user_id == "current":
         return get_own_user(db, token)
     return crud.get_user_by_id(db, user_id)


### PR DESCRIPTION
Fix project creation: Use user id instead of username. 