### PR TITLE
Fix backend dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update && \
     python3-pip \
     unzip \
     libpq-dev \
-    docker.io \
-    kubernetes-client && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8000
 COPY . /tmp/backend


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

This PR removes the *kubernetes-client* and *docker.io* from the installed packages because they are not needed and the *kubernetes-client* produced errors when creating the images.
