### PR TITLE
Remove infinite loop during authentication

### DIFF
--- a/backend/capellacollab/core/authentication/provider/oauth/flow.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/flow.py
@@ -55,7 +55,7 @@ def refresh_token(refresh_token: str) -> t.Dict[str, t.Any]:
         raise fastapi.HTTPException(
             status_code=401,
             detail={
-                "err_code": "token_exp",
+                "err_code": "REQUEST_TOKEN_EXPIRED",
                 "reason": "The Signature of the refresh token is expired. Please request a new access token.",
             },
         )


### PR DESCRIPTION
When the access token is expired, the client sends a request to the backend to renew it with the renew token. However, if the renew token is expired as well, the backend sends an unauthenticated response. That has changed, before it was an internal server error. The frontend reacts to the "Unauthenticated" by sending a request to renew the access token again... Which leads to an infinite loop and our users are basically spamming the backend with requests.