### PR TITLE
Refactor: Simplify t4c services and enhance code maintainability

### DIFF
--- a/backend/capellacollab/settings/modelsources/t4c/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/crud.py
@@ -54,6 +54,8 @@ def update_t4c_instance(
     instance: models.DatabaseT4CInstance,
     patch_t4c_instance: models.PatchT4CInstance,
 ):
+    if patch_t4c_instance.password == "":
+        patch_t4c_instance.password = None
     database.patch_database_with_pydantic_object(instance, patch_t4c_instance)
 
     db.commit()

--- a/backend/tests/settings/test_t4c_instances.py
+++ b/backend/tests/settings/test_t4c_instances.py
@@ -106,6 +106,31 @@ def test_patch_t4c_instance(
     assert t4c_instance.host == "localhost"
 
 
+def test_update_t4c_instance_password_empty_string(
+    client: testclient.TestClient,
+    db: orm.Session,
+    executor_name: str,
+    t4c_server: t4c_models.DatabaseT4CInstance,
+):
+    users_crud.create_user(db, executor_name, users_models.Role.ADMIN)
+
+    expected_password = t4c_server.password
+
+    response = client.patch(
+        f"/api/v1/settings/modelsources/t4c/{t4c_server.id}",
+        json={
+            "password": "",
+        },
+    )
+
+    updated_t4c_server = t4c_crud.get_t4c_instance_by_id(
+        db, response.json()["id"]
+    )
+
+    assert updated_t4c_server
+    assert updated_t4c_server.password == expected_password
+
+
 @responses.activate
 def test_get_t4c_license_usage(
     client: testclient.TestClient,

--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
@@ -11,7 +11,7 @@
         Please select a T4C model:
         <mat-selection-list formControlName="t4cmodel" [multiple]="false">
           <mat-list-option
-            *ngFor="let t4cModel of t4cModelService.t4cModels"
+            *ngFor="let t4cModel of t4cModelService.t4cModels | async"
             [value]="t4cModel.id"
           >
             <div mat-line>TeamForCapella model '{{ t4cModel.name }}'</div>

--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.ts
@@ -43,9 +43,11 @@ export class CreateBackupComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.t4cModelService
-      .listT4CModels(this.data.projectSlug, this.data.modelSlug)
-      .subscribe();
+    this.t4cModelService.loadT4CModels(
+      this.data.projectSlug,
+      this.data.modelSlug
+    );
+
     this.gitModelService.loadGitModels(
       this.data.projectSlug,
       this.data.modelSlug
@@ -53,7 +55,7 @@ export class CreateBackupComponent implements OnInit {
 
     combineLatest([
       this.gitModelService.gitModels,
-      this.t4cModelService._t4cModels.asObservable(),
+      this.t4cModelService.t4cModels,
     ])
       .pipe(untilDestroyed(this))
       .subscribe(

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.html
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.html
@@ -31,10 +31,10 @@
     <app-mat-card-overview-skeleton-loader
       [rows]="1"
       [reservedCards]="2"
-      [loading]="gitModels === undefined"
+      [loading]="(gitModelService.gitModels | async) === undefined"
     ></app-mat-card-overview-skeleton-loader>
     <a
-      *ngFor="let gitModel of gitModels"
+      *ngFor="let gitModel of gitModelService.gitModels | async"
       [routerLink]="['..', 'git-model', gitModel.id]"
     >
       <mat-card matRipple class="mat-card-overview">
@@ -72,7 +72,7 @@
       </div>
     </mat-card>
     <a
-      *ngFor="let t4cModel of t4cModels"
+      *ngFor="let t4cModel of t4cModelService.t4cModels | async"
       [routerLink]="['..', 't4c-model', t4cModel.id]"
     >
       <mat-card matRipple class="mat-card-overview">
@@ -87,7 +87,7 @@
     <app-mat-card-overview-skeleton-loader
       [rows]="1"
       [reservedCards]="2"
-      [loading]="t4cModels === undefined"
+      [loading]="(t4cModelService.t4cModels | async) === undefined"
     ></app-mat-card-overview-skeleton-loader>
   </div>
 </div>

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.ts
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.ts
@@ -38,7 +38,7 @@ export class ModelDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.gitModelService.clear();
+    this.gitModelService.reset();
     this.t4cModelService.reset();
   }
 }

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.ts
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.ts
@@ -6,15 +6,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { combineLatest, filter } from 'rxjs';
-import {
-  T4CModel,
-  T4CModelService,
-} from 'src/app/projects/models/model-source/t4c/service/t4c-model.service';
+import { T4CModelService } from 'src/app/projects/models/model-source/t4c/service/t4c-model.service';
 import { ModelService } from 'src/app/projects/models/service/model.service';
-import {
-  GetGitModel,
-  GitModelService,
-} from 'src/app/projects/project-detail/model-overview/model-detail/git-model.service';
+import { GitModelService } from 'src/app/projects/project-detail/model-overview/model-detail/git-model.service';
 import { ProjectService } from '../../service/project.service';
 
 @UntilDestroy()
@@ -24,37 +18,27 @@ import { ProjectService } from '../../service/project.service';
   styleUrls: ['./model-detail.component.css'],
 })
 export class ModelDetailComponent implements OnInit, OnDestroy {
-  public gitModels?: GetGitModel[] = undefined;
-  public t4cModels?: T4CModel[] = undefined;
-
   constructor(
-    private gitModelService: GitModelService,
-    public modelService: ModelService,
     public projectService: ProjectService,
-    private t4cModelService: T4CModelService
+    public modelService: ModelService,
+    public gitModelService: GitModelService,
+    public t4cModelService: T4CModelService
   ) {}
 
   ngOnInit(): void {
-    this.gitModelService.gitModels
-      .pipe(untilDestroyed(this))
-      .subscribe((gitModels) => (this.gitModels = gitModels));
-
     combineLatest([
       this.projectService.project.pipe(filter(Boolean)),
       this.modelService.model.pipe(filter(Boolean)),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([project, model]) => {
-        this.t4cModelService
-          .listT4CModels(project.slug, model.slug)
-          .subscribe((models) => (this.t4cModels = models));
-
+        this.t4cModelService.loadT4CModels(project.slug, model.slug);
         this.gitModelService.loadGitModels(project.slug, model.slug);
       });
   }
 
   ngOnDestroy(): void {
     this.gitModelService.clear();
-    this.t4cModelService.clear();
+    this.t4cModelService.reset();
   }
 }

--- a/frontend/src/app/projects/models/model-detail/t4c-model-wrapper/t4c-model-wrapper.component.ts
+++ b/frontend/src/app/projects/models/model-detail/t4c-model-wrapper/t4c-model-wrapper.component.ts
@@ -32,9 +32,11 @@ export class T4cModelWrapperComponent implements OnInit, OnDestroy {
       this.projectService.project.pipe(filter(Boolean)),
       this.modelService.model.pipe(filter(Boolean)),
       this.route.params.pipe(map((params) => parseInt(params.t4c_model_id))),
-    ]).subscribe(([project, model, t4cModelId]) =>
-      this.t4cModelService.loadT4CModel(project.slug, model.slug, t4cModelId)
-    );
+    ])
+      .pipe(untilDestroyed(this))
+      .subscribe(([project, model, t4cModelId]) =>
+        this.t4cModelService.loadT4CModel(project.slug, model.slug, t4cModelId)
+      );
 
     this.t4cModelService.t4cModel
       .pipe(untilDestroyed(this))

