### PR TITLE
Add no-console lint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
           },
         ],
         "unused-imports/no-unused-imports": "error",
+        "no-console": ["error", { allow: ["error"] }],
       },
     },
     {

--- a/frontend/src/app/general/auth/http-interceptor/auth.interceptor.ts
+++ b/frontend/src/app/general/auth/http-interceptor/auth.interceptor.ts
@@ -60,7 +60,6 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 
   refreshToken(): Observable<RefreshTokenResponse> {
-    console.log('Token is expired. Refreshing token...');
     return this.authService.performTokenRefresh();
   }
 }

--- a/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-loader/mat-card-overview-loader.component.ts
+++ b/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-loader/mat-card-overview-loader.component.ts
@@ -32,8 +32,6 @@ export class MatCardOverviewLoaderComponent implements OnInit {
 
   resize(width: number, height: number) {
     // Margin is 1vw (left + right) and 1vh (top + bottom)
-    console.log('Inner width: ' + window.innerWidth);
-    console.log('Margin: ' + width * 0.01);
 
     const cardsPerColumn = (0.98 * width) / 425;
     const cardsPerRow = (0.98 * height - 120) / 275;


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

This adds a rule to es-lint that checks if the code does not contain any console.log statements, and removes any existing `console.log`.
