### PR TITLE
Stopping the session loop when exited

### DIFF
--- a/backend/capellacollab/sessions/idletimeout.py
+++ b/backend/capellacollab/sessions/idletimeout.py
@@ -45,6 +45,7 @@ async def terminate_idle_sessions_in_background(interval=60):
                 await run_in_threadpool(terminate_idle_session)
             except BaseException:
                 log.exception("Could not handle idle sessions")
+                return
 
     asyncio.ensure_future(loop())
 

--- a/backend/capellacollab/sessions/idletimeout.py
+++ b/backend/capellacollab/sessions/idletimeout.py
@@ -43,9 +43,10 @@ async def terminate_idle_sessions_in_background(interval=60):
             try:
                 await asyncio.sleep(interval)
                 await run_in_threadpool(terminate_idle_session)
+            except asyncio.exceptions.CancelledError:
+                return
             except BaseException:
                 log.exception("Could not handle idle sessions")
-                return
 
     asyncio.ensure_future(loop())
 


### PR DESCRIPTION
<!--
 ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 ~ SPDX-License-Identifier: Apache-2.0
 -->

# Description

This PR fixes the problem that you can't exit the Backed with `CTRL + C`.
