### PR TITLE
Monitor our backend (web) server and deployed sessions

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -12,6 +12,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette_prometheus import PrometheusMiddleware, metrics
 
+import capellacollab.sessions.metrics
+
 # This import statement is required and should not be removed! (Alembic will not work otherwise)
 from capellacollab.config import config
 from capellacollab.core.database import engine, migration
@@ -64,9 +66,17 @@ async def schedule_termination_of_idle_sessions():
         await terminate_idle_sessions_in_background()
 
 
+async def register_metrics():
+    capellacollab.sessions.metrics.register()
+
+
 app = FastAPI(
     title="Capella Collaboration",
-    on_startup=[startup, schedule_termination_of_idle_sessions],
+    on_startup=[
+        startup,
+        schedule_termination_of_idle_sessions,
+        register_metrics,
+    ],
     middleware=[
         Middleware(
             CORSMiddleware,

--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware import Middleware
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from starlette_prometheus import PrometheusMiddleware, metrics
 
 # This import statement is required and should not be removed! (Alembic will not work otherwise)
 from capellacollab.config import config
@@ -78,6 +79,7 @@ app = FastAPI(
         Middleware(AttachUserNameMiddleware),
         Middleware(LogExceptionMiddleware),
         Middleware(LogRequestsMiddleware),
+        Middleware(PrometheusMiddleware),
     ],
     on_shutdown=[shutdown],
 )
@@ -111,6 +113,8 @@ async def handle_exceptions(request: Request, exc: Exception):
 async def healthcheck():
     return {"status": "alive"}
 
+
+app.add_route("/metrics", metrics)
 
 app.include_router(status.router, prefix="", tags=["Status"])
 app.include_router(router, prefix="/api/v1")

--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -66,16 +66,12 @@ async def schedule_termination_of_idle_sessions():
         await terminate_idle_sessions_in_background()
 
 
-async def register_metrics():
-    capellacollab.sessions.metrics.register()
-
-
 app = FastAPI(
     title="Capella Collaboration",
     on_startup=[
         startup,
         schedule_termination_of_idle_sessions,
-        register_metrics,
+        capellacollab.sessions.metrics.register,
     ],
     middleware=[
         Middleware(

--- a/backend/capellacollab/sessions/crud.py
+++ b/backend/capellacollab/sessions/crud.py
@@ -52,6 +52,10 @@ def get_all_sessions(db: Session):
     return db.query(DatabaseSession).all()
 
 
+def count_sessions(db: Session):
+    return db.query(DatabaseSession).count()
+
+
 def create_session(db: Session, session: DatabaseSession):
     db.add(session)
     db.commit()

--- a/backend/capellacollab/sessions/metrics.py
+++ b/backend/capellacollab/sessions/metrics.py
@@ -30,7 +30,7 @@ class DeployedSessionsCollector:
             labels=("phase",),
         )
         operator = operators.get_operator()
-        pods = operator._get_pods(label_selector=None)
+        pods = operator.get_pods(label_selector=None)
         phases = sorted(pod.status.phase.lower() for pod in pods)
         for k, g in itertools.groupby(phases):
             metric.add_metric([k], len(list(g)))

--- a/backend/capellacollab/sessions/metrics.py
+++ b/backend/capellacollab/sessions/metrics.py
@@ -1,13 +1,14 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
 import typing as t
 
 import prometheus_client
 import prometheus_client.core
 
 from capellacollab.core import database
-from capellacollab.sessions import crud
+from capellacollab.sessions import crud, operators
 
 
 class DatabaseSessionsCollector:
@@ -21,5 +22,21 @@ class DatabaseSessionsCollector:
         yield metric
 
 
+class DeployedSessionsCollector:
+    def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
+        metric = prometheus_client.core.GaugeMetricFamily(
+            "backend_deployed_sessions",
+            "Sessions running in the sessions namespace",
+            labels=("phase",),
+        )
+        operator = operators.get_operator()
+        pods = operator._get_pods(label_selector=None)
+        phases = sorted(pod.status.phase.lower() for pod in pods)
+        for k, g in itertools.groupby(phases):
+            metric.add_metric([k], len(list(g)))
+        yield metric
+
+
 def register() -> None:
     prometheus_client.REGISTRY.register(DatabaseSessionsCollector())
+    prometheus_client.REGISTRY.register(DeployedSessionsCollector())

--- a/backend/capellacollab/sessions/metrics.py
+++ b/backend/capellacollab/sessions/metrics.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import typing as t
+
+import prometheus_client
+import prometheus_client.core
+
+from capellacollab.core import database
+from capellacollab.sessions import crud
+
+
+class DatabaseSessionsCollector:
+    def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
+        metric = prometheus_client.core.GaugeMetricFamily(
+            "backend_database_sessions",
+            "Sessions registered in the backend database",
+        )
+        with database.SessionLocal() as db:
+            metric.add_metric([], crud.count_sessions(db))
+        yield metric
+
+
+def register() -> None:
+    prometheus_client.REGISTRY.register(DatabaseSessionsCollector())

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -1059,7 +1059,7 @@ class KubernetesOperator:
     def _get_pod_name(self, _id: str) -> str:
         return self._get_pods(label_selector=f"app={_id}")[0].metadata.name
 
-    def _get_pods(self, label_selector: str) -> list[client.V1Pod]:
+    def _get_pods(self, label_selector: str | None) -> list[client.V1Pod]:
         return self.v1_core.list_namespaced_pod(
             namespace=namespace, label_selector=label_selector
         ).items

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -446,7 +446,10 @@ class KubernetesOperator:
         self._create_cronjob(
             name=_id,
             image=image,
-            job_labels={"app.capellacollab/parent": _id},
+            job_labels={
+                "workload": "cronjob",
+                "app.capellacollab/parent": _id,
+            },
             environment=environment,
             schedule=schedule,
             timeout=timeout,
@@ -464,7 +467,7 @@ class KubernetesOperator:
         self._create_job(
             name=_id,
             image=image,
-            job_labels=labels,
+            job_labels={"workload": "job", **labels},
             environment=environment,
             timeout=timeout,
         )
@@ -703,7 +706,9 @@ class KubernetesOperator:
                 replicas=1,
                 selector=client.V1LabelSelector(match_labels={"app": name}),
                 template=client.V1PodTemplateSpec(
-                    metadata=client.V1ObjectMeta(labels={"app": name}),
+                    metadata=client.V1ObjectMeta(
+                        labels={"app": name, "workload": "session"}
+                    ),
                     spec=client.V1PodSpec(
                         security_context=pod_security_context,
                         containers=containers,

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -372,7 +372,7 @@ class KubernetesOperator:
 
     def _get_pod_state(self, label_selector: str):
         try:
-            pod = self._get_pods(label_selector=label_selector)[0]
+            pod = self.get_pods(label_selector=label_selector)[0]
             pod_name = pod.metadata.name
 
             log.debug("Received k8s pod: %s", pod_name)
@@ -399,7 +399,7 @@ class KubernetesOperator:
 
     def _get_pod_starttime(self, label_selector: str) -> datetime | None:
         try:
-            pods: list[client.V1Pod] = self._get_pods(
+            pods: list[client.V1Pod] = self.get_pods(
                 label_selector=label_selector
             )
             log.debug("Received k8s pods: %s", pods)
@@ -1057,9 +1057,9 @@ class KubernetesOperator:
             return None
 
     def _get_pod_name(self, _id: str) -> str:
-        return self._get_pods(label_selector=f"app={_id}")[0].metadata.name
+        return self.get_pods(label_selector=f"app={_id}")[0].metadata.name
 
-    def _get_pods(self, label_selector: str | None) -> list[client.V1Pod]:
+    def get_pods(self, label_selector: str | None) -> list[client.V1Pod]:
         return self.v1_core.list_namespaced_pod(
             namespace=namespace, label_selector=label_selector
         ).items

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "python-slugify[unidecode]",
   "jsonschema",
   "openshift",
+  "starlette-prometheus",
 ]
 
 [project.urls]

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -3,6 +3,8 @@
 
 from fastapi import testclient
 
+from capellacollab.sessions import metrics
+
 
 def test_metrics_endpoint(client: testclient.TestClient):
 
@@ -10,3 +12,12 @@ def test_metrics_endpoint(client: testclient.TestClient):
 
     assert response.status_code == 200
     assert "# HELP " in response.text
+
+
+def test_database_sessions_metric(db):
+    collector = metrics.DatabaseSessionsCollector()
+
+    data = list(collector.collect())
+
+    assert data
+    assert data[0].samples

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -29,15 +29,37 @@ def test_kubernetes_sessions_metric(monkeypatch):
 
     data = list(collector.collect())
 
-    assert data
-    assert data[0].samples
+    samples = {
+        (s.labels["workload"], s.labels["phase"]): s.value
+        for s in data[0].samples
+    }
+
+    assert samples == {
+        ("job", "running"): 1,
+        ("job", "pending"): 1,
+        ("session", "running"): 2,
+    }
 
 
 class MockOperator:
     def get_pods(self, label_selector):
         return [
-            attrdict(status=attrdict(phase="running")),
-            attrdict(status=attrdict(phase="pending")),
+            attrdict(
+                metadata=attrdict(labels=dict(workload="job")),
+                status=attrdict(phase="running"),
+            ),
+            attrdict(
+                metadata=attrdict(labels=dict(workload="job")),
+                status=attrdict(phase="pending"),
+            ),
+            attrdict(
+                metadata=attrdict(labels=dict(workload="session")),
+                status=attrdict(phase="running"),
+            ),
+            attrdict(
+                metadata=attrdict(labels=dict(workload="session")),
+                status=attrdict(phase="running"),
+            ),
         ]
 
 

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -3,7 +3,7 @@
 
 from fastapi import testclient
 
-from capellacollab.sessions import metrics
+from capellacollab.sessions import metrics, operators
 
 
 def test_metrics_endpoint(client: testclient.TestClient):
@@ -21,3 +21,26 @@ def test_database_sessions_metric(db):
 
     assert data
     assert data[0].samples
+
+
+def test_kubernetes_sessions_metric(monkeypatch):
+    monkeypatch.setattr(operators, "get_operator", MockOperator)
+    collector = metrics.DeployedSessionsCollector()
+
+    data = list(collector.collect())
+
+    assert data
+    assert data[0].samples
+
+
+class MockOperator:
+    def get_pods(self, label_selector):
+        return [
+            attrdict(status=attrdict(phase="running")),
+            attrdict(status=attrdict(phase="pending")),
+        ]
+
+
+class attrdict(dict):
+    def __getattr__(self, name):
+        return self[name]

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from fastapi import testclient
+
+
+def test_metrics_endpoint(client: testclient.TestClient):
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert "# HELP " in response.text

--- a/helm/templates/backend/backend.service.yaml
+++ b/helm/templates/backend/backend.service.yaml
@@ -5,6 +5,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-backend
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "80"
   labels:
     id: {{ .Release.Name }}-service-backend
 spec:

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -32,10 +32,15 @@ data:
       - /etc/prometheus/prometheus.rules
 
     scrape_configs:
+      - job_name: "prometheus"
+        metrics_path: /prometheus/metrics
+        static_configs:
+          - targets: ["localhost:9090"]
       - job_name: "kubernetes-services"
         kubernetes_sd_configs:
           - role: service
             namespaces:
+              own_namespace: true
               names:
                 - {{ .Values.backend.k8sSessionNamespace }}
         relabel_configs:

--- a/helm/templates/prometheus/prometheus.service.yaml
+++ b/helm/templates/prometheus/prometheus.service.yaml
@@ -8,9 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     id: {{ .Release.Name }}-service-prometheus
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9118"
 spec:
   type: ClusterIP
   selector:

--- a/helm/templates/prometheus/prometheus.serviceaccount.yaml
+++ b/helm/templates/prometheus/prometheus.serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: {{ .Values.backend.k8sSessionNamespace }}
+  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}-prometheus
   labels:
     id: {{ .Release.Name }}-role-prometheus
@@ -30,13 +30,46 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-prometheus
-  namespace: {{ .Values.backend.k8sSessionNamespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     id: {{ .Release.Name }}-rolebinding-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ .Release.Name }}-prometheus
+subjects:
+  - kind: ServiceAccount
+    apiGroup: ""
+    name: {{ .Release.Name }}-prometheus
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Values.backend.k8sSessionNamespace }}
+  name: {{ .Release.Name }}-prometheus-sessions
+  labels:
+    id: {{ .Release.Name }}-role-prometheus
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - watch
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-prometheus-sessions
+  namespace: {{ .Values.backend.k8sSessionNamespace }}
+  labels:
+    id: {{ .Release.Name }}-rolebinding-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-prometheus-sessions
 subjects:
   - kind: ServiceAccount
     apiGroup: ""


### PR DESCRIPTION
Add monitoring for the backend.

The idea is that the backend can provide metrics regarding running sessions, and the session (deployment) state.

* `backend_database_sessions` (gauge) shows the number of sessions registered in our backend database
* `backend_deployed_sessions{state}` (gauge) shows the number of pods deployed in the sessions namespace, with their state
* `backend_sessions_started` (counter) total number of sessions started since application startup
* `backend_sessions_killed` (counter) total number of sessions terminated, either by user or timeout
* `starlette_*` HTTP request metrics: requests, responses, request times, exceptions, requests in progress