### PR TITLE
Print errors in `/healthcheck`

### DIFF
--- a/backend/capellacollab/core/logging.py
+++ b/backend/capellacollab/core/logging.py
@@ -96,8 +96,8 @@ class LogRequestsMiddleware(base.BaseHTTPMiddleware):
 class HealthcheckFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         return (
-            record.getMessage().find("path=/healthcheck") == -1
-            or record.levelno > 10
+            record.getMessage().find('path="/healthcheck"') == -1
+            or record.levelno > logging.DEBUG
         )
 
 

--- a/backend/capellacollab/core/logging.py
+++ b/backend/capellacollab/core/logging.py
@@ -95,7 +95,10 @@ class LogRequestsMiddleware(base.BaseHTTPMiddleware):
 
 class HealthcheckFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        return record.getMessage().find("/healthcheck") == -1
+        return (
+            record.getMessage().find("path=/healthcheck") == -1
+            or record.levelno > 10
+        )
 
 
 class LogAdapter(logging.LoggerAdapter):


### PR DESCRIPTION
This commit also prints all messages with LEVEL >= INFO for the healthcheck route. This is particually interesting because we're not able to filter for extra arguments in the logging filter as `logging.LogRecord` doesn't contain extra attributes. Therefore, we're just filtering for the message. The filtering is more specific now, it also checks for the `path=` prefix.