### PR TITLE
Add automatic login for grafana

### DIFF
--- a/helm/config/nginx-grafana.conf
+++ b/helm/config/nginx-grafana.conf
@@ -26,6 +26,7 @@ http {
             auth_request /auth;
             rewrite  ^/grafana/(.*)  /$1 break;
             proxy_set_header Host $http_host;
+            proxy_set_header X-WEBAUTH-USER "admin";
             proxy_pass http://{{ .Release.Name }}-grafana-server:3118;
         }
 

--- a/helm/templates/grafana/grafana.configmap.yaml
+++ b/helm/templates/grafana/grafana.configmap.yaml
@@ -27,6 +27,12 @@ data:
     [server]
     root_url = http://localhost:8080/grafana/
     serve_from_sub_path = true
+
+    [auth.proxy]
+    enabled = true
+    header_name = X-WEBAUTH-USER
+    header_property = username
+    auto_sign_up = false
   datasources.yaml: |
     apiVersion: 1
     datasources:


### PR DESCRIPTION
This eliminates the need to enter login credentials for Grafana, since we already use an authenticated proxy

Resolves #505 