--- a/frontend/src/app/projects/models/model-detail/t4c-model-wrapper/t4c-model-wrapper.component.ts
+++ b/frontend/src/app/projects/models/model-detail/t4c-model-wrapper/t4c-model-wrapper.component.ts
@@ -6,7 +6,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { combineLatest, filter, map, switchMap } from 'rxjs';
+import { combineLatest, filter, map } from 'rxjs';
 import { BreadcrumbsService } from 'src/app/general/breadcrumbs/breadcrumbs.service';
 import { T4CModelService } from 'src/app/projects/models/model-source/t4c/service/t4c-model.service';
 import { ModelService } from 'src/app/projects/models/service/model.service';
@@ -32,21 +32,19 @@ export class T4cModelWrapperComponent implements OnInit, OnDestroy {
       this.projectService.project.pipe(filter(Boolean)),
       this.modelService.model.pipe(filter(Boolean)),
       this.route.params.pipe(map((params) => parseInt(params.t4c_model_id))),
-    ])
-      .pipe(
-        untilDestroyed(this),
-        switchMap(([project, model, t4cModelId]) =>
-          this.t4cModelService.getT4CModel(project.slug, model.slug, t4cModelId)
-        )
-      )
-      .subscribe((t4cModel) => {
-        this.t4cModelService._t4cModel.next(t4cModel);
-        this.breadCrumbsService.updatePlaceholder({ t4cModel });
-      });
+    ]).subscribe(([project, model, t4cModelId]) =>
+      this.t4cModelService.loadT4CModel(project.slug, model.slug, t4cModelId)
+    );
+
+    this.t4cModelService.t4cModel
+      .pipe(untilDestroyed(this))
+      .subscribe((t4cModel) =>
+        this.breadCrumbsService.updatePlaceholder({ t4cModel })
+      );
   }
 
   ngOnDestroy(): void {
-    this.t4cModelService._t4cModel.next(undefined);
+    this.t4cModelService.reset();
     this.breadCrumbsService.updatePlaceholder({ t4cModel: undefined });
   }
 }

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
@@ -10,14 +10,19 @@
   <mat-card class="section-card">
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <fieldset>
-        <app-form-field-skeleton-loader *ngIf="loading">
+        <app-form-field-skeleton-loader
+          *ngIf="(t4cInstanceService.t4cInstances | async) === undefined"
+        >
         </app-form-field-skeleton-loader>
 
