### PR TITLE
Support Python 3.11

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 name = "capellacollab-backend"
 readme = "README.md"
-requires-python = ">=3.9, <3.11"
+requires-python = ">=3.9, <3.12"
 license = { text = "Apache-2.0" }
 authors = [
   { name = "DB Netz AG" },


### PR DESCRIPTION
# Description

I'm using Python 3.11 by default (Fedora 37). It would be cool if the collab manager would allow that version too.

Resolves #issue

# Checklist

- [x] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I updated the documentation with the new functionality
- [x] I went through the code and removed all print statements, breakpoints and unused code
- [x] Error handling for all possible scenarios has been implemented
- [x] I've add logging for all relevant operations
- [x] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
