### PR TITLE
Bump OAuth mock version

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,7 +47,7 @@ docker:
     grafana: /grafana/grafana
 
     mocks:
-      oauth: ghcr.io/navikt/mock-oauth2-server:0.4.4
+      oauth: ghcr.io/navikt/mock-oauth2-server:0.5.8
 
 general:
   # Base URL on which the service listens

--- a/mocks/oauth/Makefile
+++ b/mocks/oauth/Makefile
@@ -20,7 +20,7 @@ start:
 		-v $$(pwd)/conf.json:/opt/conf.json \
 		-p 8083:8080 \
 		-e JSON_CONFIG_PATH=/opt/conf.json \
-		ghcr.io/navikt/mock-oauth2-server:0.4.4
+		ghcr.io/navikt/mock-oauth2-server:0.5.8
 
 stop:
 	docker stop oauth-mock && \


### PR DESCRIPTION
The OAuth mock can sometimes be really unstable. Let's hope that the new version makes it better. 
One huge advantage is arm64 support.

Should also increase stability during the onboarding, related to #745 