### PR TITLE
Add connection type for backup containers

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -34,4 +34,5 @@ def get_environment(
         "T4C_PASSWORD": t4c_password,
         "LOG_LEVEL": "INFO",
         "INCLUDE_COMMIT_HISTORY": json.dumps(include_commit_history),
+        "CONNECTION_TYPE": "telnet",
     }


### PR DESCRIPTION
This PR fixes the problem that for capella 6.0.0 our backups stopped working. This is done by statically setting the backup connection type to `telnet` and setting `ENABLED_CDO` to `true` for the t4c server. In a follow-up PR, we should change the connection type to `http` for capella 6.x.x, since `telnet` is deprecated (as described in #485).

This PR must first be merged with https://github.com/DSD-DBS/capella-dockerimages/pull/82 and the `ENABLED_CDO` flag for the t4c server must be set to `true`.