### PR TITLE
Solve askpass issues

### DIFF
--- a/backend/capellacollab/settings/modelsources/git/askpass.py
+++ b/backend/capellacollab/settings/modelsources/git/askpass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

Askpass was not taken in account because it’s shebang contained `python` instead of `python3`. I also needed to make it executable
