### PR TITLE
Simplify git settings component

### DIFF
--- a/frontend/src/app/settings/modelsources/git-settings/edit-git-settings/edit-git-settings.component.html
+++ b/frontend/src/app/settings/modelsources/git-settings/edit-git-settings/edit-git-settings.component.html
@@ -25,6 +25,11 @@
       <mat-form-field class="form-field-default" appearance="fill">
         <mat-label>Name</mat-label>
         <input matInput formControlName="name" />
+        <mat-error *ngIf="gitInstanceForm.controls.name.errors?.uniqueName"
+          >A instance with the name "{{
+            gitInstanceForm.controls.name.errors?.uniqueName.value
+          }}" already exists</mat-error
+        >
       </mat-form-field>
       <br />
       <mat-form-field class="form-field-default" appearance="fill">
@@ -42,12 +47,13 @@
       </mat-form-field>
     </form>
     <div class="flex-space-between">
-      <a mat-raised-button (click)="goBack()"> Back </a>
+      <a mat-raised-button [routerLink]="'../..'"> Back </a>
       <button
         [class]="'right-button'"
         mat-flat-button
         color="primary"
         (click)="editGitInstance()"
+        [disabled]="!gitInstanceForm.valid"
       >
         Save changes
       </button>

--- a/frontend/src/app/settings/modelsources/git-settings/git-settings.component.html
+++ b/frontend/src/app/settings/modelsources/git-settings/git-settings.component.html
@@ -4,34 +4,36 @@
  -->
 
 <div class="wrapper">
-  <div class="title" *ngIf="availableGitInstances.length">
-    Existing instances
-  </div>
-  <div class="instances" *ngIf="availableGitInstances.length">
-    <mat-card *ngFor="let instance of availableGitInstances">
-      <div class="mat-title">
-        <div class="instance-head">
-          {{ instance.name }}
-          <span class="mat-subtitle">{{ instance.type }}</span>
+  <div *ngIf="(this.gitInstancesService.gitInstances | async)?.length">
+    <div class="title">Existing instances</div>
+    <div class="instances">
+      <mat-card
+        *ngFor="let instance of this.gitInstancesService.gitInstances | async"
+      >
+        <div class="mat-title">
+          <div class="instance-head">
+            {{ instance.name }}
+            <span class="mat-subtitle">{{ instance.type }}</span>
+          </div>
+          <div class="icon-container">
+            <a
+              mat-icon-button
+              [routerLink]="['instances/', instance.id.toString()]"
+            >
+              <mat-icon aria-label="Edit the source">settings</mat-icon>
+            </a>
+            <button mat-icon-button (click)="deleteGitInstance(instance)">
+              <mat-icon aria-label="Delete the source">delete</mat-icon>
+            </button>
+          </div>
         </div>
-        <div class="icon-container">
-          <a
-            mat-icon-button
-            [routerLink]="['instances/', instance.id.toString()]"
-          >
-            <mat-icon aria-label="Edit the source">settings</mat-icon>
-          </a>
-          <button mat-icon-button (click)="deleteGitInstance(instance.id)">
-            <mat-icon aria-label="Delete the source">delete</mat-icon>
-          </button>
+        <div class="content">
+          Instance base URL:
+          <a href="{{ instance.url }}">{{ instance.url }}</a> <br />
+          <span *ngIf="instance.apiURL">API URL: {{ instance.apiURL }}</span>
         </div>
-      </div>
-      <div class="content">
-        Instance base URL:
-        <a href="{{ instance.url }}">{{ instance.url }}</a> <br />
-        <span *ngIf="instance.apiURL">API URL: {{ instance.apiURL }}</span>
-      </div>
-    </mat-card>
+      </mat-card>
+    </div>
   </div>
   <br />
   <div class="title">Add new integration</div>

--- a/frontend/src/app/settings/modelsources/git-settings/service/git-instances.service.ts
+++ b/frontend/src/app/settings/modelsources/git-settings/service/git-instances.service.ts
@@ -113,15 +113,14 @@ export type BackendBasicGitInstance = {
   type: GitType;
 };
 
-export type BasicGitInstance = {
+export type BasicGitInstance = Omit<GitInstance, 'id'>;
+
+export type GitInstance = {
+  id: number;
   name: string;
   url: string;
   apiURL?: string;
   type: GitType;
-};
-
-export type GitInstance = BasicGitInstance & {
-  id: number;
 };
 
 export type GitType = 'general' | 'gitlab' | 'github' | 'azuredevops';


### PR DESCRIPTION
This PR first simplifies the settings component and in addition adds a name validation for the edit git instance component (until now we could actually have two instances with the same name)