### PR TITLE
Bump minimum Python version to 3.11

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force
         working-directory: ./docs/development

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,3 +138,8 @@ repos:
     rev: v2.5.0
     hooks:
       - id: conventional-commits
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py311-plus"]

--- a/backend/capellacollab/alembic/versions/951433f1f092_move_models_to_own_table.py
+++ b/backend/capellacollab/alembic/versions/951433f1f092_move_models_to_own_table.py
@@ -158,11 +158,9 @@ def downgrade():
     for git_model in git_models:
         id = git_model.id
         project_name = next(
-            (
-                model.project_name
-                for model in models
-                if model.id == git_model.model_id
-            )
+            model.project_name
+            for model in models
+            if model.id == git_model.model_id
         )
         op.execute(
             f"UPDATE git_models SET project_name='{project_name}' WHERE id={id}"
@@ -171,11 +169,7 @@ def downgrade():
     for t4c_model in t4c_models:
         id = t4c_model.id
         project_name = next(
-            (
-                model.project_name
-                for model in models
-                if model[0] == t4c_model[-1]
-            )
+            model.project_name for model in models if model[0] == t4c_model[-1]
         )
         op.execute(
             f"UPDATE t4c_models SET project_name='{project_name}' WHERE id={id}"

--- a/backend/capellacollab/config/__init__.py
+++ b/backend/capellacollab/config/__init__.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/backend/capellacollab/config/loader.py
+++ b/backend/capellacollab/config/loader.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import pathlib

--- a/backend/capellacollab/core/authentication/helper.py
+++ b/backend/capellacollab/core/authentication/helper.py
@@ -7,5 +7,5 @@ import typing as t
 from capellacollab.config import config
 
 
-def get_username(token: t.Dict[str, t.Any]) -> str:
+def get_username(token: dict[str, t.Any]) -> str:
     return token[config["authentication"]["jwt"]["usernameClaim"]].strip()

--- a/backend/capellacollab/core/authentication/jwt_bearer.py
+++ b/backend/capellacollab/core/authentication/jwt_bearer.py
@@ -25,7 +25,7 @@ class JWTBearer(HTTPBearer):
     def __init__(self, auto_error: bool = True):
         super().__init__(auto_error=auto_error)
 
-    async def __call__(self, request: Request) -> t.Dict[str, t.Any] | None:
+    async def __call__(self, request: Request) -> dict[str, t.Any] | None:
         credentials: HTTPAuthorizationCredentials | None = (
             await super().__call__(request)
         )
@@ -51,7 +51,7 @@ class JWTBearer(HTTPBearer):
                 users_crud.update_last_login(session, created_user)
                 events.create_user_creation_event(session, created_user)
 
-    def validate_token(self, token: str) -> t.Dict[str, t.Any] | None:
+    def validate_token(self, token: str) -> dict[str, t.Any] | None:
         try:
             jwt_cfg = ep_main.get_jwk_cfg(token)
         except Exception:

--- a/backend/capellacollab/core/authentication/jwt_bearer.py
+++ b/backend/capellacollab/core/authentication/jwt_bearer.py
@@ -25,12 +25,10 @@ class JWTBearer(HTTPBearer):
     def __init__(self, auto_error: bool = True):
         super().__init__(auto_error=auto_error)
 
-    async def __call__(
-        self, request: Request
-    ) -> t.Optional[t.Dict[str, t.Any]]:
-        credentials: t.Optional[
-            HTTPAuthorizationCredentials
-        ] = await super().__call__(request)
+    async def __call__(self, request: Request) -> t.Dict[str, t.Any] | None:
+        credentials: HTTPAuthorizationCredentials | None = (
+            await super().__call__(request)
+        )
 
         if not credentials or credentials.scheme != "Bearer":
             if self.auto_error:
@@ -53,7 +51,7 @@ class JWTBearer(HTTPBearer):
                 users_crud.update_last_login(session, created_user)
                 events.create_user_creation_event(session, created_user)
 
-    def validate_token(self, token: str) -> t.Optional[t.Dict[str, t.Any]]:
+    def validate_token(self, token: str) -> t.Dict[str, t.Any] | None:
         try:
             jwt_cfg = ep_main.get_jwk_cfg(token)
         except Exception:

--- a/backend/capellacollab/core/authentication/provider/azure/keystore.py
+++ b/backend/capellacollab/core/authentication/provider/azure/keystore.py
@@ -65,7 +65,7 @@ class _KeyStore:
 
     def key_for_token(
         self, token: str, *, in_retry: int = 0
-    ) -> t.Dict[str, t.Any]:
+    ) -> dict[str, t.Any]:
         # Before we do anything, the validation keys may need to be refreshed.
         # If so, refresh them.
         if self.keys_need_refresh():

--- a/backend/capellacollab/core/authentication/provider/azure/keystore.py
+++ b/backend/capellacollab/core/authentication/provider/azure/keystore.py
@@ -3,7 +3,6 @@
 
 # pylint: skip-file
 
-from __future__ import annotations
 
 import logging
 import time

--- a/backend/capellacollab/core/authentication/provider/azure/routes.py
+++ b/backend/capellacollab/core/authentication/provider/azure/routes.py
@@ -27,7 +27,7 @@ router = APIRouter()
 cfg = config["authentication"]["azure"]
 
 
-@lru_cache()
+@lru_cache
 def ad_session():
     return ConfidentialClientApplication(
         cfg["client"]["id"],

--- a/backend/capellacollab/core/authentication/provider/azure/routes.py
+++ b/backend/capellacollab/core/authentication/provider/azure/routes.py
@@ -3,7 +3,6 @@
 
 
 import secrets
-import typing as t
 from functools import lru_cache
 
 from cachetools import TTLCache
@@ -92,7 +91,7 @@ async def logout(jwt_decoded=Depends(JWTBearer())):
 
 @router.get("/tokens", name="Validate the token")
 async def validate_token(
-    scope: t.Optional[Role],
+    scope: Role | None,
     token=Depends(JWTBearer()),
     db=Depends(get_db),
 ):

--- a/backend/capellacollab/core/authentication/provider/models.py
+++ b/backend/capellacollab/core/authentication/provider/models.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import pydantic
 

--- a/backend/capellacollab/core/authentication/provider/oauth/__main__.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/__main__.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import typing as t
 
 from capellacollab.config import config

--- a/backend/capellacollab/core/authentication/provider/oauth/flow.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/flow.py
@@ -24,7 +24,7 @@ auth_session = OAuth2Session(
 )
 
 
-def get_auth_redirect_url() -> t.Dict[str, str]:
+def get_auth_redirect_url() -> dict[str, str]:
     auth_url, state = auth_session.authorization_url(
         read_well_known()["authorization_endpoint"],
         grant_type="authorization_code",
@@ -33,7 +33,7 @@ def get_auth_redirect_url() -> t.Dict[str, str]:
     return {"auth_url": auth_url, "state": state}
 
 
-def get_token(code: str) -> t.Dict[str, t.Any]:
+def get_token(code: str) -> dict[str, t.Any]:
     return auth_session.fetch_token(
         read_well_known()["token_endpoint"],
         code=code,
@@ -42,7 +42,7 @@ def get_token(code: str) -> t.Dict[str, t.Any]:
     )
 
 
-def refresh_token(_refresh_token: str) -> t.Dict[str, t.Any]:
+def refresh_token(_refresh_token: str) -> dict[str, t.Any]:
     try:
         return auth_session.refresh_token(
             read_well_known()["token_endpoint"],

--- a/backend/capellacollab/core/authentication/provider/oauth/keystore.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/keystore.py
@@ -3,7 +3,6 @@
 
 # pylint: skip-file
 
-from __future__ import annotations
 
 import logging
 import time

--- a/backend/capellacollab/core/authentication/provider/oauth/keystore.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/keystore.py
@@ -63,7 +63,7 @@ class _KeyStore:
 
     def key_for_token(
         self, token: str, *, in_retry: int = 0
-    ) -> t.Dict[str, t.Any]:
+    ) -> dict[str, t.Any]:
         # Before we do anything, the validation keys may need to be refreshed.
         # If so, refresh them.
         if self.keys_need_refresh():

--- a/backend/capellacollab/core/authentication/provider/oauth/routes.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/routes.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import typing as t
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -51,7 +49,7 @@ async def logout():
 
 @router.get("/tokens", name="Validate the token")
 async def validate_token(
-    scope: t.Optional[Role],
+    scope: Role | None,
     token=Depends(JWTBearer()),
     db: Session = Depends(get_db),
 ):

--- a/backend/capellacollab/core/authentication/responses.py
+++ b/backend/capellacollab/core/authentication/responses.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import typing as t
 

--- a/backend/capellacollab/core/logging.py
+++ b/backend/capellacollab/core/logging.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import logging.handlers

--- a/backend/capellacollab/core/models.py
+++ b/backend/capellacollab/core/models.py
@@ -7,12 +7,12 @@ from pydantic import BaseModel
 
 
 class Message(BaseModel):
-    err_code: t.Optional[str]
-    title: t.Optional[str]
-    reason: t.Optional[t.Union[str, tuple]]
-    technical: t.Optional[str]
+    err_code: str | None
+    title: str | None
+    reason: t.Union[str, tuple] | None
+    technical: str | None
 
 
 class ResponseModel(BaseModel):
-    warnings: t.Optional[list["Message"]]
-    errors: t.Optional[list["Message"]]
+    warnings: list["Message"] | None
+    errors: list["Message"] | None

--- a/backend/capellacollab/core/models.py
+++ b/backend/capellacollab/core/models.py
@@ -1,15 +1,13 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import typing as t
-
 from pydantic import BaseModel
 
 
 class Message(BaseModel):
     err_code: str | None
     title: str | None
-    reason: t.Union[str, tuple] | None
+    reason: str | tuple | None
     technical: str | None
 
 

--- a/backend/capellacollab/core/models.py
+++ b/backend/capellacollab/core/models.py
@@ -14,5 +14,5 @@ class Message(BaseModel):
 
 
 class ResponseModel(BaseModel):
-    warnings: t.Optional[t.List["Message"]]
-    errors: t.Optional[t.List["Message"]]
+    warnings: t.Optional[list["Message"]]
+    errors: t.Optional[list["Message"]]

--- a/backend/capellacollab/notices/routes.py
+++ b/backend/capellacollab/notices/routes.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import typing as t
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -22,7 +20,7 @@ router = APIRouter()
 
 @router.get(
     "",
-    response_model=t.List[NoticeResponse],
+    response_model=list[NoticeResponse],
 )
 def get_notices(db: Session = Depends(get_db)):
     return notices.get_all_notices(db)

--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from slugify import slugify
 from sqlalchemy.orm import Session
 

--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import typing as t
-
 from slugify import slugify
 from sqlalchemy.orm import Session
 
@@ -24,7 +22,7 @@ def get_project_by_slug(db: Session, slug: str) -> DatabaseProject:
     )
 
 
-def get_all_projects(db: Session) -> t.List[DatabaseProject]:
+def get_all_projects(db: Session) -> list[DatabaseProject]:
     return db.query(DatabaseProject).all()
 
 

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -36,7 +36,7 @@ class Project(BaseModel):
     @validator("users", pre=True)
     @classmethod
     def transform_users(
-        cls, users: t.Union[UserMetadata, list[ProjectUserAssociation]]
+        cls, users: UserMetadata | list[ProjectUserAssociation]
     ):
         if isinstance(users, UserMetadata):
             return users

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -30,7 +30,7 @@ class UserMetadata(BaseModel):
 class Project(BaseModel):
     name: str
     slug: str
-    description: t.Optional[str]
+    description: str | None
     users: UserMetadata
 
     @validator("users", pre=True)
@@ -72,13 +72,13 @@ class Project(BaseModel):
 
 
 class PatchProject(BaseModel):
-    name: t.Optional[str]
-    description: t.Optional[str]
+    name: str | None
+    description: str | None
 
 
 class PostProjectRequest(BaseModel):
     name: str
-    description: t.Optional[str]
+    description: str | None
 
 
 class DatabaseProject(Base):

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -36,7 +36,7 @@ class Project(BaseModel):
     @validator("users", pre=True)
     @classmethod
     def transform_users(
-        cls, users: t.Union[UserMetadata, t.List[ProjectUserAssociation]]
+        cls, users: t.Union[UserMetadata, list[ProjectUserAssociation]]
     ):
         if isinstance(users, UserMetadata):
             return users

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -3,7 +3,6 @@
 
 
 import logging
-import typing as t
 
 from fastapi import APIRouter, Depends, HTTPException
 from slugify import slugify
@@ -43,7 +42,7 @@ router = APIRouter(
 
 @router.get(
     "/",
-    response_model=t.List[Project],
+    response_model=list[Project],
     tags=["Projects"],
 )
 def get_projects(
@@ -51,7 +50,7 @@ def get_projects(
     db: Session = Depends(database.get_db),
     token=Depends(JWTBearer()),
     log: logging.LoggerAdapter = Depends(get_request_logger),
-) -> t.List[DatabaseProject]:
+) -> list[DatabaseProject]:
     if auth_injectables.RoleVerification(
         required_role=Role.ADMIN, verify=False
     )(token, db):

--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import json
 

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import typing as t
 from datetime import datetime
 
 from pydantic import BaseModel, validator
@@ -34,7 +33,7 @@ class CreateBackup(BaseModel):
 
 class BackupJob(BaseModel):
     id: str
-    date: t.Union[datetime, None]
+    date: datetime | None
     state: str
 
 

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -44,8 +44,8 @@ class Job(BaseModel):
 
 class Backup(BaseModel):
     id: int
-    k8s_cronjob_id: t.Optional[str]
-    lastrun: t.Optional[BackupJob]
+    k8s_cronjob_id: str | None
+    lastrun: BackupJob | None
     t4c_model: SimpleT4CModel
     git_model: GitModel
     run_nightly: bool
@@ -54,7 +54,7 @@ class Backup(BaseModel):
     @validator("lastrun", pre=True, always=True)
     @classmethod
     def resolve_cronjob(
-        cls, value: t.Optional[BackupJob], values
+        cls, value: BackupJob | None, values
     ) -> BackupJob | None:
         if isinstance(value, BackupJob):
             return value

--- a/backend/capellacollab/projects/toolmodels/backups/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/routes.py
@@ -4,7 +4,6 @@
 
 import json
 import logging
-import typing as t
 import uuid
 
 import fastapi
@@ -42,7 +41,7 @@ log = logging.getLogger(__name__)
 
 @router.get(
     "",
-    response_model=t.List[Backup],
+    response_model=list[Backup],
     dependencies=[
         Depends(
             auth_injectables.ProjectRoleVerification(

--- a/backend/capellacollab/projects/toolmodels/crud.py
+++ b/backend/capellacollab/projects/toolmodels/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from slugify import slugify
 from sqlalchemy import select

--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -52,12 +52,12 @@ class EditingMode(enum.Enum):
 
 class PostCapellaModel(BaseModel):
     name: str
-    description: t.Optional[str]
+    description: str | None
     tool_id: int
 
 
 class PatchCapellaModel(BaseModel):
-    description: t.Optional[str]
+    description: str | None
     version_id: int
     nature_id: int
 
@@ -110,12 +110,12 @@ class CapellaModel(BaseModel):
     name: str
     description: str
     tool: ToolBase
-    version: t.Optional[ToolVersionBase]
-    nature: t.Optional[ToolNatureBase]
-    git_models: t.Optional[list[GitModel]]
-    t4c_models: t.Optional[list[T4CModel]]
+    version: ToolVersionBase | None
+    nature: ToolNatureBase | None
+    git_models: list[GitModel] | None
+    t4c_models: list[T4CModel] | None
 
-    restrictions: t.Optional[ToolModelRestrictions]
+    restrictions: ToolModelRestrictions | None
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-
-import typing as t
-
 import sqlalchemy
 from sqlalchemy.orm import Session
 
@@ -17,7 +14,7 @@ from capellacollab.projects.toolmodels.modelsources.git.models import (
 
 def get_gitmodels_of_capellamodels(
     db: Session, model_id: int
-) -> t.List[DatabaseGitModel]:
+) -> list[DatabaseGitModel]:
     return (
         db.query(DatabaseGitModel)
         .filter(DatabaseGitModel.model_id == model_id)

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -39,7 +39,7 @@ class GitModel(pydantic.BaseModel):
 
     @pydantic.validator("password", pre=True)
     @classmethod
-    def transform_password(cls, passw: t.Union[str, bool]) -> bool:
+    def transform_password(cls, passw: str | bool) -> bool:
         if isinstance(passw, bool):
             return passw
         return passw is not None and len(passw) > 0

--- a/backend/capellacollab/projects/toolmodels/modelsources/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError

--- a/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import fastapi
 

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/projects/toolmodels/routes.py
+++ b/backend/capellacollab/projects/toolmodels/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError, NoResultFound

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -44,8 +44,8 @@ class PostProjectUser(BaseModel):
 
 
 class PatchProjectUser(BaseModel):
-    role: t.Optional[ProjectUserRole]
-    permission: t.Optional[ProjectUserPermission]
+    role: ProjectUserRole | None
+    permission: ProjectUserPermission | None
     reason: str
 
 

--- a/backend/capellacollab/projects/users/routes.py
+++ b/backend/capellacollab/projects/users/routes.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import typing as t
-
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -81,7 +79,7 @@ def get_current_user(
 
 @router.get(
     "/",
-    response_model=t.List[ProjectUser],
+    response_model=list[ProjectUser],
     dependencies=[
         Depends(
             auth_injectables.ProjectRoleVerification(

--- a/backend/capellacollab/projects/users/routes.py
+++ b/backend/capellacollab/projects/users/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/projects/users/util.py
+++ b/backend/capellacollab/projects/users/util.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy.orm import Session
 

--- a/backend/capellacollab/sessions/crud.py
+++ b/backend/capellacollab/sessions/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/sessions/idletimeout.py
+++ b/backend/capellacollab/sessions/idletimeout.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -42,7 +42,7 @@ class DatabaseSession(Base):
     project_id: str = sa.Column(
         sa.Integer, sa.ForeignKey("projects.id"), nullable=True
     )
-    project: "projects_models.DatabaseProject" = orm.relationship(
+    project: projects_models.DatabaseProject = orm.relationship(
         "DatabaseProject"
     )
     mac: str = sa.Column(sa.String)

--- a/backend/capellacollab/sessions/operators/__init__.py
+++ b/backend/capellacollab/sessions/operators/__init__.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from capellacollab.sessions.operators.k8s import KubernetesOperator
 

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -468,7 +468,7 @@ class KubernetesOperator:
     ) -> dict[str, t.Any]:
         return {
             "id": deployment.to_dict()["metadata"]["name"],
-            "ports": set([3389]),
+            "ports": {3389},
             "created_at": deployment.to_dict()["metadata"][
                 "creation_timestamp"
             ],

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -104,7 +104,7 @@ class File:
     path: str
     name: str
     type: FileType
-    children: t.Optional[list[File]] = None
+    children: list[File] | None = None
 
 
 class KubernetesOperator:

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import itertools
 import json

--- a/backend/capellacollab/sessions/schema.py
+++ b/backend/capellacollab/sessions/schema.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import datetime
 import enum
-import typing as t
 
 from pydantic import BaseModel
 
@@ -34,17 +33,17 @@ class GetSessionsResponse(BaseModel):
     state: str
     guacamole_username: str
     guacamole_connection_id: str
-    warnings: t.Optional[list[Message]]
+    warnings: list[Message] | None
     last_seen: str
-    project: t.Optional[Project]
-    version: t.Optional[ToolVersionWithTool]
+    project: Project | None
+    version: ToolVersionWithTool | None
 
     class Config:
         orm_mode = True
 
 
 class OwnSessionResponse(GetSessionsResponse):
-    t4c_password: t.Optional[str]
+    t4c_password: str | None
 
 
 class PostReadonlySessionEntry(BaseModel):
@@ -89,7 +88,7 @@ class FileTree(BaseModel):
     path: str
     name: str
     type: FileType
-    children: t.Optional[list[FileTree]]
+    children: list[FileTree] | None
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -20,8 +20,8 @@ log = logging.getLogger(__name__)
 
 
 def inject_attrs_in_sessions(
-    db_sessions: t.List[DatabaseSession],
-) -> t.List[t.Dict[str, t.Any]]:
+    db_sessions: list[DatabaseSession],
+) -> list[t.Dict[str, t.Any]]:
     sessions_list = []
     for session in db_sessions:
         session.state = _determine_session_state(session)

--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import logging
 import re
 import typing as t

--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 def inject_attrs_in_sessions(
     db_sessions: list[DatabaseSession],
-) -> list[t.Dict[str, t.Any]]:
+) -> list[dict[str, t.Any]]:
     sessions_list = []
     for session in db_sessions:
         session.state = _determine_session_state(session)

--- a/backend/capellacollab/settings/integrations/purevariants/crud.py
+++ b/backend/capellacollab/settings/integrations/purevariants/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/settings/integrations/purevariants/models.py
+++ b/backend/capellacollab/settings/integrations/purevariants/models.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import typing as t
 
 import pydantic
 import requests
@@ -17,7 +16,7 @@ from capellacollab.core.database import Base
 log = logging.getLogger(__name__)
 
 
-def validate_license_url(value: t.Optional[str]):
+def validate_license_url(value: str | None):
     if value:
         try:
             requests.Request("GET", value).prepare()
@@ -38,8 +37,8 @@ class DatabasePureVariantsLicenses(Base):
 
 
 class PureVariantsLicenses(BaseModel):
-    license_server_url: t.Optional[str]
-    license_key_filename: t.Optional[str]
+    license_server_url: str | None
+    license_key_filename: str | None
 
     _validate_value = pydantic.validator(
         "license_server_url", allow_reuse=True

--- a/backend/capellacollab/settings/integrations/purevariants/models.py
+++ b/backend/capellacollab/settings/integrations/purevariants/models.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/backend/capellacollab/settings/integrations/purevariants/routes.py
+++ b/backend/capellacollab/settings/integrations/purevariants/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import fastapi
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/settings/integrations/purevariants/routes.py
+++ b/backend/capellacollab/settings/integrations/purevariants/routes.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import typing as t
-
 import fastapi
 from sqlalchemy.orm import Session
 
@@ -30,7 +28,7 @@ router = fastapi.APIRouter(
 
 @router.get(
     "",
-    response_model=t.Optional[PureVariantsLicenses],
+    response_model=PureVariantsLicenses | None,
 )
 def get_license(
     db: Session = fastapi.Depends(get_db),

--- a/backend/capellacollab/settings/modelsources/git/models.py
+++ b/backend/capellacollab/settings/modelsources/git/models.py
@@ -43,8 +43,8 @@ class DatabaseGitInstance(Base):
 
 
 class GetRevisionsResponseModel(BaseModel):
-    branches: t.List[str]
-    tags: t.List[str]
+    branches: list[str]
+    tags: list[str]
     default: t.Optional[str]
 
 

--- a/backend/capellacollab/settings/modelsources/git/models.py
+++ b/backend/capellacollab/settings/modelsources/git/models.py
@@ -3,7 +3,6 @@
 
 
 import enum
-import typing as t
 
 from pydantic import BaseModel
 from sqlalchemy import Column, Enum, Integer, String
@@ -19,9 +18,9 @@ class GitType(enum.Enum):
 
 
 class PostGitInstance(BaseModel):
-    type: t.Optional[GitType]
-    name: t.Optional[str]
-    url: t.Optional[str]
+    type: GitType | None
+    name: str | None
+    url: str | None
 
 
 class GitInstance(BaseModel):
@@ -45,7 +44,7 @@ class DatabaseGitInstance(Base):
 class GetRevisionsResponseModel(BaseModel):
     branches: list[str]
     tags: list[str]
-    default: t.Optional[str]
+    default: str | None
 
 
 class GitCredentials(BaseModel):

--- a/backend/capellacollab/settings/modelsources/git/routes.py
+++ b/backend/capellacollab/settings/modelsources/git/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/settings/modelsources/t4c/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def validate_rest_api_url(value: t.Optional[str]):
+def validate_rest_api_url(value: str | None):
     if value:
         try:
             requests.Request("GET", value).prepare()
@@ -86,7 +86,7 @@ class DatabaseT4CInstance(Base):
     )
 
 
-def port_validator(value: t.Optional[int]) -> t.Optional[int]:
+def port_validator(value: int | None) -> int | None:
     if not value:
         return value
     assert 0 <= value <= 65535
@@ -121,15 +121,15 @@ class T4CInstanceBase(BaseModel):
 
 
 class FieldsT4CInstance(BaseModel):
-    license: t.Optional[str]
-    host: t.Optional[str]
-    port: t.Optional[int]
-    cdo_port: t.Optional[int]
-    usage_api: t.Optional[str]
-    rest_api: t.Optional[str]
-    username: t.Optional[str]
-    password: t.Optional[str]
-    protocol: t.Optional[Protocol]
+    license: str | None
+    host: str | None
+    port: int | None
+    cdo_port: int | None
+    usage_api: str | None
+    rest_api: str | None
+    username: str | None
+    password: str | None
+    protocol: Protocol | None
 
     # validators
     _validate_rest_api_url = pydantic.validator("rest_api", allow_reuse=True)(
@@ -149,7 +149,7 @@ class FieldsT4CInstance(BaseModel):
 
 
 class PatchT4CInstance(FieldsT4CInstance):
-    version_id: t.Optional[int]
+    version_id: int | None
 
 
 class T4CInstanceComplete(T4CInstanceBase):

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -59,7 +59,7 @@ class T4CRepositoryStatus(str, enum.Enum):
 
 
 class T4CRepositories(ResponseModel):
-    payload: t.List[T4CRepository]
+    payload: list[T4CRepository]
 
 
 class T4CInstanceWithRepositories(T4CInstance):

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -72,7 +72,7 @@ class T4CInstanceWithRepositories(T4CInstance):
 class T4CRepository(CreateT4CRepository):
     id: int
     instance: T4CInstance
-    status: t.Optional[T4CRepositoryStatus]
+    status: T4CRepositoryStatus | None
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import typing as t
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from requests.exceptions import RequestException
@@ -126,7 +125,7 @@ def create_t4c_repository(
 
 @router.delete(
     "/{t4c_repository_id}",
-    response_model=t.Optional[ResponseModel],
+    response_model=ResponseModel | None,
 )
 def delete_t4c_repository(
     response: Response,

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 import logging
 

--- a/backend/capellacollab/settings/modelsources/t4c/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/routes.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -19,7 +19,7 @@ from capellacollab.tools.models import (
 from .integrations.crud import intialize_new_integration_table
 
 
-def get_all_tools(db: Session) -> t.List[Tool]:
+def get_all_tools(db: Session) -> list[Tool]:
     return db.query(Tool).all()
 
 
@@ -62,7 +62,7 @@ def get_tool_by_name(db: Session, name: str) -> Tool:
     return db.execute(select(Tool).where(Tool.name == name)).scalar_one()
 
 
-def get_versions(db: Session) -> t.List[Version]:
+def get_versions(db: Session) -> list[Version]:
     return db.execute(select(Version)).scalars().all()
 
 
@@ -96,7 +96,7 @@ def delete_tool_version(version: Version, db: Session) -> None:
     db.commit()
 
 
-def get_tool_versions(db: Session, tool_id: int) -> t.List[Version]:
+def get_tool_versions(db: Session, tool_id: int) -> list[Version]:
     return db.query(Version).filter(Version.tool_id == tool_id).all()
 
 
@@ -126,7 +126,7 @@ def create_version(
     return version
 
 
-def get_natures(db: Session) -> t.List[Nature]:
+def get_natures(db: Session) -> list[Nature]:
     return db.query(Nature).all()
 
 
@@ -134,7 +134,7 @@ def get_nature_by_id(id_: int, db: Session) -> Nature:
     return db.execute(select(Nature).where(Nature.id == id_)).scalar_one()
 
 
-def get_tool_natures(db: Session, tool_id: int) -> t.List[Nature]:
+def get_tool_natures(db: Session, tool_id: int) -> list[Nature]:
     return db.query(Nature).filter(Nature.tool_id == tool_id).all()
 
 

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import typing as t
-
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -37,7 +35,7 @@ def create_tool(db: Session, tool: Tool) -> Tool:
 def update_tool(
     db: Session,
     tool: Tool,
-    patch_tool: t.Union[CreateTool, PatchToolDockerimage],
+    patch_tool: CreateTool | PatchToolDockerimage,
 ) -> Tool:
     if isinstance(patch_tool, CreateTool):
         tool.name = patch_tool.name

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/tools/integrations/crud.py
+++ b/backend/capellacollab/tools/integrations/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from sqlalchemy.orm import Session
 

--- a/backend/capellacollab/tools/integrations/models.py
+++ b/backend/capellacollab/tools/integrations/models.py
@@ -24,8 +24,8 @@ class ToolIntegrations(BaseModel):
 
 
 class PatchToolIntegrations(BaseModel):
-    t4c: t.Optional[bool]
-    pure_variants: t.Optional[bool]
+    t4c: bool | None
+    pure_variants: bool | None
 
 
 class DatabaseToolIntegrations(Base):

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -77,8 +77,8 @@ class ToolBase(BaseModel):
 
 class ToolDockerimage(BaseModel):
     persistent: str
-    readonly: t.Optional[str]
-    backup: t.Optional[str]
+    readonly: str | None
+    backup: str | None
 
     @classmethod
     def from_orm(cls, obj: Tool) -> ToolDockerimage:
@@ -93,9 +93,9 @@ class ToolDockerimage(BaseModel):
 
 
 class PatchToolDockerimage(BaseModel):
-    persistent: t.Optional[str]
-    readonly: t.Optional[str]
-    backup: t.Optional[str]
+    persistent: str | None
+    readonly: str | None
+    backup: str | None
 
 
 class CreateToolVersion(BaseModel):
@@ -107,9 +107,9 @@ class CreateToolNature(BaseModel):
 
 
 class UpdateToolVersion(BaseModel):
-    name: t.Optional[str]
-    is_recommended: t.Optional[bool]
-    is_deprecated: t.Optional[bool]
+    name: str | None
+    is_recommended: bool | None
+    is_deprecated: bool | None
 
 
 class ToolVersionBase(BaseModel):

--- a/backend/capellacollab/users/crud.py
+++ b/backend/capellacollab/users/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from datetime import datetime
 

--- a/backend/capellacollab/users/events/crud.py
+++ b/backend/capellacollab/users/events/crud.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import typing as t
 from datetime import datetime
 
 from sqlalchemy.orm import Session
@@ -20,7 +19,7 @@ def create_event(
     executor: users_models.DatabaseUser | None = None,
     project: projects_models.DatabaseProject | None = None,
     reason: str | None = None,
-    allowed_types: t.Optional[list[models.EventType]] = None,
+    allowed_types: list[models.EventType] | None = None,
 ) -> models.DatabaseUserHistoryEvent:
     if allowed_types and event_type not in allowed_types:
         raise ValueError(

--- a/backend/capellacollab/users/events/crud.py
+++ b/backend/capellacollab/users/events/crud.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from datetime import datetime
 

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import enum
-import typing as t
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -32,11 +31,11 @@ class EventType(enum.Enum):
 
 class BaseHistoryEvent(BaseModel):
     user: User
-    executor: t.Optional[User]
-    project: t.Optional[Project]
+    executor: User | None
+    project: Project | None
     execution_time: datetime
     event_type: EventType
-    reason: t.Optional[str]
+    reason: str | None
 
     class Config:
         orm_mode = True
@@ -47,9 +46,9 @@ class HistoryEvent(BaseHistoryEvent):
 
 
 class UserHistory(User):
-    created: t.Optional[datetime]
-    last_login: t.Optional[datetime]
-    events: t.Optional[list[HistoryEvent]]
+    created: datetime | None
+    last_login: datetime | None
+    events: list[HistoryEvent] | None
 
 
 class DatabaseUserHistoryEvent(Base):

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import enum
 from datetime import datetime

--- a/backend/capellacollab/users/events/routes.py
+++ b/backend/capellacollab/users/events/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session

--- a/backend/capellacollab/users/injectables.py
+++ b/backend/capellacollab/users/injectables.py
@@ -22,7 +22,7 @@ def get_own_user(
 
 
 def get_existing_user(
-    user_id: t.Union[int, t.Literal["current"]],
+    user_id: int | t.Literal["current"],
     db=Depends(get_db),
     token=Depends(JWTBearer()),
 ) -> DatabaseUser:

--- a/backend/capellacollab/users/models.py
+++ b/backend/capellacollab/users/models.py
@@ -55,11 +55,11 @@ class DatabaseUser(Base):
     created = Column(DateTime)
     last_login = Column(DateTime)
 
-    projects: list["ProjectUserAssociation"] = relationship(
+    projects: list[ProjectUserAssociation] = relationship(
         "ProjectUserAssociation",
         back_populates="user",
     )
-    sessions: "DatabaseSession" = relationship(
+    sessions: DatabaseSession = relationship(
         "DatabaseSession",
         back_populates="owner",
     )

--- a/backend/capellacollab/users/routes.py
+++ b/backend/capellacollab/users/routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session

--- a/backend/generate_git_archival.py
+++ b/backend/generate_git_archival.py
@@ -6,7 +6,7 @@ import subprocess
 import typing as t
 
 
-def run_git_command(cmd: t.List[str]):
+def run_git_command(cmd: list[str]):
     return subprocess.run(
         ["git", *cmd],
         check=True,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 name = "capellacollab-backend"
 readme = "README.md"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.11, <3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "DB Netz AG" }]
 keywords = []
@@ -20,17 +20,14 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
   "PyYAML",
   "alembic",
   "appdirs",
   "cachetools",
-  "docker",
   "fastapi>=0.89.1",
-  "gitpython",
   "kubernetes",
   "msal",
   "psycopg2-binary",
@@ -58,6 +55,7 @@ dev = [
   "pytest",
   "testcontainers",
   "httpx",
+  "docker",
 ]
 psycopg2 = [
   "psycopg2", # Need when running in a Docker container with AArch64: https://github.com/psycopg/psycopg2/issues/1360
@@ -81,7 +79,7 @@ no_implicit_optional = true
 show_error_codes = true
 warn_redundant_casts = true
 warn_unreachable = true
-python_version = "3.9"
+python_version = "3.11"
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import typing as t
 from datetime import datetime

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -122,7 +122,7 @@ class MockOperator:
         version_name: str,
         password: str,
         docker_image: str,
-        git_repos_json: t.List[t.Dict[str, str | int]],
+        git_repos_json: list[t.Dict[str, str | int]],
     ) -> t.Dict[str, t.Any]:
         cls.sessions.append(
             {"docker_image": docker_image, "git_repos_json": git_repos_json}

--- a/backend/tests/test_sessions_routes.py
+++ b/backend/tests/test_sessions_routes.py
@@ -104,7 +104,7 @@ class MockOperator:
         t4c_json: list[dict[str, str | int]] | None,
         pure_variants_license_server: str = None,
         pure_variants_secret_name: str = None,
-    ) -> t.Dict[str, t.Any]:
+    ) -> dict[str, t.Any]:
         assert docker_image
         cls.sessions.append({"docker_image": docker_image})
         return {
@@ -122,8 +122,8 @@ class MockOperator:
         version_name: str,
         password: str,
         docker_image: str,
-        git_repos_json: list[t.Dict[str, str | int]],
-    ) -> t.Dict[str, t.Any]:
+        git_repos_json: list[dict[str, str | int]],
+    ) -> dict[str, t.Any]:
         cls.sessions.append(
             {"docker_image": docker_image, "git_repos_json": git_repos_json}
         )
@@ -148,7 +148,7 @@ class MockOperator:
 
     @classmethod
     def create_cronjob(
-        self, image: str, environment: t.Dict[str, str], schedule="* * * * *"
+        self, image: str, environment: dict[str, str], schedule="* * * * *"
     ) -> str:
         return ""
 

--- a/docs/development/docs/code-style.md
+++ b/docs/development/docs/code-style.md
@@ -45,11 +45,7 @@ Python code. The key differences are:
   writing `from typing import SomeName`, use `import typing as t` and access
   typing related classes like `t.TypedDict`.
 
-      Use the new syntax and classes for typing introduced with Python 3.10 and
-      available using `from __future__ import annotations` since Python 3.8. Be
-      aware however that this only works in the context of annotations; the code
-      still needs to run on Python 3.8! This means that in some (rare) cases, you
-      *must* use the old-style type hints.
+      Use the new syntax and classes for typing introduced with Python 3.10.
 
       - Instead of `t.Tuple`, `t.List` etc. use the builtin classes `tuple`, `list`
         etc.


### PR DESCRIPTION
This PR contains the following changes: 

- Updated all references from Python 3.9/3.10 to 3.11
- Set minimum Python version to 3.11 for all used libraries
- Replace `t.List` with `list`
- Replace `t.Optional[x]` with `x | None`
- Replace `t.Union[x, y]` with `x | y`
- Replace `t.Dict` with `dict`
- Remove `from __future__ import annotations` where possible. Unfortunately, PEP 563 has been put on hold indefinitely and was not introduced in Python 3.11, so we still need the import in some cases.

Resolves #549