### PR TITLE
Build and use multiple capella versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ RELEASE = dev-t4c-manager
 NAMESPACE = t4c-manager
 SESSION_NAMESPACE = t4c-sessions
 PORT ?= 8080
-CAPELLA_VERSIONS = 5.0.0 5.2.0 6.0.0
-T4C_CLIENT_VERSIONS = 5.2.0 6.0.0
+# List of Capella versions, e.g.: `5.0.0 5.2.0 6.0.0`
+CAPELLA_VERSIONS = 5.2.0
+# List of T4C versions, e.g., `5.2.0 6.0.0`
+T4C_CLIENT_VERSIONS = 5.2.0
 CAPELLA_DOCKERIMAGES = $(MAKE) -C capella-dockerimages PUSH_IMAGES=1 DOCKER_REGISTRY=$(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)
 
 # Adds support for msys

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CAPELLA_DOCKERIMAGES = $(MAKE) -C capella-dockerimages PUSH_IMAGES=1 DOCKER_REGI
 # Adds support for msys
 export MSYS_NO_PATHCONV := 1
 
-build: backend frontend docs capella
+build: backend frontend docs
 
 build-t4c: build t4c-client
 
@@ -50,10 +50,10 @@ docs:
 	docker build -t capella/collab/docs -t $(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)/capella/collab/docs docs/user
 	docker push $(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)/capella/collab/docs
 
-deploy: build build-capella helm-deploy open rollout
+deploy: build capella helm-deploy open rollout
 
 # Deploy with full T4C client support:
-deploy-t4c: build build-t4c helm-deploy open rollout
+deploy-t4c: build t4c-client helm-deploy open rollout
 
 deploy-without-build: helm-deploy open rollout
 

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ export MSYS_NO_PATHCONV := 1
 
 build: backend frontend docs
 
-build-t4c: build t4c-client
-
 backend:
 	python backend/generate_git_archival.py;
 	docker build -t t4c/client/backend -t $(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)/capella/collab/backend backend

--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,14 @@ frontend:
 
 capella:
 	for version in $(CAPELLA_VERSIONS)
-	do $(MAKE) capella-$$version
+	do $(CAPELLA_DOCKERIMAGES) CAPELLA_VERSION=$$version capella/remote capella/readonly
 	done
-
-capella-%: registry
-	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSION=$* capella/remote capella/readonly
 
 t4c-client:
 	for version in $(T4C_CLIENT_VERSIONS)
-	do $(MAKE) t4c-client-$$version
+	do $(CAPELLA_DOCKERIMAGES) CAPELLA_VERSION=$$version t4c/client/remote t4c/client/backup
 	done
 
-t4c-client-%: registry
-	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSION=$* t4c/client/remote t4c/client/backup
 
 docs:
 	docker build -t capella/collab/docs -t $(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)/capella/collab/docs docs/user

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ NAMESPACE = t4c-manager
 SESSION_NAMESPACE = t4c-sessions
 PORT ?= 8080
 CAPELLA_VERSIONS = 5.0.0 5.2.0 6.0.0
+T4C_CLIENT_VERSIONS = 5.2.0 6.0.0
 CAPELLA_DOCKERIMAGES = $(MAKE) -C capella-dockerimages PUSH_IMAGES=1 DOCKER_REGISTRY=$(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)
 
 # Adds support for msys
@@ -17,8 +18,7 @@ export MSYS_NO_PATHCONV := 1
 
 build: backend frontend docs capella
 
-build-t4c: build
-	$(CAPELLA_DOCKERIMAGES) t4c/client/remote t4c/client/backup
+build-t4c: build t4c-client
 
 backend:
 	python backend/generate_git_archival.py;
@@ -37,6 +37,14 @@ capella:
 
 capella-%: registry
 	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSION=$* capella/remote capella/readonly
+
+t4c-client:
+	for version in $(T4C_CLIENT_VERSIONS)
+	do $(MAKE) t4c-client-$$version
+	done
+
+t4c-client-%: registry
+	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSION=$* t4c/client/remote t4c/client/backup
 
 docs:
 	docker build -t capella/collab/docs -t $(LOCAL_REGISTRY_NAME):$(REGISTRY_PORT)/capella/collab/docs docs/user

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Please wait until all services are in the "Running" state.
 
 If all goes well, you should find Capella-collab-manager running on [http://localhost:8080/](http://localhost:8080/).
 
+To reduce the build time, the default configutation only builds a Capella 5.2.0 image. You can modify the `Makefile`
+if you want to build multiple versions.
+By default the TeamForCapella images are configured. You can change those in the Settings section of the website.
+
 If you want to see the individual services in the Kubernetes dashboard, you can run the following command:
 
 ```zsh


### PR DESCRIPTION
# Description

Build multiple capella versions as part of the local deployment. 

* Update capella-dockerimages to the latest version.
* Update Makefile to work with the latest version of capella-dockerimages.
* Align naming with what's found in capella-dockerimages.
* Use standard capella images (not t4c/client), since those are built as part of `make deploy` (the new user experience)

# Testing

Clean everything, including docker registry. Rebuild everything and start capella 6.0 through the collab manager

# Checklist

- [x] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I updated the documentation with the new functionality
- [x] I went through the code and removed all print statements, breakpoints and unused code
- [x] Error handling for all possible scenarios has been implemented
- [x] I've add logging for all relevant operations
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
