### PR TITLE
feat: Display read-only session metadata properly

### DIFF
--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -304,7 +304,7 @@ def request_persistent_session(
         None,
         t4c_password,
     )
-    response["warnings"] = warnings
+    response.warnings = warnings
     return response
 
 
@@ -351,12 +351,9 @@ def create_database_and_guacamole_session(
         version=version,
         **session,
     )
-    response = database.create_session(db=db, session=database_model).__dict__
-    response["owner"] = response["owner_name"]
-    response["state"] = "New"
-    response["rdp_password"] = rdp_password
-    response["guacamole_password"] = guacamole_password
-    response["last_seen"] = "UNKNOWN"
+    response = database.create_session(db=db, session=database_model)
+    response.state = "New"
+    response.last_seen = "UNKNOWN"
     return response
 
 

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -10,7 +10,10 @@ import typing as t
 from pydantic import BaseModel
 
 from capellacollab.core.models import Message
+from capellacollab.projects.models import Project
 from capellacollab.sessions.operators.k8s import FileType
+from capellacollab.tools.models import ToolVersionWithTool
+from capellacollab.users.models import BaseUser
 
 
 class WorkspaceType(enum.Enum):
@@ -26,15 +29,15 @@ class DepthType(enum.Enum):
 class GetSessionsResponse(BaseModel):
     id: str
     type: WorkspaceType
-    ports: t.List[str]
     created_at: datetime.datetime
-    owner: str
-    repository: t.Optional[str]
+    owner: BaseUser
     state: str
     guacamole_username: str
     guacamole_connection_id: str
-    last_seen: str
     warnings: t.Optional[list[Message]]
+    last_seen: str
+    project: t.Optional[Project]
+    version: t.Optional[ToolVersionWithTool]
 
     class Config:
         orm_mode = True
@@ -42,16 +45,6 @@ class GetSessionsResponse(BaseModel):
 
 class OwnSessionResponse(GetSessionsResponse):
     t4c_password: t.Optional[str]
-
-
-class PostSessionRequest(BaseModel):
-    type: WorkspaceType
-    branch: str
-    depth: DepthType
-    repository: t.Optional[str]
-
-    class Config:
-        orm_mode = True
 
 
 class PostReadonlySessionRequest(BaseModel):

--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -24,12 +24,10 @@ def inject_attrs_in_sessions(
 ) -> t.List[t.Dict[str, t.Any]]:
     sessions_list = []
     for session in db_sessions:
-        session_dict = session.__dict__
-        session_dict["state"] = _determine_session_state(session_dict)
-        session_dict["last_seen"] = get_last_seen(session.id)
-        session_dict["owner"] = session_dict["owner_name"]
+        session.state = _determine_session_state(session)
+        session.last_seen = get_last_seen(session.id)
 
-        sessions_list.append(session_dict)
+        sessions_list.append(session)
 
     return sessions_list
 
@@ -74,12 +72,12 @@ def _get_last_seen(idletime: int | float) -> str:
 
 
 def _determine_session_state(session: t.Dict[str, t.Any]) -> str:
-    state = OPERATOR.get_session_state(session["id"])
+    state = OPERATOR.get_session_state(session.id)
 
-    if session["type"] == WorkspaceType.READONLY:
+    if session.type == WorkspaceType.READONLY:
         try:
             if state == "Started" or state == "BackOff":
-                logs = OPERATOR.get_session_logs(session["id"]).splitlines()
+                logs = OPERATOR.get_session_logs(session.id).splitlines()
                 for line in logs:
                     res = re.search(r"^---(.*?)---$", line)
                     if res:

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -60,7 +60,6 @@ class Nature(Base):
 class ToolBase(BaseModel):
     id: int
     name: str
-    docker_image_template: str
 
     class Config:
         orm_mode = True
