### PR TITLE
Terminate unused sessions

### DIFF
--- a/backend/capellacollab/sessions/idletimeout.py
+++ b/backend/capellacollab/sessions/idletimeout.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+
+import requests
+
+from capellacollab.config import config
+from capellacollab.core.database import SessionLocal
+from capellacollab.sessions import database
+from capellacollab.sessions.operators import OPERATOR
+
+log = logging.getLogger(__name__)
+
+
+def terminate_idle_session():
+    url = config["prometheus"]["url"]
+    url += "/".join(("api", "v1", 'query?query=ALERTS{alertstate="firing"}'))
+    response = requests.get(
+        url,
+        timeout=config["requests"]["timeout"],
+    )
+    log.info("Requested alerts %d", response.status_code)
+    for metric in response.json()["data"]["result"]:
+        if session_id := metric.get("metric", {}).get("app"):
+            log.info("Terminating idle session %s", session_id)
+            OPERATOR.kill_session(session_id)
+            with SessionLocal() as db:
+                if session := database.get_session_by_id(db, session_id):
+                    database.delete_session(db, session)
+
+
+def run():
+    logging.basicConfig(level=config["logging"]["level"])
+    terminate_idle_session()
+
+
+if __name__ == "__main__":
+    run()

--- a/helm/templates/backend/backend.batch.yaml
+++ b/helm/templates/backend/backend.batch.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-backend-idle-sessions
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: config
+              configMap:
+                name: {{ .Release.Name }}-backend
+          containers:
+            - name: {{ .Release.Name }}-backend-idle-sessions
+              image:  {{ .Values.docker.registry.internal }}{{ .Values.docker.images.backend }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - python3
+                - -m
+                - capellacollab.sessions.idletimeout
+              resources:
+                limits:
+                  cpu: "0.2"
+                  memory: 50Mi
+                requests:
+                  cpu: "0.05"
+                  memory: 20Mi
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/capellacollab
+                  readOnly: true
+          restartPolicy: OnFailure

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -13,11 +13,16 @@ data:
     groups:
       - name: Inactivity
         rules:
-          - alert: Inactivity (10m)
+          - alert: Inactivity session
             expr: idletime_minutes > 60
             for: 1m
             annotations:
               summary: High Idletime
+          - alert: Unused session
+            expr: idletime_minutes < 0
+            for: 60m
+            annotations:
+              summary: Unused session
 
   prometheus.yml: |-
     global:

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -21,8 +21,8 @@ data:
 
   prometheus.yml: |-
     global:
-      scrape_interval: 5s
-      evaluation_interval: 5s
+      scrape_interval: 30s
+      evaluation_interval: 30s
     rule_files:
       - /etc/prometheus/prometheus.rules
 

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -14,13 +14,13 @@ data:
       - name: Inactivity
         rules:
           - alert: Inactivity session
-            expr: idletime_minutes > 60
+            expr: idletime_minutes > {{ .Values.sessions.timeout }}
             for: 1m
             annotations:
               summary: High Idletime
           - alert: Unused session
             expr: idletime_minutes < 0
-            for: 60m
+            for: {{ .Values.sessions.timeout }}m
             annotations:
               summary: Unused session
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,7 +45,7 @@ general:
 
 sessions:
   # Session timeout in minutes for unused and idle sessions
-  timeout: 5
+  timeout: 90
 
 database:
   # Database Configuration for Guacamole

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -43,6 +43,10 @@ general:
   port: 80
   scheme: http
 
+sessions:
+  # Session timeout in minutes for unused and idle sessions
+  timeout: 5
+
 database:
   # Database Configuration for Guacamole
   guacamole:


### PR DESCRIPTION
# Description

Terminate idle sessions from the cluster.

In the end I went with a cronjob.batch definition in Kubernetes. A sleep-based timed job in the backend itself did cause unexpected crashes. This job runs safely outside the context of the backend web service.

Resolves #76 

# Testing

Live tested.


# Checklist

- [ ] My code follows the guidelines of this project: [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I updated the documentation with the new functionality
- [ ] I went through the code and removed all print statements, breakpoints and unused code
- [ ] Error handling for all possible scenarios has been implemented
- [ ] I've add logging for all relevant operations
- [ ] I added the appropriate labels to this PR (enhancement/bug/documentation, effort, priority)
