### PR TITLE
fix: Reenable diagram cache

### DIFF
--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -105,6 +105,15 @@
           >
             <mat-icon>open_in_new</mat-icon>
           </a>
+          <button
+            mat-mini-fab
+            *ngIf="model.git_models && model.tool.name === 'Capella'"
+            matTooltip="Show diagrams of model"
+            [disabled]="!getPrimaryGitModelURL(model)"
+            (click)="openDiagramsDialog(model)"
+          >
+            <mat-icon>image_search</mat-icon>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
For some reason, the diagram cache button has been removed in #740, not providing a reason in the commit or PR message.

This commit adds the button again.