### PR TITLE
Git types matches now the database structure

### DIFF
--- a/backend/capellacollab/settings/modelsources/git/models.py
+++ b/backend/capellacollab/settings/modelsources/git/models.py
@@ -12,10 +12,10 @@ from capellacollab.core.database import Base
 
 
 class GitType(enum.Enum):
-    General = "General"
-    GitLab = "GitLab"
-    GitHub = "GitHub"
-    AzureDevOps = "AzureDevOps"
+    GENERAL = "General"
+    GITLAB = "GitLab"
+    GITHUB = "GitHub"
+    AZUREDEVOPS = "AzureDevOps"
 
 
 class GitSettings(BaseModel):


### PR DESCRIPTION
Creating instances was not working with the migration script. This is a fix.