-        <mat-form-field *ngIf="!loading" appearance="fill">
+        <mat-form-field
+          *ngIf="(t4cInstanceService.t4cInstances | async) !== undefined"
+          appearance="fill"
+        >
           <mat-label>Instance</mat-label>
           <mat-select formControlName="t4cInstanceId">
             <mat-option
-              *ngFor="let instance of t4cInstances"
+              *ngFor="let instance of t4cInstanceService.t4cInstances | async"
               [value]="instance.id"
             >
               {{ instance.name }}
@@ -29,13 +34,20 @@
         </mat-form-field>
       </fieldset>
       <fieldset>
-        <app-form-field-skeleton-loader *ngIf="loading">
+        <app-form-field-skeleton-loader
+          *ngIf="(t4cInstanceService.t4cInstances | async) === undefined"
+        >
         </app-form-field-skeleton-loader>
-        <mat-form-field *ngIf="!loading" appearance="fill">
+        <mat-form-field
+          *ngIf="(t4cInstanceService.t4cInstances | async) !== undefined"
+          appearance="fill"
+        >
           <mat-label>Repository</mat-label>
           <mat-select formControlName="t4cRepositoryId">
             <mat-option
-              *ngFor="let repository of t4cRepositories"
+              *ngFor="
+                let repository of t4cRepositoryService.repositories | async
+              "
               [value]="repository.id"
             >
               {{ repository.name }}
@@ -72,7 +84,7 @@
           Choose primary source
         </button>
         <button
-          *ngIf="editing"
+          *ngIf="t4cModel !== undefined"
           (click)="unlinkT4CModel()"
           mat-flat-button
           color="warn"

--- a/frontend/src/app/projects/models/model-wrapper/model-wrapper.component.ts
+++ b/frontend/src/app/projects/models/model-wrapper/model-wrapper.component.ts
@@ -47,6 +47,6 @@ export class ModelWrapperComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.breadcrumbService.updatePlaceholder({ model: undefined });
     this.modelService.clearModel();
-    this.t4cModelService._t4cModels.next(undefined);
+    this.t4cModelService.reset();
   }
 }

--- a/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
@@ -109,7 +109,7 @@ export class GitModelService {
     );
   }
 
