### PR TITLE
Fix: Set tool version to null on tool change

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.ts
@@ -95,6 +95,7 @@ export class CreateReadonlySessionComponent implements OnInit {
 
   onToolChange(tool: Tool): void {
     this.toolSelectionForm.controls.version.enable();
+    this.toolSelectionForm.controls.version.patchValue(null);
     this.toolVersions = undefined;
 
     this.toolService.getVersionsForTool(tool.id).subscribe((toolVersions) => {


### PR DESCRIPTION
Currently, when changing the tool for requesting a readonly session from the project detail view, the tool version was not reset on a tool change. As a result, you were still able to click on "Request a ..." even though you have changed the tool and no tool version was selected. This fix simply sets the versions' form value to null in case of a tool change, invalidating the form (as the version is required), and therefore, disabling the button.