### PR TITLE
Move storageClassName to cluster config

### DIFF
--- a/helm/templates/backend/postgres.volume.yaml
+++ b/helm/templates/backend/postgres.volume.yaml
@@ -13,6 +13,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: {{ .Values.database.backend.internal.storageClassName }}
+  storageClassName: {{ .Values.cluster.pvc.storageClassName }}
 {{ end }}
 {{ end }}

--- a/helm/templates/guacamole/postgres.volume.yaml
+++ b/helm/templates/guacamole/postgres.volume.yaml
@@ -13,6 +13,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: {{ .Values.database.guacamole.internal.storageClassName }}
+  storageClassName: {{ .Values.cluster.pvc.storageClassName }}
 {{ end }}
 {{ end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -162,7 +162,6 @@ target: other
 mocks:
   oauth: False
 
-
 cluster:
   kind: Kubernetes # Kubernetes | OpenShift
 
@@ -173,6 +172,9 @@ cluster:
     sessions:
       containers:
       # The following values are appended to each container in the sessions namespace
+
+  pvc:
+    storageClassName: null
 
 # Specify the NO_PROXY environment for the backend
 # Leave it empty if not needed


### PR DESCRIPTION
The `storageClassName` was missing in the `values.yaml` template. It was leading to unintended helm behavior (the user was not able to define the storageClassName)