### PR TITLE
Hotfix authentication

### DIFF
--- a/backend/capellacollab/settings/modelsources/t4c/repositories/interface.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/interface.py
@@ -26,7 +26,10 @@ def create_repository(instance: DatabaseT4CInstance, name: str):
         instance.rest_api + "/repositories",
         json={
             "repositoryName": name,
-            "authenticationType": "",
+            "authenticationType": "FILE",
+            "authenticationData": {
+                "users": [{"login": "admin", "password": generate_password()}]
+            },
             "datasourceType": "H2_EMBEDDED",
         },
         auth=HTTPBasicAuth(instance.username, instance.password),


### PR DESCRIPTION
TeamForCapella repositories were created without authentication per default. This PR fixes the issue.