@@ -111,6 +110,10 @@ class ToolVersionBase(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class ToolVersionWithTool(ToolVersionBase):
+    tool: ToolBase
 
 
 class ToolNatureBase(BaseModel):

--- a/frontend/src/app/schemes.ts
+++ b/frontend/src/app/schemes.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Project } from 'src/app/services/project/project.service';
+import { User } from 'src/app/services/user/user.service';
+import { ToolVersionWithTool } from 'src/app/settings/core/tools-settings/tool.service';
+
 export interface Session {
-  ports: string[];
   created_at: string;
   id: string;
   last_seen: string;
@@ -14,9 +17,10 @@ export interface Session {
   guacamole_username: string;
   guacamole_password: string;
   guacamole_connection_id: string;
-  repository: string;
+  project: Project | undefined;
+  version: ToolVersionWithTool | undefined;
   state: string;
-  owner: string;
+  owner: User;
   t4c_password: string;
 }
 

--- a/frontend/src/app/sessions/active-sessions/active-sessions.component.html
+++ b/frontend/src/app/sessions/active-sessions/active-sessions.component.html
@@ -17,9 +17,7 @@
 <mat-card *ngFor="let session of ownSessionService.sessions">
   <div class="type">
     <h2 *ngIf="session.type === 'persistent'">Persistent workspace session</h2>
-    <h2 *ngIf="session.type === 'readonly'">
-      {{ session.repository }} (read-only session)
-    </h2>
+    <h2 *ngIf="session.type === 'readonly'">Read-only session</h2>
   </div>
   <mat-card-content class="sessionContent">
     <h3
@@ -32,6 +30,13 @@
       The session was created
       {{ beautifyService.beatifyDate(session.created_at) }}
     </p>
+    <div *ngIf="session.type === 'readonly'">
+      <span>Project: {{ session.project!.name }}</span
+      ><br />
+      <span>
+        Tool: {{ session.version!.tool.name }} ({{ session.version!.name }})
+      </span>
+    </div>
   </mat-card-content>
   <mat-card-actions class="flex-space-between">
     <button mat-button color="primary" (click)="openDeletionDialog([session])">

--- a/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.html
+++ b/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.html
@@ -9,8 +9,7 @@
   <ul>
     <li *ngFor="let session of sessions">
       ID: {{ session.id }} <br />
-      Owner: {{ session.owner }} <br />
-      {{ session.repository }}
+      Owner: {{ session.owner.name }} <br />
     </li>
   </ul>
   <p>This will force close the sessions and all unsaved work will be lost!</p>

--- a/frontend/src/app/sessions/session-overview/session-overview.component.html
+++ b/frontend/src/app/sessions/session-overview/session-overview.component.html
@@ -26,17 +26,7 @@
 
     <ng-container matColumnDef="user">
       <th mat-header-cell *matHeaderCellDef>Username</th>
-      <td mat-cell *matCellDef="let element">{{ element.owner }}</td>
-    </ng-container>
-
-    <ng-container matColumnDef="repository">
-      <th mat-header-cell *matHeaderCellDef>Repository</th>
-      <td mat-cell *matCellDef="let element">{{ element.repository }}</td>
-    </ng-container>
-
-    <ng-container matColumnDef="ports">
-      <th mat-header-cell *matHeaderCellDef>Ports</th>
-      <td mat-cell *matCellDef="let element">{{ element.ports }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.owner.name }}</td>
     </ng-container>
 
     <ng-container matColumnDef="created_at">
@@ -51,7 +41,7 @@
       </td>
     </ng-container>
 
-    <ng-container matColumnDef="docker_state">
+    <ng-container matColumnDef="state">
       <th mat-header-cell *matHeaderCellDef>State of Container</th>
       <td mat-cell *matCellDef="let element">{{ element.state }}</td>
     </ng-container>
@@ -59,6 +49,20 @@
     <ng-container matColumnDef="last_seen">
       <th mat-header-cell *matHeaderCellDef>Last seen</th>
       <td mat-cell *matCellDef="let element">{{ element.last_seen }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="project">
+      <th mat-header-cell *matHeaderCellDef>Project</th>
+      <td mat-cell *matCellDef="let element">{{ element.project?.name }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="tool">
+      <th mat-header-cell *matHeaderCellDef>Tool</th>
+      <td mat-cell *matCellDef="let element">
+        <div *ngIf="element.type === 'readonly'">
+          {{ element.version?.tool?.name }} ({{ element.version?.name }})
+        </div>
+      </td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/frontend/src/app/sessions/session-overview/session-overview.component.ts
+++ b/frontend/src/app/sessions/session-overview/session-overview.component.ts
@@ -32,12 +32,12 @@ export class SessionOverviewComponent implements OnInit {
     'checkbox',
     'id',
     'user',
-    'repository',
-    'ports',
     'created_at',
-    'docker_state',
+    'state',
     'guacamole_user',
     'last_seen',
+    'project',
+    'tool',
   ];
 
   ngOnInit(): void {

--- a/frontend/src/app/settings/core/tools-settings/tool.service.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool.service.ts
@@ -23,6 +23,8 @@ export type ToolVersion = {
   is_deprecated: boolean;
 };
 
+export type ToolVersionWithTool = ToolVersion & { tool: Tool };
+
 export type PatchToolVersion = {
   isRecommended: boolean;
   isDeprecated: boolean;


### PR DESCRIPTION
Read-only sessions were not displayed properly, with this comment, project and tool information is displayed in the frontend ("Own sessions" and "Overview").