-  clear() {
+  reset() {
     this._gitModels.next(undefined);
     this._gitModel.next(undefined);
   }

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -41,7 +41,11 @@ export type T4CInstance = NewT4CInstance & {
 export class T4CInstanceService {
   constructor(private http: HttpClient) {}
 
-  base_url = `${environment.backend_url}/settings/modelsources/t4c`;
+  baseUrl = `${environment.backend_url}/settings/modelsources/t4c`;
+
+  urlFactory(instanceId: number): string {
+    return `${this.baseUrl}/${instanceId}`;
+  }
 
   private _t4cInstances = new BehaviorSubject<T4CInstance[] | undefined>(
     undefined
@@ -54,21 +58,21 @@ export class T4CInstanceService {
   readonly t4cInstance = this._t4cInstance.asObservable();
 
   loadInstances(): void {
-    this.http.get<T4CInstance[]>(this.base_url).subscribe({
+    this.http.get<T4CInstance[]>(this.baseUrl).subscribe({
       next: (instances) => this._t4cInstances.next(instances),
       error: () => this._t4cInstances.next(undefined),
     });
   }
 
-  loadInstance(id: number): void {
-    this.http.get<T4CInstance>(this.base_url + '/' + id).subscribe({
+  loadInstance(instanceId: number): void {
+    this.http.get<T4CInstance>(this.urlFactory(instanceId)).subscribe({
       next: (instance) => this._t4cInstance.next(instance),
       error: () => this._t4cInstance.next(undefined),
     });
   }
 
   createInstance(instance: NewT4CInstance): Observable<T4CInstance> {
-    return this.http.post<T4CInstance>(this.base_url, instance).pipe(
+    return this.http.post<T4CInstance>(this.baseUrl, instance).pipe(
       tap((instance) => {
         this._t4cInstance.next(instance);
         this.loadInstances();
@@ -77,11 +81,11 @@ export class T4CInstanceService {
   }
 
   updateInstance(
-    id: number,
+    instanceId: number,
     instance: BaseT4CInstance
   ): Observable<T4CInstance> {
     return this.http
-      .patch<T4CInstance>(this.base_url + '/' + id, instance)
+      .patch<T4CInstance>(this.urlFactory(instanceId), instance)
       .pipe(
         tap((instance) => {
           this._t4cInstance.next(instance);
@@ -95,9 +99,9 @@ export class T4CInstanceService {
     this._t4cInstances.next(undefined);
   }
 
-  getLicenses(t4cInstanceId: number): Observable<SessionUsage> {
+  getLicenses(instanceId: number): Observable<SessionUsage> {
     return this.http.get<SessionUsage>(
-      `${this.base_url}/${t4cInstanceId}/licenses`
+      `${this.urlFactory(instanceId)}/licenses`
     );
   }
 }

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -20,7 +20,7 @@
             <mat-label>Capella version</mat-label>
             <mat-select formControlName="version_id">
               <mat-option
-                *ngFor="let version of capella_versions"
+                *ngFor="let version of capellaVersions"
                 [value]="version.id"
               >
                 {{ version.name }}
@@ -180,7 +180,9 @@
     class="flex flex-col flex-wrap"
     *ngIf="(t4cInstanceService.t4cInstance | async) !== undefined"
   >
-    <app-licences [instance]="instance"></app-licences>
+    <app-licences
+      [instance]="(t4cInstanceService.t4cInstance | async)!"
+    ></app-licences>
     <app-t4c-instance-settings
       [instance]="(t4cInstanceService.t4cInstance | async)!"
     ></app-t4c-instance-settings>

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -27,7 +27,11 @@
               </mat-option>
             </mat-select>
             <mat-hint
-              *ngIf="instance && instance.version.id !== form.value.version_id"
+              *ngIf="
+                (t4cInstanceService.t4cInstance | async) !== undefined &&
+                (t4cInstanceService.t4cInstance | async)!.version.id !==
+                  form.value.version_id
+              "
               >Models are not auto-migrated on version change.</mat-hint
             >
             <mat-error *ngIf="form.controls.version_id.errors?.required">
@@ -172,11 +176,13 @@
     </mat-card>
   </div>
 
-  <div class="flex flex-col flex-wrap">
-    <app-licences *ngIf="this.instance" [instance]="instance"></app-licences>
+  <div
+    class="flex flex-col flex-wrap"
+    *ngIf="(t4cInstanceService.t4cInstance | async) !== undefined"
+  >
+    <app-licences [instance]="instance"></app-licences>
     <app-t4c-instance-settings
-      *ngIf="this.instance"
-      [instance]="instance"
+      [instance]="(t4cInstanceService.t4cInstance | async)!"
     ></app-t4c-instance-settings>
   </div>
 </div>

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -32,7 +32,7 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
   existing = false;
 
   instanceId?: number;
-  capella_versions?: ToolVersion[];
+  capellaVersions?: ToolVersion[];
 
   public form = new FormGroup({
     name: new FormControl('', Validators.required),
@@ -98,9 +98,7 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
     this.toolService
       .getVersionsForTool(1)
       .pipe(filter(Boolean))
-      .subscribe(
-        (capella_versions) => (this.capella_versions = capella_versions)
-      );
+      .subscribe((capellaVersions) => (this.capellaVersions = capellaVersions));
   }
 
   enableEditing(): void {

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
@@ -9,7 +9,7 @@
     <button
       mat-icon-button
       [disabled]="!instance"
-      (click)="refreshRepositories()"
+      (click)="this.t4cRepoService.refreshRepositories(instance!.id)"
     >
       <mat-icon>sync</mat-icon>
     </button>
@@ -40,7 +40,7 @@
   </form>
   <mat-selection-list #repositoryList [multiple]="false" class="user-selection">
     <mat-list-option
-      *ngFor="let repository of t4cRepoService.repositories"
+      *ngFor="let repository of t4cRepoService.repositories | async"
       [value]="repository"
     >
       <mat-icon mat-list-icon *ngIf="repository.status === 'LOADING'"
@@ -77,7 +77,7 @@
       <button
         mat-flat-button
         color="warn"
-        (click)="removeRepository(selectedRepository)"
+        (click)="deleteRepository(selectedRepository)"
       >
         <mat-icon>delete</mat-icon> Remove {{ selectedRepository.name }}
       </button>

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
@@ -21,7 +21,7 @@
   </a>
 
   <a
-    *ngFor="let instance of instances"
+    *ngFor="let instance of t4cInstanceService.t4cInstances | async"
     [routerLink]="['instance', instance.id]"
   >
     <mat-card matRipple class="mat-card-overview">

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.ts
@@ -3,29 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
-import {
-  T4CInstance,
-  T4CInstanceService,
-} from 'src/app/services/settings/t4c-instance.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { T4CInstanceService } from 'src/app/services/settings/t4c-instance.service';
 
 @Component({
   selector: 'app-t4c-settings',
   templateUrl: './t4c-settings.component.html',
   styleUrls: ['./t4c-settings.component.css'],
 })
-export class T4CSettingsComponent implements OnInit {
-  _instances = new BehaviorSubject<T4CInstance[] | undefined>(undefined);
-  get instances() {
-    return this._instances.value;
-  }
-
-  constructor(private t4CInstanceService: T4CInstanceService) {}
+export class T4CSettingsComponent implements OnInit, OnDestroy {
+  constructor(public t4cInstanceService: T4CInstanceService) {}
 
   ngOnInit(): void {
-    this.t4CInstanceService.listInstances().subscribe((res) => {
-      this._instances.next(res);
-    });
+    this.t4cInstanceService.loadInstances();
+  }
+
+  ngOnDestroy(): void {
+    this.t4cInstanceService.reset();
   }
 }


### PR DESCRIPTION
This PR simplifies the logic within the t4c model, t4c repository and t4c instance services by moving it from components to services. This change is significant as it reduces the complexity of the components, making the code easier to maintain and read. 

**Main changes include:**

- Adoption of the BehaviourSubject workflow within services.
- Reduction of reliance on rxjs within components.
- Removal of complex constructs such as `switchMaps`.

Through these changes, we've made the code more maintainable and readable, enhancing overall code quality.
