### PR TITLE
Introduce project renaming

### DIFF
--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -33,6 +33,7 @@ def update_project(
 ) -> DatabaseProject:
     if patch_project.name:
         project.name = patch_project.name
+        project.slug = slugify(patch_project.name)
     if patch_project.description:
         project.description = patch_project.description
     db.commit()

--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -9,7 +9,7 @@ import typing as t
 from slugify import slugify
 from sqlalchemy.orm import Session
 
-from capellacollab.projects.models import DatabaseProject
+from capellacollab.projects.models import DatabaseProject, PatchProject
 
 
 def get_project_by_name(db: Session, name: str) -> DatabaseProject:
@@ -28,10 +28,13 @@ def get_all_projects(db: Session) -> t.List[DatabaseProject]:
     return db.query(DatabaseProject).all()
 
 
-def update_description(
-    db: Session, project: DatabaseProject, description: str
+def update_project(
+    db: Session, project: DatabaseProject, patch_project: PatchProject
 ) -> DatabaseProject:
-    project.description = description
+    if patch_project.name:
+        project.name = patch_project.name
+    if patch_project.description:
+        project.description = patch_project.description
     db.commit()
     return project
 

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -71,7 +71,8 @@ class Project(BaseModel):
 
 
 class PatchProject(BaseModel):
-    description: str
+    name: t.Optional[str]
+    description: t.Optional[str]
 
 
 class PostProjectRequest(BaseModel):

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -66,12 +66,10 @@ def get_projects(
 )
 def update_project_description(
     patch_project: PatchProject,
-    db_project: DatabaseProject = Depends(get_existing_project),
+    project: DatabaseProject = Depends(get_existing_project),
     database: Session = Depends(get_db),
 ) -> DatabaseProject:
-    return crud.update_description(
-        database, db_project, patch_project.description
-    )
+    return crud.update_project(database, project, patch_project)
 
 
 @router.get(

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -65,12 +65,12 @@ def get_projects(
         Depends(ProjectRoleVerification(required_role=ProjectUserRole.MANAGER))
     ],
 )
-def update_project_description(
+def patch_project(
     patch_project: PatchProject,
     project: DatabaseProject = Depends(get_existing_project),
     database: Session = Depends(get_db),
 ) -> DatabaseProject:
-    new_slug = slugify(project.name)
+    new_slug = slugify(patch_project.name)
     if (
         crud.get_project_by_slug(database, new_slug)
         and project.slug != new_slug

--- a/frontend/src/app/projects/create-project/create-project.component.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.ts
@@ -99,6 +99,7 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
       return null;
     };
   }
+
   getColorByModelCreationStep(): string {
     switch (this.modelCreationStep) {
       case 'create-model':

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
@@ -11,6 +11,17 @@
         <mat-form-field appearance="fill">
           <mat-label>Name</mat-label>
           <input matInput formControlName="name" />
+          <mat-error *ngIf="form.controls.name.errors?.required"
+            >The project name is required.</mat-error
+          >
+          <mat-error *ngIf="form.controls.name.errors?.uniqueSlug"
+            >A project with a similar name already exists.</mat-error
+          >
+          <mat-hint *ngIf="project.slug !== newSlug && form.controls.name.valid"
+            >If you proceed, the project slug will be changed to
+            <i>{{ newSlug }}</i> - Please make sure to update all
+            references.</mat-hint
+          >
         </mat-form-field>
       </fieldset>
       <fieldset>
@@ -28,7 +39,12 @@
         </mat-form-field>
       </fieldset>
     </form>
-    <button (click)="updateDescription()" mat-raised-button id="submit">
+    <button
+      [disabled]="!form.valid"
+      (click)="updateDescription()"
+      mat-raised-button
+      id="submit"
+    >
       Submit
     </button>
   </mat-card>

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
@@ -6,19 +6,27 @@
 <div class="wrapper">
   <h2 id="title">Metadata</h2>
   <mat-card>
-    <form>
-      <mat-form-field class="example-full-width" appearance="fill">
-        <mat-label>Description</mat-label>
-        <textarea
-          [formControl]="updateDescriptionForm"
-          matInput
-          rows="3"
-          style="resize: none"
-          [placeholder]="
-            'This is the description of the project ' + project!.slug
-          "
-        ></textarea>
-      </mat-form-field>
+    <form [formGroup]="form">
+      <fieldset>
+        <mat-form-field appearance="fill">
+          <mat-label>Name</mat-label>
+          <input matInput formControlName="name" />
+        </mat-form-field>
+      </fieldset>
+      <fieldset>
+        <mat-form-field appearance="fill">
+          <mat-label>Description</mat-label>
+          <textarea
+            formControlName="description"
+            matInput
+            rows="3"
+            style="resize: none"
+            [placeholder]="
+              'This is the description of the project ' + project!.name
+            "
+          ></textarea>
+        </mat-form-field>
+      </fieldset>
     </form>
     <button (click)="updateDescription()" mat-raised-button id="submit">
       Submit

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
@@ -19,6 +19,7 @@ import {
   ValidatorFn,
   Validators,
 } from '@angular/forms';
+import { Router } from '@angular/router';
 import slugify from 'slugify';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
 import {
@@ -46,7 +47,8 @@ export class ProjectMetadataComponent implements OnChanges {
 
   constructor(
     private toastService: ToastService,
-    private projectService: ProjectService
+    private projectService: ProjectService,
+    private router: Router
   ) {}
 
   ngOnChanges(_changes: SimpleChanges): void {
@@ -60,9 +62,12 @@ export class ProjectMetadataComponent implements OnChanges {
         .updateProject(this.project.slug, this.form.value as PatchProject)
         .subscribe((project) => {
           this.projectService._project.next(project);
+          this.router.navigateByUrl(`/project/${project.slug}`);
           this.toastService.showSuccess(
             'Project updated',
-            `Updated to ${project.name}: ${project.description}`
+            `The new name is: '${project.name}' and the new description is '${
+              project.description || ''
+            }'`
           );
         });
     }

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
@@ -11,9 +11,10 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
 import {
+  PatchProject,
   Project,
   ProjectService,
 } from 'src/app/services/project/project.service';
@@ -27,7 +28,10 @@ export class ProjectMetadataComponent implements OnChanges {
   @Input() project!: Project;
   @Output() changeProject = new EventEmitter<Project>();
 
-  public updateDescriptionForm = new FormControl();
+  public form = new FormGroup({
+    name: new FormControl<string>('', Validators.required),
+    description: new FormControl<string>('', Validators.required),
+  });
 
   constructor(
     private toastService: ToastService,
@@ -35,13 +39,13 @@ export class ProjectMetadataComponent implements OnChanges {
   ) {}
 
   ngOnChanges(_changes: SimpleChanges): void {
-    this.updateDescriptionForm.patchValue(this.project.description);
+    this.form.patchValue(this.project);
   }
 
   updateDescription() {
-    if (this.updateDescriptionForm.valid) {
+    if (this.form.valid) {
       this.projectService
-        .updateDescription(this.project.slug, this.updateDescriptionForm.value)
+        .updateProject(this.project.slug, this.form.value as PatchProject)
         .subscribe((project) => {
           this.projectService._project.next(project);
           this.toastService.showSuccess(

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
@@ -49,8 +49,8 @@ export class ProjectMetadataComponent implements OnChanges {
         .subscribe((project) => {
           this.projectService._project.next(project);
           this.toastService.showSuccess(
-            'Description updated for project ' + this.project.name,
-            "Updated to '" + project.description + "'"
+            'Project updated',
+            `Updated to ${project.name}: ${project.description}`
           );
         });
     }

--- a/frontend/src/app/services/project/project.service.spec.ts
+++ b/frontend/src/app/services/project/project.service.spec.ts
@@ -11,7 +11,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 
 import { environment } from 'src/environments/environment';
-import { ProjectService, Project } from './project.service';
+import { ProjectService, Project, PatchProject } from './project.service';
 
 const BACKEND_PROJECTS_URL = environment.backend_url + '/projects/';
 
@@ -110,13 +110,16 @@ describe('ProjectService', () => {
 
   it('should update the project description', () => {
     const updatedMockProjectDescription = 'update-test-project-description';
-    let updatedMockProject: Project = mockProject;
+    const updatedMockProjectName = 'update-test-project-name';
+    let updatedMockProject: PatchProject = mockProject;
     updatedMockProject.description = updatedMockProjectDescription;
+    updatedMockProject.name = updatedMockProjectName;
 
     projectService
-      .updateProject(testProjectSlug, updatedMockProjectDescription)
+      .updateProject(testProjectSlug, updatedMockProject)
       .subscribe({
-        next: (project) => expect(project).toEqual(updatedMockProject),
+        next: (project) =>
+          expect(project as PatchProject).toEqual(updatedMockProject),
       });
 
     const req = httpTestingController.expectOne(

--- a/frontend/src/app/services/project/project.service.spec.ts
+++ b/frontend/src/app/services/project/project.service.spec.ts
@@ -114,7 +114,7 @@ describe('ProjectService', () => {
     updatedMockProject.description = updatedMockProjectDescription;
 
     projectService
-      .updateDescription(testProjectSlug, updatedMockProjectDescription)
+      .updateProject(testProjectSlug, updatedMockProjectDescription)
       .subscribe({
         next: (project) => expect(project).toEqual(updatedMockProject),
       });

--- a/frontend/src/app/services/project/project.service.spec.ts
+++ b/frontend/src/app/services/project/project.service.spec.ts
@@ -108,19 +108,22 @@ describe('ProjectService', () => {
     req.flush(mockProject);
   });
 
-  it('should update the project description', () => {
+  it('should update the project', () => {
     const updatedMockProjectDescription = 'update-test-project-description';
     const updatedMockProjectName = 'update-test-project-name';
-    let updatedMockProject: PatchProject = mockProject;
+    let updatedMockProject: Project = mockProject;
+
+    let patchMockProject: PatchProject = {
+      name: updatedMockProjectName,
+      description: updatedMockProjectDescription,
+    };
     updatedMockProject.description = updatedMockProjectDescription;
     updatedMockProject.name = updatedMockProjectName;
 
-    projectService
-      .updateProject(testProjectSlug, updatedMockProject)
-      .subscribe({
-        next: (project) =>
-          expect(project as PatchProject).toEqual(updatedMockProject),
-      });
+    projectService.updateProject(testProjectSlug, patchMockProject).subscribe({
+      next: (project) =>
+        expect(project as PatchProject).toEqual(updatedMockProject),
+    });
 
     const req = httpTestingController.expectOne(
       BACKEND_PROJECTS_URL + testProjectSlug
@@ -128,6 +131,7 @@ describe('ProjectService', () => {
     expect(req.request.method).toEqual('PATCH');
     expect(req.request.body).toEqual({
       description: updatedMockProjectDescription,
+      name: updatedMockProjectName,
     });
   });
 

--- a/frontend/src/app/services/project/project.service.ts
+++ b/frontend/src/app/services/project/project.service.ts
@@ -41,20 +41,15 @@ export class ProjectService {
     return this.http.get<Project>(this.base_url + name);
   }
 
-  updateDescription(
+  updateProject(
     project_slug: string,
-    description: string
+    project: PatchProject
   ): Observable<Project> {
-    return this.http.patch<Project>(this.base_url + project_slug, {
-      description,
-    });
+    return this.http.patch<Project>(this.base_url + project_slug, project);
   }
 
   createProject(
-    project: {
-      name: string;
-      description: string;
-    },
+    project: Required<PatchProject>,
     update?: boolean
   ): Observable<Project> {
     let observable = this.http.post<Project>(this.base_url, project);
@@ -74,18 +69,18 @@ export class ProjectService {
   }
 }
 
-export interface UserMetadata {
+export type UserMetadata = {
   leads: number;
   contributors: number;
   subscribers: number;
-}
+};
 
-export interface Project {
-  name: string;
+export type PatchProject = {
+  name?: string;
+  description?: string;
+};
+
+export type Project = Required<PatchProject> & {
   slug: string;
-  description: string;
   users: UserMetadata;
-}
-
-export type EditingMode = 't4c' | 'git';
-export type ProjectType = 'project' | 'library';
+};


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

Projects can now be renamed. The slug stays unchanged.

- [x] Validation on the front-end
- [x] Validation on the back-end
- [x] Update toaster

Resolves #396