### PR TITLE
Fix loading of git and t4c models

### DIFF
--- a/backend/capellacollab/settings/modelsources/t4c/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/routes.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from capellacollab.core.authentication.database import (
-    RoleVerification,
-    verify_admin,
-)
-from capellacollab.core.authentication.jwt_bearer import JWTBearer
+from capellacollab.core.authentication.database import RoleVerification
 from capellacollab.core.database import get_db
 from capellacollab.projects.toolmodels.routes import get_version_by_id_or_raise
 from capellacollab.sessions.schema import GetSessionUsageResponse
@@ -21,14 +17,12 @@ from capellacollab.settings.modelsources.t4c.interface import get_t4c_status
 from capellacollab.settings.modelsources.t4c.models import (
     CreateT4CInstance,
     DatabaseT4CInstance,
-    FieldsT4CInstance,
     PatchT4CInstance,
     T4CInstance,
 )
 from capellacollab.settings.modelsources.t4c.repositories.routes import (
     router as repositories_router,
 )
-from capellacollab.tools import crud as tools_crud
 from capellacollab.users.models import Role
 
 router = APIRouter(
@@ -36,7 +30,7 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=list[T4CInstance])
+@router.get("", response_model=list[T4CInstance])
 def list_t4c_settings(
     db: Session = Depends(get_db),
 ) -> list[DatabaseT4CInstance]:

