### PR TITLE
Helm version update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ certs/*
 .vscode
 /backend/log/*
 /helm/charts/*
-/helm/Chart.lock

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To deploy the application you need:
 
 - [Docker](https://docs.docker.com/engine/install/ubuntu/) >= 20.10.X
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) >= 1.24 (Stargazer)
-- [helm](https://helm.sh/docs/intro/install/) >= 3.X.X
+- [helm](https://helm.sh/docs/intro/install/) >= 3.9.X
 - [Make](https://www.gnu.org/software/make/manual/make.html) >= 3.82, recommended 4.X
 
 If you'd like to run it locally, these tools are additionally required:

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: loki
+  repository: https://grafana.github.io/helm-charts/
+  version: 3.3.4
+digest: sha256:18021c601af9a504193e3fc344b41ace9e6d292b5719d4b4e051aad0cc01738f
+generated: "2023-01-12T15:10:10.598705288+01:00"

--- a/helm/Chart.lock.license
+++ b/helm/Chart.lock.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
With Helm 3.5 it's not possible to deploy the Collab Manager helm chart, since we now have a dependency on the Loki chart from Bitnami.

* Updated minimal required version to 3.9.x
* Check in the `Chart.lock` file, so we know which version we're deploying