### PR TITLE
fix(frontend): Make docsURL optional in env

### DIFF
--- a/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.ts
@@ -70,7 +70,10 @@ export class ModelComplexityBadgeComponent implements OnChanges {
   }
 
   openModelComplexityBadgeDocs() {
-    const docsURL = environment.docsURL || '/docs';
-    window.open(docsURL + '/projects/models/complexity_badge', '_blank');
+    let docsURL = '/docs';
+    if ('docsURL' in environment) {
+      docsURL = environment.docsURL as string;
+    }
+    window.open(docsURL + '/projects/models/complexity_badge/', '_blank');
   }
 }


### PR DESCRIPTION
A small fix which makes the docsURL environment optional. In addition, it adds a trailing slash to the docs, otherwise it doesn't load.