--- a/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-loader/mat-card-overview-loader.component.ts
+++ b/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-loader/mat-card-overview-loader.component.ts
@@ -14,6 +14,8 @@ export class MatCardOverviewLoaderComponent implements OnInit {
   @Input() loading = true;
   @Input() reservedCards = 1;
 
+  @Input() rows: number | undefined = undefined;
+
   _cardNumbersArray: number[] = [];
   set cardsNumber(value: number) {
     this._cardNumbersArray = [...Array(value).keys()];
@@ -33,8 +35,14 @@ export class MatCardOverviewLoaderComponent implements OnInit {
   resize(width: number, height: number) {
     // Margin is 1vw (left + right) and 1vh (top + bottom)
 
-    const cardsPerColumn = (0.98 * width) / 425;
-    const cardsPerRow = (0.98 * height - 120) / 275;
+    let cardsPerColumn = 0;
+    if (this.rows) {
+      cardsPerColumn = this.rows;
+    } else {
+      cardsPerColumn = (0.98 * height - 120) / 275;
+    }
+
+    const cardsPerRow = (0.98 * width) / 425;
 
     this.cardsNumber =
       Math.trunc(cardsPerColumn) * Math.trunc(cardsPerRow) - this.reservedCards;

--- a/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-loader/mat-card-overview-loader.component.ts
+++ b/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-loader/mat-card-overview-loader.component.ts
@@ -35,13 +35,7 @@ export class MatCardOverviewLoaderComponent implements OnInit {
   resize(width: number, height: number) {
     // Margin is 1vw (left + right) and 1vh (top + bottom)
 
-    let cardsPerColumn = 0;
-    if (this.rows) {
-      cardsPerColumn = this.rows;
-    } else {
-      cardsPerColumn = (0.98 * height - 120) / 275;
-    }
-
+    const cardsPerColumn = this.rows ? this.rows : (0.98 * height - 120) / 275;
     const cardsPerRow = (0.98 * width) / 425;
 
     this.cardsNumber =

--- a/frontend/src/app/projects/models/add-git-source/add-git-source.component.ts
+++ b/frontend/src/app/projects/models/add-git-source/add-git-source.component.ts
@@ -155,10 +155,10 @@ export class AddGitSourceComponent implements OnInit, OnDestroy {
         this.gitModelSubscription = this.gitModelService.gitModel.subscribe(
           (gitModel) => {
             this.gitModel = gitModel;
-            this.fillFormWithGitModel(gitModel);
+            this.fillFormWithGitModel(gitModel!);
 
             this.gitService.loadPrivateRevisions(
-              gitModel.path,
+              gitModel!.path,
               this.projectService.project?.slug!,
               this.modelService.model?.slug!,
               gitModelId

--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.ts
@@ -90,7 +90,7 @@ export class CreateBackupComponent {
   t4cModelAndGitModelExists(): boolean {
     return !!(
       this.t4cModelService.t4cModels?.length &&
-      this.gitModelService?._gitModels.value.length
+      this.gitModelService._gitModels.value?.length
     );
   }
 }

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.css
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.css
@@ -18,3 +18,7 @@ title {
 .visually-disabled {
   background-color: grey !important;
 }
+
+app-mat-card-overview-loader {
+  display: contents;
+}

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.html
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.html
@@ -25,6 +25,11 @@
         </div>
       </div>
     </mat-card>
+    <app-mat-card-overview-loader
+      [rows]="1"
+      [reservedCards]="2"
+      [loading]="gitModels === undefined"
+    ></app-mat-card-overview-loader>
     <a
       *ngFor="let gitModel of gitModels"
       [routerLink]="['git-model', gitModel.id]"
@@ -76,5 +81,10 @@
         </div>
       </mat-card>
     </a>
+    <app-mat-card-overview-loader
+      [rows]="1"
+      [reservedCards]="2"
+      [loading]="t4cModels === undefined"
+    ></app-mat-card-overview-loader>
   </div>
 </div>

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.ts
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.ts
@@ -4,7 +4,7 @@
  */
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { BehaviorSubject, filter, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import {
   GetGitModel,
   GitModelService,
@@ -22,9 +22,8 @@ import { ProjectService } from 'src/app/services/project/project.service';
   styleUrls: ['./model-detail.component.css'],
 })
 export class ModelDetailComponent implements OnInit, OnDestroy {
-  public gitModels: Array<GetGitModel> = [];
-  private _t4cModels = new BehaviorSubject<T4CModel[] | undefined>(undefined);
-  public t4cModels: T4CModel[] = [];
+  public gitModels: Array<GetGitModel> | undefined = undefined;
+  public t4cModels: T4CModel[] | undefined = undefined;
 
   private gitModelsSubscription?: Subscription;
   private t4cModelsSubscription?: Subscription;
@@ -41,17 +40,13 @@ export class ModelDetailComponent implements OnInit, OnDestroy {
       (gitModels) => (this.gitModels = gitModels)
     );
 
-    this._t4cModels.pipe(filter(Boolean)).subscribe((models) => {
-      this.t4cModels = models;
-    });
-
     this.t4cModelsSubscription = this.t4cModelService
       .listT4CModels(
         this.projectService.project!.slug,
         this.modelService.model!.slug
       )
       .subscribe((models) => {
-        this._t4cModels.next(models);
+        this.t4cModels = models;
       });
 
     this.gitModelService.loadGitModels(
@@ -62,5 +57,8 @@ export class ModelDetailComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.gitModelsSubscription?.unsubscribe();
+    this.gitModelService.clear();
+    this.t4cModelsSubscription?.unsubscribe();
+    this.t4cModelService.clear();
   }
 }

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.ts
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.ts
@@ -22,8 +22,8 @@ import { ProjectService } from 'src/app/services/project/project.service';
   styleUrls: ['./model-detail.component.css'],
 })
 export class ModelDetailComponent implements OnInit, OnDestroy {
-  public gitModels: Array<GetGitModel> | undefined = undefined;
-  public t4cModels: T4CModel[] | undefined = undefined;
+  public gitModels?: GetGitModel[] = undefined;
+  public t4cModels?: T4CModel[] = undefined;
 
   private gitModelsSubscription?: Subscription;
   private t4cModelsSubscription?: Subscription;
@@ -45,9 +45,7 @@ export class ModelDetailComponent implements OnInit, OnDestroy {
         this.projectService.project!.slug,
         this.modelService.model!.slug
       )
-      .subscribe((models) => {
-        this.t4cModels = models;
-      });
+      .subscribe((models) => (this.t4cModels = models));
 
     this.gitModelService.loadGitModels(
       this.projectService.project!.slug,

--- a/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
@@ -16,8 +16,10 @@ export class GitModelService {
 
   constructor(private http: HttpClient) {}
 
-  private _gitModel = new Subject<GetGitModel>();
-  public _gitModels = new BehaviorSubject<Array<GetGitModel>>([]);
+  private _gitModel = new Subject<GetGitModel | undefined>();
+  public _gitModels = new BehaviorSubject<Array<GetGitModel> | undefined>(
+    undefined
+  );
 
   readonly gitModel = this._gitModel.asObservable();
   readonly gitModels = this._gitModels.asObservable();
@@ -105,6 +107,11 @@ export class GitModelService {
         `/projects/${project_slug}/models/${model_slug}/modelsources/git/validate/path`,
       path
     );
+  }
+
+  clear() {
+    this._gitModels.next(undefined);
+    this._gitModel.next(undefined);
   }
 }
 

--- a/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
@@ -17,9 +17,7 @@ export class GitModelService {
   constructor(private http: HttpClient) {}
 
   private _gitModel = new Subject<GetGitModel | undefined>();
-  public _gitModels = new BehaviorSubject<Array<GetGitModel> | undefined>(
-    undefined
-  );
+  public _gitModels = new BehaviorSubject<GetGitModel[] | undefined>(undefined);
 
   readonly gitModel = this._gitModel.asObservable();
   readonly gitModels = this._gitModels.asObservable();

--- a/frontend/src/app/services/modelsources/t4c-model/t4c-model.service.ts
+++ b/frontend/src/app/services/modelsources/t4c-model/t4c-model.service.ts
@@ -82,6 +82,11 @@ export class T4CModelService {
       body
     );
   }
+
+  clear() {
+    this._t4cModels.next(undefined);
+    this._t4cModel.next(undefined);
+  }
 }
 
 export type SubmitT4CModel = {

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -41,14 +41,14 @@ export type T4CInstance = NewT4CInstance & {
 export class T4CInstanceService {
   constructor(private http: HttpClient) {}
 
-  base_url = `${environment.backend_url}/settings/modelsources/t4c/`;
+  base_url = `${environment.backend_url}/settings/modelsources/t4c`;
 
   listInstances(): Observable<T4CInstance[]> {
     return this.http.get<T4CInstance[]>(this.base_url);
   }
 
   getInstance(id: number): Observable<T4CInstance> {
-    return this.http.get<T4CInstance>(this.base_url + id);
+    return this.http.get<T4CInstance>(this.base_url + '/' + id);
   }
 
   createInstance(instance: NewT4CInstance): Observable<T4CInstance> {
@@ -59,12 +59,12 @@ export class T4CInstanceService {
     id: number,
     instance: BaseT4CInstance
   ): Observable<T4CInstance> {
-    return this.http.patch<T4CInstance>(this.base_url + id, instance);
+    return this.http.patch<T4CInstance>(this.base_url + '/' + id, instance);
   }
 
   getLicenses(t4cInstanceId: number): Observable<SessionUsage> {
     return this.http.get<SessionUsage>(
-      `${this.base_url}${t4cInstanceId}/licenses`
+      `${this.base_url}/${t4cInstanceId}/licenses`
     );
   }
 }


### PR DESCRIPTION
In the Git and T4C model overview, the loading of models is not done properly. The Git models and T4C models are only reset when there is a new update from the backend. When switching between the view fast enough, you can see Git and T4C models from other tool models. This PR fixes this behaviour and adds the skeleton loader.