### PR TITLE
Fix login

### DIFF
--- a/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
+++ b/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
@@ -7,7 +7,6 @@ import { Injectable } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
   CanActivate,
-  Router,
   RouterStateSnapshot,
   UrlTree,
 } from '@angular/router';
@@ -18,7 +17,7 @@ import { AuthService } from 'src/app/services/auth/auth.service';
   providedIn: 'root',
 })
 export class AuthGuardService implements CanActivate {
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(private authService: AuthService) {}
 
   canActivate(
     _route: ActivatedRouteSnapshot,
@@ -33,14 +32,8 @@ export class AuthGuardService implements CanActivate {
     } else {
       // Needs window.location, since Router.url isn't updated yet
       this.authService.cacheCurrentPath(window.location.pathname);
-      this.webSSO();
+      this.authService.webSSO();
       return false;
     }
-  }
-
-  webSSO() {
-    this.authService.getRedirectURL().subscribe((res) => {
-      window.location.href = res.auth_url;
-    });
   }
 }

--- a/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
+++ b/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
@@ -31,8 +31,16 @@ export class AuthGuardService implements CanActivate {
     if (this.authService.isLoggedIn()) {
       return true;
     } else {
-      this.router.navigateByUrl('/auth');
+      // Needs window.location, since Router.url isn't updated yet
+      this.authService.cacheCurrentPath(window.location.pathname);
+      this.webSSO();
       return false;
     }
+  }
+
+  webSSO() {
+    this.authService.getRedirectURL().subscribe((res) => {
+      window.location.href = res.auth_url;
+    });
   }
 }

--- a/frontend/src/app/general/auth/auth-redirect/auth-redirect.component.ts
+++ b/frontend/src/app/general/auth/auth-redirect/auth-redirect.component.ts
@@ -42,7 +42,7 @@ export class AuthRedirectComponent implements OnInit {
           this.authService.logIn(res.access_token, res.refresh_token);
           this.userService.updateOwnUser();
 
-          this.router.navigateByUrl('/');
+          this.router.navigateByUrl(this.authService.getCurrentPath());
         });
     });
   }

--- a/frontend/src/app/general/auth/auth/auth.component.ts
+++ b/frontend/src/app/general/auth/auth/auth.component.ts
@@ -18,7 +18,7 @@ export class AuthComponent implements OnInit {
   @Input()
   set autoLogin(value: boolean) {
     if (value) {
-      this.webSSO();
+      this.authService.webSSO();
     }
   }
 
@@ -41,8 +41,6 @@ export class AuthComponent implements OnInit {
   }
 
   webSSO() {
-    this.authService.getRedirectURL().subscribe((res) => {
-      window.location.href = res.auth_url;
-    });
+    this.authService.webSSO();
   }
 }

--- a/frontend/src/app/services/auth/auth.service.ts
+++ b/frontend/src/app/services/auth/auth.service.ts
@@ -82,6 +82,12 @@ export class AuthService {
     return !!this._accessToken;
   }
 
+  webSSO() {
+    this.getRedirectURL().subscribe((res) => {
+      window.location.href = res.auth_url;
+    });
+  }
+
   logIn(accessToken: string, refreshToken: string) {
     this._accessToken = accessToken;
     this._refreshToken = refreshToken;

--- a/frontend/src/app/services/auth/auth.service.ts
+++ b/frontend/src/app/services/auth/auth.service.ts
@@ -108,6 +108,16 @@ export class AuthService {
       .get(environment.backend_url + '/authentication/logout')
       .subscribe();
   }
+
+  cacheCurrentPath(path: String) {
+    this.localStorageService.setValue('current_path', path);
+  }
+
+  getCurrentPath() {
+    let path = this.localStorageService.getValue('current_path');
+    this.cacheCurrentPath('');
+    return path || '/';
+  }
 }
 
 export interface GetRedirectURLResponse {


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

## Current behavior

* When refreshing a page you'll end up on the login page (`/auth`).
* After login you'll end up on the default page ('/').

## New behavior

* When refreshing, you're automatically forwarded to the SSO provider page. This normally results in instant authentication.
* When redirected back, you'll be forwarded to the page you were on before reloading.

Resolves #401

# Testing

Locally, with oauth mock (the mock requires you to provide a new name).

# Checklist

- [x] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I updated the documentation with the new functionality
- [x] I went through the code and removed all print statements, breakpoints and unused code
- [x] Error handling for all possible scenarios has been implemented
- [x] I've add logging for all relevant operations
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
