### PR TITLE
Allow deletion of t4c models from the frontend

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/crud.py
+++ b/backend/capellacollab/projects/toolmodels/backups/crud.py
@@ -9,6 +9,9 @@ from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
 from capellacollab.projects.toolmodels.modelsources.git.models import (
     DatabaseGitModel,
 )
+from capellacollab.projects.toolmodels.modelsources.t4c import (
+    models as t4c_models,
+)
 
 from .models import DatabaseBackup
 
@@ -38,6 +41,20 @@ def get_pipelines_for_git_model(
         db.execute(
             select(DatabaseBackup).where(
                 DatabaseBackup.git_model_id == model.id
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def get_pipelines_for_t4c_model(
+    db: Session, t4c_model: t4c_models.DatabaseT4CModel
+) -> list[DatabaseBackup]:
+    return (
+        db.execute(
+            select(DatabaseBackup).where(
+                DatabaseBackup.t4c_model_id == t4c_model.id
             )
         )
         .scalars()

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
@@ -95,9 +95,6 @@ def update_git_model(
     return db_model
 
 
-def delete_git_model(
-    db: Session,
-    git_model: DatabaseGitModel,
-) -> DatabaseGitModel:
+def delete_git_model(db: Session, git_model: DatabaseGitModel):
     db.delete(git_model)
     db.commit()

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/crud.py
@@ -84,3 +84,8 @@ def set_repository_for_t4c_model(
 ):
     t4c_model.repository = t4c_repository
     db.commit()
+
+
+def delete_t4c_model(db: Session, t4c_model: DatabaseT4CModel):
+    db.delete(t4c_model)
+    db.commit()

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
@@ -72,7 +72,7 @@
           Choose primary source
         </button>
         <button
-          *ngIf="!asStepper"
+          *ngIf="editing"
           (click)="unlinkT4CModel()"
           mat-flat-button
           color="warn"

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
@@ -71,6 +71,15 @@
           <mat-icon class="mat-icon-position">arrow_back</mat-icon>
           Choose primary source
         </button>
+        <button
+          *ngIf="!asStepper"
+          (click)="unlinkT4CModel()"
+          mat-flat-button
+          color="warn"
+          type="button"
+        >
+          Unlink
+        </button>
         <app-button-skeleton-loader
           *ngIf="loading"
         ></app-button-skeleton-loader>

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.ts
@@ -182,4 +182,35 @@ export class ManageT4CModelComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.t4cModelService._t4cModel.next(undefined);
   }
+
+  unlinkT4CModel() {
+    if (!window.confirm(`Do you really want to unlink this T4C model?`)) {
+      return;
+    }
+
+    this.t4cModelService
+      .deleteT4CModel(
+        this.projectService.project?.slug!,
+        this.modelService.model?.slug!,
+        this.t4cModel!.id
+      )
+      .subscribe({
+        next: () => {
+          this.toastService.showSuccess(
+            'T4C model deleted',
+            `${this.t4cModel!.name} has been deleted`
+          );
+          this.router.navigateByUrl(
+            `/project/${this.projectService.project?.slug!}/model/${this
+              .modelService.model?.slug!}`
+          );
+        },
+        error: () => {
+          this.toastService.showError(
+            'T4C model deletion failed',
+            `${this.t4cModel!.name} has not been deleted`
+          );
+        },
+      });
+  }
 }

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.ts
@@ -189,7 +189,7 @@ export class ManageT4CModelComponent implements OnInit, OnDestroy {
     }
 
     this.t4cModelService
-      .deleteT4CModel(
+      .unlinkT4CModel(
         this.projectService.project?.slug!,
         this.modelService.model?.slug!,
         this.t4cModel!.id

--- a/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
@@ -76,7 +76,7 @@ export class T4CModelService {
     );
   }
 
-  deleteT4CModel(
+  unlinkT4CModel(
     project_slug: string,
     model_slug: string,
     t4c_model_id: number

--- a/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
@@ -76,6 +76,16 @@ export class T4CModelService {
     );
   }
 
+  deleteT4CModel(
+    project_slug: string,
+    model_slug: string,
+    t4c_model_id: number
+  ): Observable<void> {
+    return this.http.delete<void>(
+      `${this.urlFactory(project_slug, model_slug)}/${t4c_model_id}`
+    );
+  }
+
   clear() {
     this._t4cModels.next(undefined);
     this._t4cModel.next(undefined);

--- a/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
@@ -77,12 +77,12 @@ export class T4CModelService {
   }
 
   unlinkT4CModel(
-    project_slug: string,
-    model_slug: string,
-    t4c_model_id: number
+    projectSlug: string,
+    modelSlug: string,
+    t4cModelId: number
   ): Observable<void> {
     return this.http.delete<void>(
-      `${this.urlFactory(project_slug, model_slug)}/${t4c_model_id}`
+      `${this.urlFactory(projectSlug, modelSlug)}/${t4cModelId}`
     );
   }
 


### PR DESCRIPTION
Add a "Unlink" button to remove a T4C model.

There is already a backend route to _delete_ a t4c model. I left that untouched.

I could not test this completely, since I have no running T4C server.