### PR TITLE
Persistent sessions for multiple T4C Instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 deployments/*
 certs/*
 /node_modules
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: CC0-1.0
 
-# SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
-# SPDX-License-Identifier: CC0-1.0
-
-.vscode
 .venv*
 /.provision-backend
 /.provision-guacamole
@@ -15,4 +11,3 @@
 deployments/*
 certs/*
 /node_modules
-.idea

--- a/backend/capellacollab/alembic/versions/9a1e6729858b_introduce_protocol_on_instance.py
+++ b/backend/capellacollab/alembic/versions/9a1e6729858b_introduce_protocol_on_instance.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Introduce protocol on instance.
+
+Revision ID: 9a1e6729858b
+Revises: e7a140389e22
+Create Date: 2022-11-08 10:06:04.740051
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9a1e6729858b"
+down_revision = "e7a140389e22"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    protocol = sa.Enum("tcp", "ssl", "ws", "wss", name="protocol")
+    protocol.create(op.get_bind())
+    op.add_column(
+        "t4c_instances",
+        sa.Column("protocol", protocol, server_default="tcp", nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("t4c_instances", "protocol")
+    sa.Enum(name="protocol").drop(op.get_bind(), checkfirst=False)

--- a/backend/capellacollab/alembic/versions/9a1e6729858b_introduce_protocol_on_instance.py
+++ b/backend/capellacollab/alembic/versions/9a1e6729858b_introduce_protocol_on_instance.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "9a1e6729858b"
-down_revision = "e7a140389e22"
+down_revision = "8eceebe9b3ea"
 branch_labels = None
 depends_on = None
 

--- a/backend/capellacollab/projects/capellamodels/models.py
+++ b/backend/capellacollab/projects/capellamodels/models.py
@@ -36,6 +36,15 @@ from capellacollab.tools.models import (
     Version,
 )
 
+if t.TYPE_CHECKING:
+    from capellacollab.projects.capellamodels.modelsources.git.models import (
+        DB_GitModel,
+    )
+    from capellacollab.projects.capellamodels.modelsources.t4c.models import (
+        DatabaseT4CModel,
+    )
+    from capellacollab.projects.models import DatabaseProject
+
 
 class EditingMode(enum.Enum):
     T4C = "t4c"
@@ -63,21 +72,27 @@ class DatabaseCapellaModel(Base):
     description = Column(String)
 
     project_id = Column(Integer, ForeignKey("projects.id"))
-    project = relationship("DatabaseProject", back_populates="models")
+    project: DatabaseProject = relationship(
+        "DatabaseProject", back_populates="models"
+    )
 
     tool_id = Column(Integer, ForeignKey(Tool.id))
-    tool = relationship(Tool)
+    tool: Tool = relationship(Tool)
 
     version_id = Column(Integer, ForeignKey(Version.id))
-    version = relationship(Version)
+    version: Version = relationship(Version)
 
     nature_id = Column(Integer, ForeignKey(Nature.id))
     nature = relationship(Nature)
 
     editing_mode = Column(Enum(EditingMode))
 
-    t4c_models = relationship("DatabaseT4CModel", back_populates="model")
-    git_models = relationship("DB_GitModel", back_populates="model")
+    t4c_models: list[DatabaseT4CModel] = relationship(
+        "DatabaseT4CModel", back_populates="model"
+    )
+    git_models: list[DB_GitModel] = relationship(
+        "DB_GitModel", back_populates="model"
+    )
 
 
 class ResponseModel(BaseModel):

--- a/backend/capellacollab/projects/capellamodels/modelsources/t4c/models.py
+++ b/backend/capellacollab/projects/capellamodels/modelsources/t4c/models.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import typing as t
 
 from pydantic import BaseModel
 from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
@@ -10,6 +11,11 @@ from capellacollab.core.database import Base
 from capellacollab.settings.modelsources.t4c.repositories.models import (
     T4CRepository,
 )
+
+if t.TYPE_CHECKING:
+    from capellacollab.projects.capellamodels.models import (
+        DatabaseCapellaModel,
+    )
 
 
 class DatabaseT4CModel(Base):
@@ -23,7 +29,9 @@ class DatabaseT4CModel(Base):
     repository = relationship("DatabaseT4CRepository", back_populates="models")
 
     model_id = Column(Integer, ForeignKey("models.id"))
-    model = relationship("DatabaseCapellaModel", back_populates="t4c_models")
+    model: "DatabaseCapellaModel" = relationship(
+        "DatabaseCapellaModel", back_populates="t4c_models"
+    )
 
 
 class SubmitT4CModel(BaseModel):

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import relationship
 import capellacollab.projects.capellamodels.models
 import capellacollab.projects.users.models
 from capellacollab.core.database import Base
+from capellacollab.projects.capellamodels.models import DatabaseCapellaModel
 from capellacollab.projects.users.models import (
     ProjectUserAssociation,
     ProjectUserPermission,
@@ -86,8 +87,10 @@ class DatabaseProject(Base):
     name = Column(String, unique=True, index=True)
     slug = Column(String, unique=True, index=True, nullable=False)
     description = Column(String)
-    users = relationship(
+    users: ProjectUserAssociation = relationship(
         "ProjectUserAssociation",
         back_populates="projects",
     )
-    models = relationship("DatabaseCapellaModel", back_populates="project")
+    models: DatabaseCapellaModel = relationship(
+        "DatabaseCapellaModel", back_populates="project"
+    )

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -54,5 +54,7 @@ class ProjectUserAssociation(Base):
     projects_name = Column(ForeignKey("projects.name"), primary_key=True)
     user = relationship("DatabaseUser", back_populates="projects")
     projects = relationship("DatabaseProject", back_populates="users")
-    permission = Column(Enum(ProjectUserPermission), nullable=False)
+    permission: ProjectUserPermission = Column(
+        Enum(ProjectUserPermission), nullable=False
+    )
     role = Column(Enum(ProjectUserRole))

--- a/backend/capellacollab/sessions/operators/abc.py
+++ b/backend/capellacollab/sessions/operators/abc.py
@@ -12,7 +12,7 @@ class Operator(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def start_persistent_session(
-        self,
+        cls,
         username: str,
         password: str,
         docker_image: str,

--- a/backend/capellacollab/sessions/operators/abc.py
+++ b/backend/capellacollab/sessions/operators/abc.py
@@ -16,7 +16,8 @@ class Operator(abc.ABC):
         username: str,
         password: str,
         docker_image: str,
-        repositories: t.List[str],
+        t4c_license_secret: str | None,
+        t4c_json: list[dict[str, str | int]] | None,
     ) -> t.Dict[str, t.Any]:
         """Start / Create a session
 

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import enum
+import json
 import logging
 import random
 import string
@@ -90,10 +91,10 @@ class KubernetesOperator(Operator):
         username: str,
         password: str,
         docker_image: str,
-        repositories: t.List[str],
-    ) -> t.Dict[str, t.Any]:
+        t4c_license_secret: str | None,
+        t4c_json: list[dict[str, str | int]] | None,
+    ) -> dict[str, t.Any]:
         log.info("Launching a persistent session for user %s", username)
-        t4c_cfg = config["modelsources"]["t4c"]
 
         id = self._generate_id()
         self._create_persistent_volume_claim(username)
@@ -101,10 +102,8 @@ class KubernetesOperator(Operator):
             docker_image,
             id,
             {
-                "T4C_LICENCE_SECRET": t4c_cfg["licence"],
-                "T4C_SERVER_HOST": t4c_cfg["host"],
-                "T4C_SERVER_PORT": t4c_cfg["port"],
-                "T4C_REPOSITORIES": ",".join(repositories),
+                "T4C_LICENCE_SECRET": t4c_license_secret,
+                "T4C_JSON": json.dumps(t4c_json),
                 "RMT_PASSWORD": password,
                 "FILESERVICE_PASSWORD": password,
                 "T4C_USERNAME": username,

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -250,7 +250,7 @@ def request_persistent_session(
         for repository in t4c_repositories
     ]
 
-    t4c_license_secret: str = (
+    t4c_license_secret = (
         t4c_repositories[0].instance.license if t4c_repositories else None
     )
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -238,8 +238,6 @@ def request_persistent_session(
         else None
     )
 
-    print(t4c_repositories)
-
     t4c_json: list[dict[str, str | int]] = [
         {
             "repository": repository.name,

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -206,6 +206,7 @@ def request_persistent_session(
     t4c_json = [
         {
             "repository": repository.name,
+            "protocol": repository.instance.protocol,
             "port": repository.instance.port,
             "host": repository.instance.host,
             "instance": repository.instance.name,

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -7,7 +7,6 @@ import logging
 import typing as t
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 import capellacollab.projects.capellamodels.modelsources.git.crud as git_models_crud
@@ -21,16 +20,7 @@ from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
-from capellacollab.projects.capellamodels.models import DatabaseCapellaModel
-from capellacollab.projects.capellamodels.modelsources.t4c.models import (
-    DatabaseT4CModel,
-)
-from capellacollab.projects.models import DatabaseProject
 from capellacollab.projects.users.crud import ProjectUserRole
-from capellacollab.projects.users.models import (
-    ProjectUserAssociation,
-    ProjectUserPermission,
-)
 from capellacollab.sessions import database, guacamole
 from capellacollab.sessions.files import routes as files
 from capellacollab.sessions.models import DatabaseSession
@@ -48,9 +38,6 @@ from capellacollab.sessions.schema import (
 from capellacollab.sessions.sessions import inject_attrs_in_sessions
 from capellacollab.settings.modelsources.t4c.repositories.crud import (
     get_user_t4c_repositories,
-)
-from capellacollab.settings.modelsources.t4c.repositories.models import (
-    DatabaseT4CRepository,
 )
 from capellacollab.tools.crud import get_image_for_tool_version
 from capellacollab.tools.injectables import (

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -236,7 +236,7 @@ def request_persistent_session(
         else None
     )
 
-    t4c_json: list[dict[str, str | int]] = [
+    t4c_json = [
         {
             "repository": repository.name,
             "port": repository.instance.port,

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -22,8 +22,18 @@ from capellacollab.core.authentication.helper import get_username
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.credentials import generate_password
 from capellacollab.core.database import get_db
+from capellacollab.projects.capellamodels.models import DatabaseCapellaModel
+from capellacollab.projects.capellamodels.modelsources.t4c.models import (
+    DatabaseT4CModel,
+)
+from capellacollab.projects.models import DatabaseProject
 from capellacollab.projects.users.crud import ProjectUserRole
+from capellacollab.projects.users.models import (
+    ProjectUserAssociation,
+    ProjectUserPermission,
+)
 from capellacollab.sessions import database, guacamole
+from capellacollab.sessions.files import routes as files
 from capellacollab.sessions.models import DatabaseSession
 from capellacollab.sessions.operators import Operator, get_operator
 from capellacollab.sessions.schema import (
@@ -36,27 +46,18 @@ from capellacollab.sessions.schema import (
     PostSessionRequest,
     WorkspaceType,
 )
-from capellacollab.sessions.sessions import (
-    get_last_seen,
-    inject_attrs_in_sessions,
-)
-from capellacollab.tools.crud import get_image_for_tool_version
-from capellacollab.users.injectables import get_own_user
-from capellacollab.users.models import DatabaseUser, Role
-
-from ..projects.capellamodels.models import DatabaseCapellaModel
-from ..projects.capellamodels.modelsources.t4c.models import DatabaseT4CModel
-from ..projects.models import DatabaseProject
-from ..projects.users.models import (
-    ProjectUserAssociation,
-    ProjectUserPermission,
-)
-from ..settings.modelsources.t4c.repositories.models import (
+from capellacollab.sessions.sessions import inject_attrs_in_sessions
+from capellacollab.settings.modelsources.t4c.repositories.models import (
     DatabaseT4CRepository,
 )
-from ..tools.injectables import get_exisiting_tool_version, get_existing_tool
-from ..tools.models import Tool, Version
-from .files import routes as files
+from capellacollab.tools.crud import get_image_for_tool_version
+from capellacollab.tools.injectables import (
+    get_exisiting_tool_version,
+    get_existing_tool,
+)
+from capellacollab.tools.models import Tool, Version
+from capellacollab.users.injectables import get_own_user
+from capellacollab.users.models import DatabaseUser, Role
 
 router = APIRouter(
     dependencies=[Depends(RoleVerification(required_role=Role.USER))]

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -213,10 +213,8 @@ def request_persistent_session(
         select(DatabaseT4CRepository)
         .join(DatabaseT4CRepository.models)
         .join(DatabaseT4CModel.model)
-        .join(DatabaseCapellaModel.tool)
-        .where(Tool.id == tool.id)
-        .join(DatabaseCapellaModel.version)
-        .where(Version.id == version.id)
+        .where(DatabaseCapellaModel.tool == tool)
+        .where(DatabaseCapellaModel.version == version)
     )
 
     stmt = (
@@ -225,8 +223,7 @@ def request_persistent_session(
         .where(
             ProjectUserAssociation.permission == ProjectUserPermission.WRITE
         )
-        .join(ProjectUserAssociation.user)
-        .where(DatabaseUser.id == user.id)
+        .where(ProjectUserAssociation.user == user)
     )
 
     t4c_repositories: t.Optional[list[DatabaseT4CRepository]] = (

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -56,8 +56,8 @@ class PostSessionRequest(BaseModel):
 
 
 class PostPersistentSessionRequest(BaseModel):
-    tool: int
-    version: int
+    tool_id: int
+    version_id: int
 
 
 class GetSessionUsageResponse(BaseModel):

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -7,13 +7,19 @@ import typing as t
 
 import pydantic
 import requests
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, validator
 from requests.exceptions import RequestException
-from sqlalchemy import CheckConstraint, Column, ForeignKey, Integer, String
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+)
 from sqlalchemy.orm import relationship
 
 from capellacollab.core.database import Base
-from capellacollab.core.models import ResponseModel
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +34,13 @@ def validate_rest_api_url(value: t.Optional[str]):
                 "The provided TeamForCapella REST API is not valid."
             )
     return value
+
+
+class Protocol(str, enum.Enum):
+    tcp = "tcp"
+    ssl = "ssl"
+    ws = "ws"
+    wss = "wss"
 
 
 class DatabaseT4CInstance(Base):
@@ -45,6 +58,11 @@ class DatabaseT4CInstance(Base):
     rest_api = Column(String)
     username = Column(String)
     password = Column(String)
+    protocol = Column(
+        Enum(Protocol),
+        nullable=False,
+        default=Protocol.tcp,
+    )
 
     version = relationship("Version")
     repositories = relationship(
@@ -71,6 +89,7 @@ class T4CInstanceBase(BaseModel):
     usage_api: str
     rest_api: str
     username: str
+    protocol: Protocol
 
     # validators
     _validate_username = validator("username", allow_reuse=True)(
@@ -93,6 +112,7 @@ class PatchT4CInstance(BaseModel):
     rest_api: t.Optional[str]
     username: t.Optional[str]
     password: t.Optional[str]
+    protocol: t.Optional[Protocol]
 
     # validators
     _validate_username = validator("username", allow_reuse=True)(

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -12,7 +12,15 @@ from sqlalchemy.orm import relationship
 
 from capellacollab.core.database import Base
 from capellacollab.core.models import ResponseModel
-from capellacollab.settings.modelsources.t4c.models import T4CInstance
+from capellacollab.settings.modelsources.t4c.models import (
+    DatabaseT4CInstance,
+    T4CInstance,
+)
+
+if t.TYPE_CHECKING:
+    from capellacollab.projects.capellamodels.modelsources.t4c.models import (
+        DatabaseT4CModel,
+    )
 
 
 class DatabaseT4CRepository(Base):
@@ -27,11 +35,11 @@ class DatabaseT4CRepository(Base):
         Integer, ForeignKey("t4c_instances.id"), nullable=False
     )
 
-    instance = relationship(
+    instance: DatabaseT4CInstance = relationship(
         "DatabaseT4CInstance", back_populates="repositories"
     )
 
-    models = relationship(
+    models: list[DatabaseT4CModel] = relationship(
         "DatabaseT4CModel",
         back_populates="repository",
         cascade="all, delete",

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -7,7 +7,14 @@ import enum
 import typing as t
 
 from pydantic import BaseModel
-from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import relationship
 
 from capellacollab.core.database import Base

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -71,7 +71,8 @@ class MockOperator(Operator):
         username: str,
         password: str,
         docker_image: str,
-        repositories: t.List[str],
+        t4c_license_secret: str | None,
+        t4c_json: list[dict[str, str | int]] | None,
     ) -> t.Dict[str, t.Any]:
         cls.sessions.append({"docker_image": docker_image})
         return {
@@ -186,8 +187,8 @@ def test_create_persistent_session_as_user(client, db, username, kubernetes):
     response = client.post(
         "/api/v1/sessions/persistent",
         json={
-            "tool": tool_id,
-            "version": version_id,
+            "tool_id": tool_id,
+            "version_id": version_id,
         },
     )
 

--- a/frontend/src/app/services/session/session.service.ts
+++ b/frontend/src/app/services/session/session.service.ts
@@ -39,8 +39,8 @@ export class SessionService {
     versionId: number
   ): Observable<Session> {
     return this.http.post<Session>(`${this.BACKEND_URL_PREFIX}persistent`, {
-      tool: toolId,
-      version: versionId,
+      tool_id: toolId,
+      version_id: versionId,
     });
   }
 

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -9,6 +9,8 @@ import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { T4CRepository } from '../../settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service';
 
+export type Protocol = 'tcp' | 'ssl' | 'ws' | 'wss';
+
 export type BaseT4CInstance = {
   license: string;
   host: string;
@@ -17,6 +19,7 @@ export type BaseT4CInstance = {
   rest_api: string;
   username: string;
   password: string;
+  protocol: Protocol;
 };
 
 export type NewT4CInstance = BaseT4CInstance & {

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.css
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.css
@@ -11,3 +11,15 @@
   display: flex;
   justify-content: space-evenly;
 }
+
+#protocol {
+  width: 6em;
+}
+
+#host {
+  width: 15em;
+}
+
+#port {
+  width: 8em;
+}

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -42,12 +42,23 @@
           </mat-form-field>
         </fieldset>
         <fieldset>
-          <mat-form-field appearance="fill">
+          <mat-form-field id="protocol" appearance="fill">
+            <mat-label>Protocol</mat-label>
+            <mat-select formControlName="protocol">
+              <mat-option
+                *ngFor="let protocol of ['tcp', 'ssl', 'ws', 'wss']"
+                [value]="protocol"
+                >{{ protocol }}</mat-option
+              >
+            </mat-select>
+          </mat-form-field>
+          <div class="half-field-separator"></div>
+          <mat-form-field id="host" appearance="fill">
             <mat-label>Host</mat-label>
             <input matInput formControlName="host" />
           </mat-form-field>
-          <div class="field-separator"></div>
-          <mat-form-field appearance="fill">
+          <div class="half-field-separator"></div>
+          <mat-form-field id="port" appearance="fill">
             <mat-label>Port</mat-label>
             <input matInput inputmode="numeric" formControlName="port" />
             <mat-error

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -17,15 +17,16 @@ import {
 import { NavBarService } from 'src/app/general/navbar/service/nav-bar.service';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
 import {
+  BaseT4CInstance,
+  NewT4CInstance,
+  Protocol,
+  T4CInstance,
+  T4CInstanceService,
+} from 'src/app/services/settings/t4c-instance.service';
+import {
   ToolService,
   ToolVersion,
 } from 'src/app/settings/core/tools-settings/tool.service';
-import {
-  BaseT4CInstance,
-  NewT4CInstance,
-  T4CInstance,
-  T4CInstanceService,
-} from '../../../../services/settings/t4c-instance.service';
 
 @Component({
   selector: 'app-edit-t4c-instance',
@@ -56,6 +57,7 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
     name: new FormControl('', Validators.required),
     version_id: new FormControl(-1, Validators.required),
     license: new FormControl('', Validators.required),
+    protocol: new FormControl<Protocol>('tcp', Validators.required),
     host: new FormControl('', Validators.required),
     port: new FormControl(null as number | null, [
       Validators.required,

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
@@ -31,7 +31,7 @@
         {{ instance.version.name }}
         <br />
         <mat-icon class="aligned">link</mat-icon><b> Host:</b>
-        {{ instance.host }}:{{ instance.port }}
+        {{ instance.protocol }}://{{ instance.host }}:{{ instance.port }}
       </div>
     </mat-card>
   </a>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -148,6 +148,11 @@ mat-spinner {
   display: inline-block;
 }
 
+.half-field-separator {
+  margin: 0 1em 0 0;
+  display: inline-block;
+}
+
 .field-separator::before {
   display: inline-block;
   content: "\00a0\00a0";


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

This PR allows to launch a persistent session with either
- All the T4C repositories of the projects where the user has write permission
- All the T4C repositories if the user is an admin

# Testing

How were the changes tested?

# Checklist

- [x] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I updated the documentation with the new functionality
- [x] I went through the code and removed all print statements, breakpoints and unused code
- [x] Error handling for all possible scenarios has been implemented
- [x] I've add logging for all relevant operations
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
