### PR TITLE
Add no relative import eslint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -52,6 +52,14 @@ module.exports = {
             caughtErrorsIgnorePattern: "^_",
           },
         ],
+        "@typescript-eslint/no-restricted-imports": [
+          "error",
+          {
+            name: "no-relative-imports",
+            patterns: ["../../../*"],
+            message: "Please use absolute imports instead",
+          },
+        ],
         "unused-imports/no-unused-imports": "error",
         "no-console": ["error", { allow: ["error"] }],
         "deprecation/deprecation": "error",

--- a/frontend/src/app/services/modelsources/t4c-model/t4c-model.service.ts
+++ b/frontend/src/app/services/modelsources/t4c-model/t4c-model.service.ts
@@ -6,8 +6,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, tap } from 'rxjs';
-import { environment } from '../../../../environments/environment';
-import { T4CRepository } from '../../../settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service';
+import { T4CRepository } from 'src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root',

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.ts
@@ -9,7 +9,7 @@ import { NavBarService } from 'src/app/general/navbar/service/nav-bar.service';
 import {
   T4CInstance,
   T4CInstanceService,
-} from '../../../services/settings/t4c-instance.service';
+} from 'src/app/services/settings/t4c-instance.service';
 
 @Component({
   selector: 'app-t4c-settings',


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

This adds an es-lint rule prohibiting relative imports with a depth of three or more, and fixes existing problems with relative imports.

Resolves #371 
