### PR TITLE
fix: Use ingress class name from the config correctly

### DIFF
--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -7,8 +7,8 @@ docker:
 
 k8s:
   namespace: {{ .Values.backend.k8sSessionNamespace }}
-  {{- if .Values.ingressClassName }}
-  ingressClassName: {{ .Values.ingressClassName }}
+  {{- if .Values.cluster.namespaces.sessions.ingressClassName }}
+  ingressClassName: {{ .Values.cluster.namespaces.sessions.ingressClassName }}
   {{- end }}
   storageClassName: {{ .Values.backend.storageClassName }}
   storageAccessMode: {{ .Values.backend.storageAccessMode }}


### PR DESCRIPTION
`ingressClassName` is [not a toplevel property](https://github.com/DSD-DBS/capella-collab-manager/blob/main/helm/values.yaml#L201).

