### PR TITLE
Fix lastrun possible null after backups creation

### DIFF
--- a/frontend/src/app/general/metadata/version/version.component.ts
+++ b/frontend/src/app/general/metadata/version/version.component.ts
@@ -27,7 +27,7 @@ export class VersionComponent implements OnInit {
     this.versionService
       .loadBackendMetadata()
       .subscribe((metadata: BackendMetadata) => {
-        this.backend = metadata.version;
+        this.backend = `v${metadata.version}`;
       });
   }
 }

--- a/frontend/src/app/projects/models/backup-settings/trigger-pipeline/trigger-pipeline.component.html
+++ b/frontend/src/app/projects/models/backup-settings/trigger-pipeline/trigger-pipeline.component.html
@@ -104,7 +104,7 @@
         mat-raised-button
         (click)="viewLogs(selectedPipeline)"
         color="primary"
-        *ngIf="selectedPipeline.lastrun.id"
+        *ngIf="selectedPipeline?.lastrun?.id"
       >
         View logs of last run
       </button>


### PR DESCRIPTION
This PR fixes a minor issue that `lastrun` is undefined after a backup is created and never run. In that case, selecting this pipeline resulted in an error in the console. In addition, this PR adds a `v` in front of the backend version displayed in the frontend to make it consistent with the other versions displayed.