### PR TITLE
feat: Enhance breadcrumb functionality

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -69,13 +69,20 @@ const routes: Routes = [
         children: [
           {
             path: '',
-            data: { breadcrumb: (data: Data) => data.project?.name },
+            data: {
+              breadcrumb: (data: Data) => data.project?.name || '...',
+              redirect: (data: Data) => `/project/${data.project?.slug}`,
+            },
             component: ProjectDetailsComponent,
           },
           {
             path: 'metadata',
             data: {
-              breadcrumb: (data: Data) => `${data.project?.name} / Metadata`,
+              breadcrumb: [(data: Data) => data.project?.name, 'Metadata'],
+              redirect: [
+                (data: Data) => `/project/${data.project?.slug}`,
+                (data: Data) => `/project/${data.project?.slug}/metadata`,
+              ],
             },
             component: EditProjectMetadataComponent,
           },


### PR DESCRIPTION
Updated the BreadcrumbsService and routing configurations to support dynamic breadcrumb labels and their respective links. This update allows us to separate the breadcrumb for 'project' and 'Metadata'.

This can be further enhanced in the future, to not have two separate breadcrumb and redirect lists but rather `[{breadcrumb: ..., redirect: ...}, {...}, ...]`. However, this most likely result in some more changes, so this here works for now.

**Update:**
It seems like this is already resolved in #647 as there a new abstraction layer for the `:project` is introduced. However, I would still merge this PR as being able to specify more than one breadcrumb for a url could still be useful in the future.