### PR TITLE
Remove @vik378 from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: CC0-1.0
 
-*   @MoritzWeber0 @vik378
+*   @MoritzWeber0


### PR DESCRIPTION
When two CODEOWNERS are created and one CODEOWNER opens a PR, the merge is blocked until the second CODEOWNER approves. This is not the wanted workflow - PRs from the main CODEOWNER shouldn't require a review from another CODEOWNER.