### PR TITLE
Support postgres URLs with special characters

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -40,7 +40,7 @@ app = FastAPI(title="Capella Collaboration")
 
 @app.on_event("startup")
 async def migrate_database():
-    migration.migrate_db(engine)
+    migration.migrate_db(engine, config["database"]["url"])
 
 
 @app.on_event("startup")

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -34,7 +34,7 @@ from capellacollab.users.models import Role
 LOGGER = logging.getLogger(__name__)
 
 
-def migrate_db(engine):
+def migrate_db(engine, database_url: str):
     if os.getenv("ALEMBIC_CONTEXT") != "1":
         os.environ["ALEMBIC_CONFIGURE_LOGGER"] = "false"
         root_dir = pathlib.Path(__file__).parents[2]
@@ -44,9 +44,7 @@ def migrate_db(engine):
         alembic_cfg.set_main_option(
             "script_location", str(root_dir / "alembic")
         )
-        alembic_cfg.set_main_option(
-            "sqlalchemy.url", config["database"]["url"]
-        )
+        alembic_cfg.set_main_option("sqlalchemy.url", database_url)
         alembic_cfg.attributes["configure_logger"] = False
 
         with engine.connect() as conn:

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -44,7 +44,9 @@ def migrate_db(engine):
         alembic_cfg.set_main_option(
             "script_location", str(root_dir / "alembic")
         )
-        alembic_cfg.set_main_option("sqlalchemy.url", str(engine.url))
+        alembic_cfg.set_main_option(
+            "sqlalchemy.url", config["database"]["url"]
+        )
         alembic_cfg.attributes["configure_logger"] = False
 
         with engine.connect() as conn:

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/interface.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/interface.py
@@ -26,7 +26,10 @@ def create_repository(instance: DatabaseT4CInstance, name: str):
         instance.rest_api + "/repositories",
         json={
             "repositoryName": name,
-            "authenticationType": "",
+            "authenticationType": "FILE",
+            "authenticationData": {
+                "users": [{"login": "admin", "password": generate_password()}]
+            },
             "datasourceType": "H2_EMBEDDED",
         },
         auth=HTTPBasicAuth(instance.username, instance.password),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,7 +34,7 @@ def db(postgresql, monkeypatch) -> Session:
     monkeypatch.setattr(database_, "engine", postgresql)
     monkeypatch.setattr(database_, "SessionLocal", session_local)
 
-    migration.migrate_db(postgresql)
+    migration.migrate_db(postgresql, str(postgresql.url))
 
     with session_local() as session:
         yield session

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -99,10 +99,10 @@ def test_init_database(
     initialized_database, alembic_cfg, alembic_revision: str
 ):
     # Update database to HEAD
-    migration.migrate_db(initialized_database)
+    migration.migrate_db(initialized_database, str(initialized_database.url))
 
     # Downgrade database to alembic_revision
     command.downgrade(alembic_cfg, alembic_revision)
 
     # And migrate to HEAD again
-    migration.migrate_db(initialized_database)
+    migration.migrate_db(initialized_database, str(initialized_database.url))


### PR DESCRIPTION
SQLAlchemy replaces special characters.
They can not be read again via engine.url, because they are escaped.