### PR TITLE
Add tool to persistent sessions in session overview

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -33,7 +33,7 @@ app:
 		source $(VENV)/Scripts/activate;
 	fi
 	export OAUTHLIB_INSECURE_TRANSPORT=1;
-	uvicorn --reload --reload-dir $$(pwd) --reload-include "*.json" --reload-include "*.py" --reload-include "*.yaml" --reload-include "*.yml" capellacollab.__main__:app
+	uvicorn --reload --reload-dir $$(pwd) --reload-include "*.py" --reload-include "*.yaml" --reload-include "*.yml" capellacollab.__main__:app
 
 
 install:

--- a/frontend/src/app/sessions/session-overview/session-overview.component.html
+++ b/frontend/src/app/sessions/session-overview/session-overview.component.html
@@ -59,9 +59,7 @@
     <ng-container matColumnDef="tool">
       <th mat-header-cell *matHeaderCellDef>Tool</th>
       <td mat-cell *matCellDef="let element">
-        <div *ngIf="element.type === 'readonly'">
-          {{ element.version?.tool?.name }} ({{ element.version?.name }})
-        </div>
+        {{ element.version?.tool?.name }} ({{ element.version?.name }})
       </td>
     </ng-container>
 


### PR DESCRIPTION
This PR includes showing the tool + version also for persistent sessions in the session overview. Since the tool and version are already written into the database the only change need for this was to remove a condition in the `session-overview.component.html`.

Solves #446 