### PR TITLE
Fix Guacamole authentication issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,8 @@ provision-guacamole:
 	@kubectl wait --for=condition=Ready pods --timeout=$(TIMEOUT) --context k3d-$(CLUSTER_NAME) -n $(NAMESPACE) -l id=$(RELEASE)-deployment-guacamole-guacamole
 	@kubectl wait --for=condition=Ready pods --timeout=$(TIMEOUT) --context k3d-$(CLUSTER_NAME) -n $(NAMESPACE) -l id=$(RELEASE)-deployment-guacamole-postgres
 	@kill %%
-	@kubectl exec --context k3d-$(CLUSTER_NAME) --namespace $(NAMESPACE) --container $(RELEASE)-guacamole-guacamole $$(kubectl get pod --namespace $(NAMESPACE) -l id=$(RELEASE)-deployment-guacamole-guacamole --no-headers | cut -f1 -d' ') -- /opt/guacamole/bin/initdb.sh --postgres | \
-	kubectl exec -i --context k3d-$(CLUSTER_NAME) --namespace $(NAMESPACE) $$(kubectl get pod --namespace $(NAMESPACE) -l id=$(RELEASE)-deployment-guacamole-postgres --no-headers | cut -f1 -d' ') -- psql -U guacamole guacamole
+	@kubectl exec --context k3d-$(CLUSTER_NAME) --namespace $(NAMESPACE) --container $(RELEASE)-guacamole-guacamole deployment/$(RELEASE)-guacamole-guacamole -- /opt/guacamole/bin/initdb.sh --postgres | \
+	kubectl exec -i --context k3d-$(CLUSTER_NAME) --namespace $(NAMESPACE) deployment/$(RELEASE)-guacamole-postgres -- psql -U guacamole guacamole
 	@echo "Guacamole database initialized sucessfully.";
 
 # Execute with `make -j3 dev`

--- a/guacamole/Dockerfile
+++ b/guacamole/Dockerfile
@@ -10,3 +10,4 @@ RUN chmod -R 777 \
     /home/guacamole
 
 ENV HOME=/home/guacamole
+ENV JAVA_OPTS="-Duser.home=/home/guacamole"

--- a/helm/templates/guacamole/guacamole.deployment.yaml
+++ b/helm/templates/guacamole/guacamole.deployment.yaml
@@ -85,12 +85,12 @@ spec:
               mountPath: /home/guacamole/tomcat/logs
           resources:
             {{ if eq .Values.target "local" }}
-            limits:
-              cpu: "0.5"
-              memory: 500Mi
             requests:
-              cpu: "0.04"
-              memory: 5Mi
+              cpu: "0.1"
+              memory: 20Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
             {{ else }}
             requests:
               memory: "1Gi"


### PR DESCRIPTION
There was a weird behaviour that Guacamole used `/etc/guacamole` as home directory, which used the wrong `guacamole.properties`. As result, the postgres authentication module was not loaded. This was caused by an issue with the Java handling of the system variable user.home if the user doesn't exist (it was evaluated to `?`).