### PR TITLE
refactor: Use `$` as suffix for observable variables

### DIFF
--- a/frontend/src/app/projects/create-project/create-project.component.html
+++ b/frontend/src/app/projects/create-project/create-project.component.html
@@ -90,7 +90,7 @@
     </mat-step>
 
     <mat-step label="Add team members">
-      <div *ngIf="projectService.project | async" class="flex-center">
+      <div *ngIf="projectService.project$ | async" class="flex-center">
         <div>
           <app-project-user-settings></app-project-user-settings>
           <mat-card class="mat-card-default">
@@ -124,7 +124,7 @@
               mat-flat-button
               [routerLink]="[
                 '/project',
-                (projectService.project | async)?.slug
+                (projectService.project$ | async)?.slug
               ]"
               [color]="getColorByModelCreationStep()"
               data-testId="a-skipModelAndFinishProjectCreation"

--- a/frontend/src/app/projects/create-project/create-project.component.spec.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.spec.ts
@@ -67,11 +67,11 @@ describe('CreateProjectComponent', () => {
     _project: new BehaviorSubject<Project | undefined>(undefined),
     _projects: new BehaviorSubject<Project[] | undefined>(undefined),
 
-    get project(): Observable<Project | undefined> {
+    get project$(): Observable<Project | undefined> {
       return this._project.asObservable();
     },
 
-    get projects(): Observable<Project[] | undefined> {
+    get projects$(): Observable<Project[] | undefined> {
       return this._projects.asObservable();
     },
 
@@ -98,7 +98,7 @@ describe('CreateProjectComponent', () => {
         control: AbstractControl
       ): Observable<ValidationErrors | null> => {
         const projectSlug = slugify(control.value, { lower: true });
-        return this.projects.pipe(
+        return this.projects$.pipe(
           take(1),
           map((projects) => {
             return projects?.find((project) => project.slug === projectSlug)

--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
@@ -11,7 +11,7 @@
         Please select a T4C model:
         <mat-selection-list formControlName="t4cmodel" [multiple]="false">
           <mat-list-option
-            *ngFor="let t4cModel of t4cModelService.t4cModels | async"
+            *ngFor="let t4cModel of t4cModelService.t4cModels$ | async"
             [value]="t4cModel.id"
           >
             <div mat-line>TeamForCapella model '{{ t4cModel.name }}'</div>
@@ -28,7 +28,7 @@
         Please select a Git model:
         <mat-selection-list formControlName="gitmodel" [multiple]="false">
           <mat-list-option
-            *ngFor="let gitModel of gitModelService.gitModels | async"
+            *ngFor="let gitModel of gitModelService.gitModels$ | async"
             [value]="gitModel.id"
           >
             <div mat-line>Git model {{ gitModel.id }}</div>

--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.ts
@@ -54,8 +54,8 @@ export class CreateBackupComponent implements OnInit {
     );
 
     combineLatest([
-      this.gitModelService.gitModels,
-      this.t4cModelService.t4cModels,
+      this.gitModelService.gitModels$,
+      this.t4cModelService.t4cModels$,
     ])
       .pipe(untilDestroyed(this))
       .subscribe(

--- a/frontend/src/app/projects/models/backup-settings/job-run-overview/job-run-overview.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/job-run-overview/job-run-overview.component.ts
@@ -43,9 +43,9 @@ export class JobRunOverviewComponent implements OnInit, AfterViewInit {
 
   ngOnInit() {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
-      this.pipelineService.pipeline.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
+      this.pipelineService.pipeline$.pipe(filter(Boolean)),
     ]).subscribe(([project, model, pipeline]) => {
       this.pipelineRunService.loadPipelineRuns(
         project.slug,
@@ -59,9 +59,9 @@ export class JobRunOverviewComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
-      this.pipelineService.pipeline.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
+      this.pipelineService.pipeline$.pipe(filter(Boolean)),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([project, model, pipeline]) => {

--- a/frontend/src/app/projects/models/backup-settings/pipeline-runs/service/pipeline-run.service.ts
+++ b/frontend/src/app/projects/models/backup-settings/pipeline-runs/service/pipeline-run.service.ts
@@ -60,7 +60,7 @@ export class PipelineRunService {
   }
 
   resetPipelineRunsOnPipelineChange() {
-    this.pipelineService.pipeline.subscribe(() => {
+    this.pipelineService.pipeline$.subscribe(() => {
       this.resetPipelineRuns();
     });
   }

--- a/frontend/src/app/projects/models/backup-settings/pipeline-runs/wrapper/pipeline-run-wrapper/pipeline-run-wrapper.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/pipeline-runs/wrapper/pipeline-run-wrapper/pipeline-run-wrapper.component.ts
@@ -30,7 +30,7 @@ export class PipelineRunWrapperComponent implements OnDestroy {
   ) {
     // Reset pipeline runs on pipeline or pipelineRunID change
     combineLatest([
-      this.pipelineService.pipeline.pipe(
+      this.pipelineService.pipeline$.pipe(
         filter((pipeline) => pipeline === undefined)
       ),
       this.route.params.pipe(
@@ -53,9 +53,9 @@ export class PipelineRunWrapperComponent implements OnDestroy {
 
   updatePipelineRun() {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
-      this.pipelineService.pipeline.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
+      this.pipelineService.pipeline$.pipe(filter(Boolean)),
       this.route.params.pipe(map((params) => params.pipelineRun as number)),
     ])
       .pipe(untilDestroyed(this))

--- a/frontend/src/app/projects/models/backup-settings/service/pipeline.service.ts
+++ b/frontend/src/app/projects/models/backup-settings/service/pipeline.service.ts
@@ -20,11 +20,11 @@ export class PipelineService {
     private breadcrumbsService: BreadcrumbsService
   ) {}
 
-  _pipelines = new BehaviorSubject<Pipeline[] | undefined>(undefined);
-  _pipeline = new BehaviorSubject<Pipeline | undefined>(undefined);
+  private _pipelines = new BehaviorSubject<Pipeline[] | undefined>(undefined);
+  private _pipeline = new BehaviorSubject<Pipeline | undefined>(undefined);
 
-  pipelines = this._pipelines.asObservable();
-  pipeline = this._pipeline.asObservable();
+  public readonly pipelines$ = this._pipelines.asObservable();
+  public readonly pipeline$ = this._pipeline.asObservable();
 
   urlFactory(projectSlug: string, modelSlug: string): string {
     return `${environment.backend_url}/projects/${projectSlug}/models/${modelSlug}/backups/pipelines`;

--- a/frontend/src/app/projects/models/backup-settings/trigger-pipeline/trigger-pipeline.component.html
+++ b/frontend/src/app/projects/models/backup-settings/trigger-pipeline/trigger-pipeline.component.html
@@ -14,7 +14,7 @@
       >
     </div>
     <div class="pipelines">
-      <div *ngFor="let pipeline of this.pipelineService.pipelines | async">
+      <div *ngFor="let pipeline of this.pipelineService.pipelines$ | async">
         <mat-card
           matRipple
           *ngIf="!selectedPipeline || selectedPipeline.id === pipeline.id"
@@ -59,7 +59,7 @@
     </div>
     <div
       class="margin default"
-      *ngIf="(this.pipelineService.pipelines | async)?.length === 0"
+      *ngIf="(this.pipelineService.pipelines$ | async)?.length === 0"
     >
       No pipelines found. Please create a new pipeline.
     </div>

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.ts
@@ -34,9 +34,9 @@ export class ViewLogsDialogComponent {
 
   refreshEvents(): void {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
-      this.pipelineService.pipeline.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
+      this.pipelineService.pipeline$.pipe(filter(Boolean)),
       this.pipelineRunService.pipelineRun$.pipe(filter(Boolean)),
     ])
       .pipe(
@@ -62,9 +62,9 @@ export class ViewLogsDialogComponent {
 
   refreshLogs(): void {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
-      this.pipelineService.pipeline.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
+      this.pipelineService.pipeline$.pipe(filter(Boolean)),
       this.pipelineRunService.pipelineRun$.pipe(filter(Boolean)),
     ])
       .pipe(

--- a/frontend/src/app/projects/models/backup-settings/wrapper/pipeline-wrapper/pipeline-wrapper.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/wrapper/pipeline-wrapper/pipeline-wrapper.component.ts
@@ -29,7 +29,7 @@ export class PipelineWrapperComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     // Reset pipeline runs on pipeline change
-    this.modelService.model.pipe(
+    this.modelService.model$.pipe(
       filter((model) => model === undefined),
       tap(() => {
         this.pipelineService.resetPipeline();
@@ -45,8 +45,8 @@ export class PipelineWrapperComponent implements OnInit, OnDestroy {
       });
 
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
       this.route.params.pipe(
         map((params) => params.pipeline as number),
         filter(Boolean)

--- a/frontend/src/app/projects/models/choose-init/choose-init.component.html
+++ b/frontend/src/app/projects/models/choose-init/choose-init.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div *ngIf="(projectService.project | async) && (modelService.model | async)">
+<div *ngIf="(projectService.project$ | async) && (modelService.model$ | async)">
   <div class="flex-center">
     <div class="field-separator"></div>
     <button mat-raised-button (click)="modelInitSelection.emit('create-empty')">

--- a/frontend/src/app/projects/models/create-model-base/create-model-base.component.html
+++ b/frontend/src/app/projects/models/create-model-base/create-model-base.component.html
@@ -4,7 +4,7 @@
  -->
 
 <div class="flex-center">
-  <mat-card *ngIf="projectService.project | async">
+  <mat-card *ngIf="projectService.project$ | async">
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <fieldset class="flex flex-wrap">
         <mat-form-field appearance="fill">

--- a/frontend/src/app/projects/models/create-model-base/create-model-base.component.ts
+++ b/frontend/src/app/projects/models/create-model-base/create-model-base.component.ts
@@ -56,7 +56,7 @@ export class CreateModelBaseComponent implements OnInit {
     this.toolService.getTools().subscribe();
     this.modelService.clearModel();
 
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this))
       .subscribe((project) => (this.projectSlug = project?.slug));
   }

--- a/frontend/src/app/projects/models/create-model/create-model.component.ts
+++ b/frontend/src/app/projects/models/create-model/create-model.component.ts
@@ -43,7 +43,7 @@ export class CreateModelComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this))
       .subscribe((project) => (this.projectSlug = project?.slug));
   }

--- a/frontend/src/app/projects/models/init-model/init-model.component.html
+++ b/frontend/src/app/projects/models/init-model/init-model.component.html
@@ -4,14 +4,14 @@
  -->
 
 <div class="wrapper flex flex-center">
-  <mat-card *ngIf="modelService.model | async">
+  <mat-card *ngIf="modelService.model$ | async">
     <form [formGroup]="form">
       <fieldset class="flex flex-wrap gap-2">
         <mat-form-field appearance="fill">
           <mat-label>Modelling tool</mat-label>
           <input
             matInput
-            [value]="(modelService.model | async)!.tool.name"
+            [value]="(modelService.model$ | async)!.tool.name"
             disabled
           />
         </mat-form-field>

--- a/frontend/src/app/projects/models/init-model/init-model.component.ts
+++ b/frontend/src/app/projects/models/init-model/init-model.component.ts
@@ -54,7 +54,7 @@ export class InitModelComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    this.modelService.model
+    this.modelService.model$
       .pipe(
         untilDestroyed(this),
         filter(Boolean),
@@ -80,7 +80,7 @@ export class InitModelComponent implements OnInit {
         this.toolNatures = result[1];
       });
 
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this))
       .subscribe((project) => (this.projectSlug = project?.slug));
   }

--- a/frontend/src/app/projects/models/model-description/model-description.component.html
+++ b/frontend/src/app/projects/models/model-description/model-description.component.html
@@ -4,8 +4,8 @@
  -->
 
 <div class="wrapper flex flex-center">
-  <mat-card *ngIf="modelService.model | async" class="basis-1 grow">
-    <mat-card-title>{{ (modelService.model | async)!.name }}</mat-card-title>
+  <mat-card *ngIf="modelService.model$ | async" class="basis-1 grow">
+    <mat-card-title>{{ (modelService.model$ | async)!.name }}</mat-card-title>
     <form (submit)="onSubmit()" [formGroup]="form">
       <fieldset>
         <mat-form-field appearance="fill">

--- a/frontend/src/app/projects/models/model-description/model-description.component.ts
+++ b/frontend/src/app/projects/models/model-description/model-description.component.ts
@@ -47,7 +47,7 @@ export class ModelDescriptionComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.modelService.model
+    this.modelService.model$
       .pipe(
         untilDestroyed(this),
         filter(Boolean),
@@ -75,7 +75,7 @@ export class ModelDescriptionComponent implements OnInit {
         this.toolVersions = result[1];
       });
 
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this))
       .subscribe((project) => (this.projectSlug = project?.slug));
   }

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.html
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.html
@@ -5,7 +5,7 @@
 
 <div
   class="wrapper"
-  *ngIf="(projectService.project | async) && (modelService.model | async)"
+  *ngIf="(projectService.project$ | async) && (modelService.model$ | async)"
 >
   <h1 class="title">Git Models</h1>
   <div class="flex">
@@ -31,10 +31,10 @@
     <app-mat-card-overview-skeleton-loader
       [rows]="1"
       [reservedCards]="2"
-      [loading]="(gitModelService.gitModels | async) === undefined"
+      [loading]="(gitModelService.gitModels$ | async) === undefined"
     ></app-mat-card-overview-skeleton-loader>
     <a
-      *ngFor="let gitModel of gitModelService.gitModels | async"
+      *ngFor="let gitModel of gitModelService.gitModels$ | async"
       [routerLink]="['..', 'git-model', gitModel.id]"
     >
       <mat-card matRipple class="mat-card-overview">
@@ -72,7 +72,7 @@
       </div>
     </mat-card>
     <a
-      *ngFor="let t4cModel of t4cModelService.t4cModels | async"
+      *ngFor="let t4cModel of t4cModelService.t4cModels$ | async"
       [routerLink]="['..', 't4c-model', t4cModel.id]"
     >
       <mat-card matRipple class="mat-card-overview">
@@ -87,7 +87,7 @@
     <app-mat-card-overview-skeleton-loader
       [rows]="1"
       [reservedCards]="2"
-      [loading]="(t4cModelService.t4cModels | async) === undefined"
+      [loading]="(t4cModelService.t4cModels$ | async) === undefined"
     ></app-mat-card-overview-skeleton-loader>
   </div>
 </div>

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.ts
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.ts
@@ -27,8 +27,8 @@ export class ModelDetailComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([project, model]) => {

--- a/frontend/src/app/projects/models/model-detail/t4c-model-wrapper/t4c-model-wrapper.component.ts
+++ b/frontend/src/app/projects/models/model-detail/t4c-model-wrapper/t4c-model-wrapper.component.ts
@@ -29,8 +29,8 @@ export class T4CModelWrapperComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
       this.route.params.pipe(map((params) => parseInt(params.t4c_model_id))),
     ])
       .pipe(untilDestroyed(this))
@@ -38,7 +38,7 @@ export class T4CModelWrapperComponent implements OnInit, OnDestroy {
         this.t4cModelService.loadT4CModel(project.slug, model.slug, t4cModelId)
       );
 
-    this.t4cModelService.t4cModel
+    this.t4cModelService.t4cModel$
       .pipe(untilDestroyed(this))
       .subscribe((t4cModel) =>
         this.breadCrumbsService.updatePlaceholder({ t4cModel })

--- a/frontend/src/app/projects/models/model-restrictions/model-restrictions.component.html
+++ b/frontend/src/app/projects/models/model-restrictions/model-restrictions.component.html
@@ -4,10 +4,10 @@
  -->
 
 <div class="wrapper flex-center">
-  <mat-card *ngIf="modelService.model | async">
+  <mat-card *ngIf="modelService.model$ | async">
     <mat-card-title>Restrictions for models</mat-card-title>
     <form
-      *ngIf="(modelService.model | async)!.tool.integrations.pure_variants"
+      *ngIf="(modelService.model$ | async)!.tool.integrations.pure_variants"
       [formGroup]="restrictionsForm"
     >
       <ng-template #pureVariants>
@@ -21,7 +21,9 @@
         <ng-template [ngTemplateOutlet]="pureVariants"> </ng-template>
       </mat-checkbox>
     </form>
-    <div *ngIf="!(modelService.model | async)!.tool.integrations.pure_variants">
+    <div
+      *ngIf="!(modelService.model$ | async)!.tool.integrations.pure_variants"
+    >
       This model has no restrictions. Please check the documentation for more
       information.
     </div>

--- a/frontend/src/app/projects/models/model-restrictions/model-restrictions.component.ts
+++ b/frontend/src/app/projects/models/model-restrictions/model-restrictions.component.ts
@@ -46,14 +46,14 @@ export class ModelRestrictionsComponent implements OnInit {
       this.patchRestrictions();
     });
 
-    this.modelService.model
+    this.modelService.model$
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe((model) => {
         this.model = model;
         this.updateRestrictionsForm(model.restrictions);
       });
 
-    this.projectService.project.subscribe(
+    this.projectService.project$.subscribe(
       (project) => (this.projectSlug = project?.slug)
     );
   }

--- a/frontend/src/app/projects/models/model-source/choose-source.component.html
+++ b/frontend/src/app/projects/models/model-source/choose-source.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div *ngIf="(projectService.project | async) && (modelService.model | async)">
+<div *ngIf="(projectService.project$ | async) && (modelService.model$ | async)">
   <h2 class="title text-center">Git sources</h2>
   <div class="flex justify-center flex-wrap">
     <a (click)="modelSourceSelection.emit('git-add')">
@@ -21,7 +21,7 @@
 
   <div
     *ngIf="
-      (modelService.model | async)!.tool?.integrations?.t4c &&
+      (modelService.model$ | async)!.tool?.integrations?.t4c &&
       userService.user?.role === 'administrator'
     "
   >

--- a/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.component.html
+++ b/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div *ngIf="(projectService.project | async) && (modelService.model | async)">
+<div *ngIf="(projectService.project$ | async) && (modelService.model$ | async)">
   <mat-card class="w-fit">
     <form [formGroup]="form">
       <div formGroupName="urls">

--- a/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.component.ts
+++ b/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.component.ts
@@ -112,7 +112,7 @@ export class ManageGitModelComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.gitService.revisions.pipe(untilDestroyed(this)).subscribe({
+    this.gitService.revisions$.pipe(untilDestroyed(this)).subscribe({
       next: (revisions) => {
         this.revisions = revisions;
         this.filteredRevisions = revisions;
@@ -125,7 +125,7 @@ export class ManageGitModelComponent implements OnInit, OnDestroy {
       this.filteredRevisionsByPrefix(value as string)
     );
 
-    this.gitInstancesService.gitInstances
+    this.gitInstancesService.gitInstances$
       .pipe(untilDestroyed(this))
       .subscribe((gitInstances) => {
         this.availableGitInstances = gitInstances;
@@ -141,7 +141,7 @@ export class ManageGitModelComponent implements OnInit, OnDestroy {
         }
       });
 
-    this.modelService.model
+    this.modelService.model$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((model) => {
         this.modelSlug = model.slug;
@@ -152,7 +152,7 @@ export class ManageGitModelComponent implements OnInit, OnDestroy {
         }
       });
 
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((project) => {
         this.projectSlug = project.slug;
@@ -167,7 +167,7 @@ export class ManageGitModelComponent implements OnInit, OnDestroy {
             this.gitModelId = gitModelId;
             this.form.disable();
 
-            this.gitModelService.gitModel
+            this.gitModelService.gitModel$
               .pipe(untilDestroyed(this), filter(Boolean))
               .subscribe((gitModel) => {
                 this.gitModel = gitModel;

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
@@ -4,25 +4,25 @@
  -->
 
 <div
-  *ngIf="(projectService.project | async) && (modelService.model | async)"
+  *ngIf="(projectService.project$ | async) && (modelService.model$ | async)"
   class="wrapper flex-center"
 >
   <mat-card class="section-card">
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <fieldset>
         <app-form-field-skeleton-loader
-          *ngIf="(t4cInstanceService.t4cInstances | async) === undefined"
+          *ngIf="(t4cInstanceService.t4cInstances$ | async) === undefined"
         >
         </app-form-field-skeleton-loader>
 
         <mat-form-field
-          *ngIf="(t4cInstanceService.t4cInstances | async) !== undefined"
+          *ngIf="(t4cInstanceService.t4cInstances$ | async) !== undefined"
           appearance="fill"
         >
           <mat-label>Instance</mat-label>
           <mat-select formControlName="t4cInstanceId">
             <mat-option
-              *ngFor="let instance of t4cInstanceService.t4cInstances | async"
+              *ngFor="let instance of t4cInstanceService.t4cInstances$ | async"
               [value]="instance.id"
             >
               {{ instance.name }}
@@ -35,18 +35,18 @@
       </fieldset>
       <fieldset>
         <app-form-field-skeleton-loader
-          *ngIf="(t4cInstanceService.t4cInstances | async) === undefined"
+          *ngIf="(t4cInstanceService.t4cInstances$ | async) === undefined"
         >
         </app-form-field-skeleton-loader>
         <mat-form-field
-          *ngIf="(t4cInstanceService.t4cInstances | async) !== undefined"
+          *ngIf="(t4cInstanceService.t4cInstances$ | async) !== undefined"
           appearance="fill"
         >
           <mat-label>Repository</mat-label>
           <mat-select formControlName="t4cRepositoryId">
             <mat-option
               *ngFor="
-                let repository of t4cRepositoryService.repositories | async
+                let repository of t4cRepositoryService.repositories$ | async
               "
               [value]="repository.id"
             >

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.ts
@@ -95,14 +95,14 @@ export class ManageT4CModelComponent implements OnInit, OnDestroy {
         }
       });
 
-    this.t4cRepositoryService.repositories
+    this.t4cRepositoryService.repositories$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((repositories) => {
         this.t4cRepositories = repositories;
         this.form.controls.t4cRepositoryId.enable({ emitEvent: false });
       });
 
-    this.t4cModelService.t4cModel
+    this.t4cModelService.t4cModel$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((t4cModel) => {
         this.t4cModel = t4cModel;
@@ -119,8 +119,8 @@ export class ManageT4CModelComponent implements OnInit, OnDestroy {
     this.t4cInstanceService.loadInstances();
 
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.modelService.model.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.modelService.model$.pipe(filter(Boolean)),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([project, model]) => {
@@ -129,7 +129,7 @@ export class ManageT4CModelComponent implements OnInit, OnDestroy {
         this.t4cModelService.loadT4CModels(project.slug, model.slug);
       });
 
-    this.t4cRepositoryService.repositories
+    this.t4cRepositoryService.repositories$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe(() =>
         this.form.controls.t4cRepositoryId.enable({

--- a/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
+++ b/frontend/src/app/projects/models/model-source/t4c/service/t4c-model.service.ts
@@ -21,10 +21,10 @@ export class T4CModelService {
   constructor(private http: HttpClient) {}
 
   private _t4cModel = new BehaviorSubject<T4CModel | undefined>(undefined);
-  readonly t4cModel = this._t4cModel.asObservable();
+  public readonly t4cModel$ = this._t4cModel.asObservable();
 
   private _t4cModels = new BehaviorSubject<T4CModel[] | undefined>(undefined);
-  readonly t4cModels = this._t4cModels.asObservable();
+  public readonly t4cModels$ = this._t4cModels.asObservable();
 
   urlFactory(projectSlug: string, modelSlug: string): string {
     return `${environment.backend_url}/projects/${projectSlug}/models/${modelSlug}/modelsources/t4c`;
@@ -107,7 +107,7 @@ export class T4CModelService {
     repositoryId: number
   ): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      return this.t4cModels.pipe(
+      return this.t4cModels$.pipe(
         take(1),
         map((t4cModels) => {
           const nameExists = t4cModels?.find(

--- a/frontend/src/app/projects/models/model-wrapper/model-wrapper.component.html
+++ b/frontend/src/app/projects/models/model-wrapper/model-wrapper.component.html
@@ -3,4 +3,4 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<router-outlet *ngIf="modelService.model | async"></router-outlet>
+<router-outlet *ngIf="modelService.model$ | async"></router-outlet>

--- a/frontend/src/app/projects/models/model-wrapper/model-wrapper.component.ts
+++ b/frontend/src/app/projects/models/model-wrapper/model-wrapper.component.ts
@@ -30,14 +30,14 @@ export class ModelWrapperComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     combineLatest([
       this.route.params.pipe(map((params) => params.model as string)),
-      this.projectService.project.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean)),
     ])
       .pipe(untilDestroyed(this))
       .subscribe(([modelSlug, project]) =>
         this.modelService.loadModelbySlug(modelSlug, project.slug)
       );
 
-    this.modelService.model
+    this.modelService.model$
       .pipe(untilDestroyed(this))
       .subscribe((model) =>
         this.breadcrumbService.updatePlaceholder({ model })

--- a/frontend/src/app/projects/models/service/model.service.ts
+++ b/frontend/src/app/projects/models/service/model.service.ts
@@ -33,8 +33,8 @@ export class ModelService {
   private _model = new BehaviorSubject<Model | undefined>(undefined);
   private _models = new BehaviorSubject<Model[] | undefined>(undefined);
 
-  readonly model = this._model.asObservable();
-  readonly models = this._models.asObservable();
+  public readonly model$ = this._model.asObservable();
+  public readonly models$ = this._models.asObservable();
 
   backendURLFactory(projectSlug: string, modelSlug: string) {
     return `${this.base_url}${projectSlug}/models/${modelSlug}`;
@@ -135,7 +135,7 @@ export class ModelService {
   asyncSlugValidator(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
       const modelSlug = slugify(control.value, { lower: true });
-      return this.models.pipe(
+      return this.models$.pipe(
         take(1),
         map((models) => {
           return models?.find((model) => model.slug === modelSlug)

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.ts
@@ -41,7 +41,7 @@ export class EditProjectMetadataComponent implements OnInit, OnChanges {
   });
 
   ngOnInit(): void {
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((project) => {
         this.project = project;

--- a/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.ts
@@ -38,7 +38,7 @@ export class ModelComplexityBadgeComponent implements OnChanges {
   }
 
   loadModelComplexityBadge() {
-    this.projectService.project
+    this.projectService.project$
       .pipe(
         untilDestroyed(this),
         filter(Boolean),

--- a/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-detail/git-model.service.ts
@@ -21,8 +21,8 @@ export class GitModelService {
     undefined
   );
 
-  readonly gitModel = this._gitModel.asObservable();
-  readonly gitModels = this._gitModels.asObservable();
+  public readonly gitModel$ = this._gitModel.asObservable();
+  public readonly gitModels$ = this._gitModels.asObservable();
 
   loadGitModels(project_slug: string, model_slug: string): void {
     this.http

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -10,7 +10,7 @@
       mat-stroked-button
       [routerLink]="[
         '/project',
-        (projectService.project | async)?.slug,
+        (projectService.project$ | async)?.slug,
         'models',
         'create'
       ]"
@@ -22,7 +22,7 @@
     </a>
   </div>
   <div class="flex flex-wrap">
-    <div class="flex" *ngIf="(modelService.models | async) === undefined">
+    <div class="flex" *ngIf="(modelService.models$ | async) === undefined">
       <div *ngFor="let card of [0, 1, 2]">
         <ngx-skeleton-loader
           appearance="circle"
@@ -39,7 +39,7 @@
 
     <mat-card
       class="overview-card"
-      *ngFor="let model of modelService.models | async"
+      *ngFor="let model of modelService.models$ | async"
     >
       <div class="header">
         <div class="header-text">

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -38,7 +38,7 @@ export class ModelOverviewComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this))
       .subscribe((project) => (this.projectSlug = project?.slug));
   }
@@ -53,7 +53,7 @@ export class ModelOverviewComponent implements OnInit {
   }
 
   openPipelineDialog(model: Model): void {
-    this.projectService.project.pipe(first()).subscribe((project) => {
+    this.projectService.project$.pipe(first()).subscribe((project) => {
       this.dialog.open(TriggerPipelineComponent, {
         data: { projectSlug: project!.slug, modelSlug: model.slug },
       });

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
@@ -7,10 +7,10 @@
   <h2 id="title">Project information</h2>
   <mat-card class="!flex flex-col grow justify-between">
     <div class="flex flex-col">
-      <div *ngIf="projectService.project | async">
-        <h2 id="title">{{ (projectService.project | async)!.name }}</h2>
+      <div *ngIf="projectService.project$ | async">
+        <h2 id="title">{{ (projectService.project$ | async)!.name }}</h2>
       </div>
-      <div *ngIf="(projectService.project | async) === undefined">
+      <div *ngIf="(projectService.project$ | async) === undefined">
         <ngx-skeleton-loader
           [theme]="{
             'border-radius': '5px',
@@ -21,16 +21,16 @@
         ></ngx-skeleton-loader>
       </div>
       <div
-        *ngIf="(projectService.project | async) !== undefined"
+        *ngIf="(projectService.project$ | async) !== undefined"
         class="grow"
         id="description"
       >
         {{
-          (projectService.project | async)!.description ||
+          (projectService.project$ | async)!.description ||
             "No description available."
         }}
       </div>
-      <div *ngIf="(projectService.project | async) === undefined">
+      <div *ngIf="(projectService.project$ | async) === undefined">
         <ngx-skeleton-loader
           [theme]="{
             'border-radius': '5px',
@@ -60,7 +60,7 @@
         </button>
       </span>
       <a
-        [disabled]="(projectService.project | async) === undefined"
+        [disabled]="(projectService.project$ | async) === undefined"
         mat-raised-button
         routerLink="metadata"
         id="modify"

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.ts
@@ -32,13 +32,13 @@ export class ProjectMetadataComponent {
   ) {}
 
   ngOnInit(): void {
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((project) => {
         this.project = project;
       });
 
-    this.modelService.models
+    this.modelService.models$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((models) => (this.canDelete = !models.length));
   }

--- a/frontend/src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.component.ts
+++ b/frontend/src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.component.ts
@@ -50,7 +50,7 @@ export class AddUserToProjectComponent {
 
   asyncUserAlreadyInProjectValidator(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      return this.projectUserService.projectUsers.pipe(
+      return this.projectUserService.projectUsers$.pipe(
         take(1),
         map((projectUsers) => {
           if (
@@ -85,7 +85,7 @@ export class AddUserToProjectComponent {
   }
 
   addUser(): void {
-    this.projectService.project.pipe(filter(Boolean)).subscribe((project) => {
+    this.projectService.project$.pipe(filter(Boolean)).subscribe((project) => {
       if (this.addUserToProjectForm.valid) {
         const formValue = this.addUserToProjectForm.value;
 

--- a/frontend/src/app/projects/project-detail/project-users/project-audit-log/service/project-audit-log.service.ts
+++ b/frontend/src/app/projects/project-detail/project-users/project-audit-log/service/project-audit-log.service.ts
@@ -21,7 +21,8 @@ export class ProjectAuditLogService {
     pages: [],
     total: undefined,
   });
-  readonly projectHistoryEventsPages$ =
+
+  public readonly projectHistoryEventsPages$ =
     this._projectHistoryEventPages.asObservable();
 
   constructor(
@@ -32,7 +33,7 @@ export class ProjectAuditLogService {
   }
 
   resetProjectAuditLogOnPipelineChange() {
-    this.projectService.project.subscribe(() => {
+    this.projectService.project$.subscribe(() => {
       this.resetProjectHistoryEvents();
     });
   }

--- a/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.html
+++ b/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.html
@@ -44,7 +44,7 @@
           class="user"
           *ngFor="
             let user of getProjectUsersByRole(
-              projectUserService.projectUsers | async,
+              projectUserService.projectUsers$ | async,
               role
             )
           "
@@ -114,7 +114,7 @@
             </div>
           </div>
         </div>
-        <div *ngIf="(projectUserService.projectUsers | async) === undefined">
+        <div *ngIf="(projectUserService.projectUsers$ | async) === undefined">
           <ngx-skeleton-loader
             appearance="circle"
             [theme]="{

--- a/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.ts
+++ b/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.ts
@@ -38,7 +38,7 @@ export class ProjectUserSettingsComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.projectService.project
+    this.projectService.project$
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe((project) => {
         this.project = project;
@@ -148,7 +148,7 @@ export class ProjectUserSettingsComponent implements OnInit {
   }
 
   openAuditLogDialog() {
-    this.projectService.project.pipe(take(1)).subscribe((project) => {
+    this.projectService.project$.pipe(take(1)).subscribe((project) => {
       this.matDialog.open(ProjectAuditLogComponent, {
         data: {
           projectSlug: project?.slug,

--- a/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
+++ b/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
@@ -36,14 +36,18 @@ export class ProjectUserService {
   ROLES = { user: 'User', manager: 'Manager' };
   ADVANCED_ROLES = { administrator: 'Administrator', ...this.ROLES };
 
-  _projectUser = new BehaviorSubject<ProjectUser | undefined>(undefined);
-  projectUser = this._projectUser.asObservable();
+  private _projectUser = new BehaviorSubject<ProjectUser | undefined>(
+    undefined
+  );
+  public readonly projectUser$ = this._projectUser.asObservable();
 
-  _projectUsers = new BehaviorSubject<ProjectUser[] | undefined>(undefined);
-  projectUsers = this._projectUsers.asObservable();
+  private _projectUsers = new BehaviorSubject<ProjectUser[] | undefined>(
+    undefined
+  );
+  public readonly projectUsers$ = this._projectUsers.asObservable();
 
   resetProjectUserOnProjectReset() {
-    this.projectService.project
+    this.projectService.project$
       .pipe(
         filter((project) => project === undefined),
         tap(() => {
@@ -54,7 +58,7 @@ export class ProjectUserService {
   }
 
   resetProjectUsersOnProjectReset() {
-    this.projectService.project
+    this.projectService.project$
       .pipe(
         filter((project) => project === undefined),
         tap(() => {
@@ -88,7 +92,7 @@ export class ProjectUserService {
 
   loadProjectUserOnProjectChange(): void {
     this._projectUser.next(undefined);
-    this.projectService.project
+    this.projectService.project$
       .pipe(
         filter(Boolean),
         switchMap((project) =>
@@ -108,8 +112,8 @@ export class ProjectUserService {
   loadProjectUsersOnProjectChange(): void {
     this._projectUsers.next(undefined);
     combineLatest([
-      this.projectService.project.pipe(filter(Boolean)),
-      this.projectUser.pipe(
+      this.projectService.project$.pipe(filter(Boolean)),
+      this.projectUser$.pipe(
         filter(
           (projectUser) =>
             projectUser?.role === 'manager' ||

--- a/frontend/src/app/projects/project-overview/project-overview.component.html
+++ b/frontend/src/app/projects/project-overview/project-overview.component.html
@@ -15,11 +15,11 @@
     </mat-card>
   </a>
   <app-mat-card-overview-skeleton-loader
-    [loading]="(projectService.projects | async) === undefined"
+    [loading]="(projectService.projects$ | async) === undefined"
   ></app-mat-card-overview-skeleton-loader>
-  <ng-container *ngIf="projectService.projects | async">
+  <ng-container *ngIf="projectService.projects$ | async">
     <a
-      *ngFor="let project of (projectService.projects | async)!"
+      *ngFor="let project of (projectService.projects$ | async)!"
       [routerLink]="['/project', project.slug]"
     >
       <mat-card matRipple class="mat-card-overview">

--- a/frontend/src/app/projects/project-wrapper/project-wrapper.component.ts
+++ b/frontend/src/app/projects/project-wrapper/project-wrapper.component.ts
@@ -36,7 +36,7 @@ export class ProjectWrapperComponent implements OnInit, OnDestroy {
         this.modelService.loadModels(projectSlug);
       });
 
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this))
       .subscribe((project) =>
         this.breadcrumbsService.updatePlaceholder({ project })

--- a/frontend/src/app/projects/service/project.service.ts
+++ b/frontend/src/app/projects/service/project.service.ts
@@ -25,8 +25,8 @@ export class ProjectService {
   private _project = new BehaviorSubject<Project | undefined>(undefined);
   private _projects = new BehaviorSubject<Project[] | undefined>(undefined);
 
-  readonly project = this._project.asObservable();
-  readonly projects = this._projects.asObservable();
+  public readonly project$ = this._project.asObservable();
+  public readonly projects$ = this._projects.asObservable();
 
   loadProjects(): void {
     this.http.get<Project[]>(this.BACKEND_URL_PREFIX).subscribe({
@@ -90,7 +90,7 @@ export class ProjectService {
     const ignoreSlug = !!ignoreProject ? ignoreProject.slug : -1;
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
       const projectSlug = slugify(control.value, { lower: true });
-      return this.projects.pipe(
+      return this.projects$.pipe(
         take(1),
         map((projects) => {
           return projects?.find(

--- a/frontend/src/app/services/git/git.service.ts
+++ b/frontend/src/app/services/git/git.service.ts
@@ -32,7 +32,7 @@ export class GitService {
 
   private _revisions = new BehaviorSubject<Revisions | undefined>(undefined);
 
-  readonly revisions = this._revisions.asObservable();
+  public readonly revisions$ = this._revisions.asObservable();
 
   constructor(private http: HttpClient) {}
 
@@ -87,7 +87,7 @@ export class GitService {
 
   asyncExistingRevisionValidator(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      return this.revisions.pipe(
+      return this.revisions$.pipe(
         take(1),
         map((revisions) => {
           const revision = control.value;

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -51,12 +51,12 @@ export class T4CInstanceService {
   private _t4cInstances = new BehaviorSubject<T4CInstance[] | undefined>(
     undefined
   );
-  readonly t4cInstances = this._t4cInstances.asObservable();
+  public readonly t4cInstances$ = this._t4cInstances.asObservable();
 
   private _t4cInstance = new BehaviorSubject<T4CInstance | undefined>(
     undefined
   );
-  readonly t4cInstance = this._t4cInstance.asObservable();
+  public readonly t4cInstance$ = this._t4cInstance.asObservable();
 
   loadInstances(): void {
     this.http.get<T4CInstance[]>(this.baseUrl).subscribe({

--- a/frontend/src/app/sessions/service/user-session.service.ts
+++ b/frontend/src/app/sessions/service/user-session.service.ts
@@ -20,12 +20,12 @@ export class UserSessionService {
 
   private _sessions = new BehaviorSubject<Session[] | undefined>(undefined);
 
-  readonly sessions = this._sessions.asObservable();
-  readonly readonlySessions = this.sessions.pipe(
+  public readonly sessions$ = this._sessions.asObservable();
+  public readonly readonlySessions$ = this.sessions$.pipe(
     filter(Boolean),
     map((sessions) => sessions.filter(isReadonlySession))
   );
-  readonly persistentSessions = this.sessions.pipe(
+  public readonly persistentSessions$ = this.sessions$.pipe(
     filter(Boolean),
     map((sessions) => sessions.filter(isPersistentSession))
   );

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.html
@@ -8,7 +8,7 @@
 </div>
 
 <ngx-skeleton-loader
-  *ngIf="(userSessionService.sessions | async) === undefined"
+  *ngIf="(userSessionService.sessions$ | async) === undefined"
   appearance="circle"
   [theme]="{
     'border-radius': '5px',
@@ -18,14 +18,14 @@
   }"
 ></ngx-skeleton-loader>
 
-<mat-card *ngIf="(userSessionService.sessions | async)?.length === 0">
+<mat-card *ngIf="(userSessionService.sessions$ | async)?.length === 0">
   <h2>No active sessions</h2>
   <div class="content">
     No active sessions for your user are found in our system. <br />
   </div>
 </mat-card>
 
-<mat-card *ngFor="let session of userSessionService.sessions | async">
+<mat-card *ngFor="let session of userSessionService.sessions$ | async">
   <div class="type">
     <h2 *ngIf="isPersistentSession(session)">Persistent workspace session</h2>
     <h2 *ngIf="isReadonlySession(session)">Read-only session</h2>

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.ts
@@ -60,11 +60,11 @@ export class CreateReadonlySessionComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.modelService.models
+    this.modelService.models$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((models) => (this.models = models));
 
-    this.projectService.project
+    this.projectService.project$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((project) => (this.projectSlug = project.slug));
 
@@ -111,7 +111,7 @@ export class CreateReadonlySessionComponent implements OnInit {
 
   asyncReadonlyValidator(): AsyncValidatorFn {
     return (_: AbstractControl): Observable<ValidationErrors | null> => {
-      return this.userSessionService.readonlySessions.pipe(
+      return this.userSessionService.readonlySessions$.pipe(
         take(1),
         map((readOnlySessions) => {
           return readOnlySessions?.find(

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
@@ -39,7 +39,7 @@ export class CreatePersistentSessionComponent implements OnInit {
   ngOnInit(): void {
     this.toolService.getTools().subscribe();
 
-    this.userSessionService.persistentSessions
+    this.userSessionService.persistentSessions$
       .pipe(untilDestroyed(this))
       .subscribe((sessions) => (this.persistentSession = sessions?.at(0)));
   }

--- a/frontend/src/app/settings/modelsources/git-settings/edit-git-settings/edit-git-settings.component.ts
+++ b/frontend/src/app/settings/modelsources/git-settings/edit-git-settings/edit-git-settings.component.ts
@@ -39,7 +39,7 @@ export class EditGitSettingsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.gitInstancesService.gitInstance
+    this.gitInstancesService.gitInstance$
       .pipe(filter(Boolean), untilDestroyed(this))
       .subscribe((instance: GitInstance) => {
         this.gitInstanceForm.controls.name.addAsyncValidators(

--- a/frontend/src/app/settings/modelsources/git-settings/git-settings.component.html
+++ b/frontend/src/app/settings/modelsources/git-settings/git-settings.component.html
@@ -4,11 +4,11 @@
  -->
 
 <div class="wrapper">
-  <div *ngIf="(this.gitInstancesService.gitInstances | async)?.length">
+  <div *ngIf="(this.gitInstancesService.gitInstances$ | async)?.length">
     <div class="title">Existing instances</div>
     <div class="flex flex-wrap">
       <mat-card
-        *ngFor="let instance of this.gitInstancesService.gitInstances | async"
+        *ngFor="let instance of this.gitInstancesService.gitInstances$ | async"
       >
         <div class="mat-title">
           <div class="instance-head">

--- a/frontend/src/app/settings/modelsources/git-settings/service/git-instances.service.ts
+++ b/frontend/src/app/settings/modelsources/git-settings/service/git-instances.service.ts
@@ -27,8 +27,8 @@ export class GitInstancesService {
     undefined
   );
 
-  readonly gitInstances = this._gitInstances.asObservable();
-  readonly gitInstance = this._gitInstance.asObservable();
+  public readonly gitInstances$ = this._gitInstances.asObservable();
+  public readonly gitInstance$ = this._gitInstance.asObservable();
 
   constructor(private http: HttpClient) {}
 
@@ -91,7 +91,7 @@ export class GitInstancesService {
   asyncNameValidator(ignoreInstance?: GitInstance): AsyncValidatorFn {
     const ignoreId = !!ignoreInstance ? ignoreInstance.id : -1;
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      return this.gitInstances.pipe(
+      return this.gitInstances$.pipe(
         take(1),
         map((gitInstances) => {
           const nameExists = gitInstances?.find(

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -28,8 +28,8 @@
             </mat-select>
             <mat-hint
               *ngIf="
-                (t4cInstanceService.t4cInstance | async) !== undefined &&
-                (t4cInstanceService.t4cInstance | async)!.version.id !==
+                (t4cInstanceService.t4cInstance$ | async) !== undefined &&
+                (t4cInstanceService.t4cInstance$ | async)!.version.id !==
                   form.value.version_id
               "
               >Models are not auto-migrated on version change.</mat-hint
@@ -197,13 +197,13 @@
 
   <div
     class="flex flex-col flex-wrap"
-    *ngIf="(t4cInstanceService.t4cInstance | async) !== undefined"
+    *ngIf="(t4cInstanceService.t4cInstance$ | async) !== undefined"
   >
     <app-licences
-      [instance]="(t4cInstanceService.t4cInstance | async)!"
+      [instance]="(t4cInstanceService.t4cInstance$ | async)!"
     ></app-licences>
     <app-t4c-instance-settings
-      [instance]="(t4cInstanceService.t4cInstance | async)!"
+      [instance]="(t4cInstanceService.t4cInstance$ | async)!"
     ></app-t4c-instance-settings>
   </div>
 </div>

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -87,7 +87,7 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
         this.t4cInstanceService.loadInstance(instanceId);
       });
 
-    this.t4cInstanceService.t4cInstance
+    this.t4cInstanceService.t4cInstance$
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((t4cInstance) => {
         t4cInstance.password = '***********';

--- a/frontend/src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service.ts
@@ -29,7 +29,7 @@ export class T4CRepoService {
     T4CServerRepository[] | undefined
   >(undefined);
 
-  readonly repositories = this._repositories.asObservable();
+  public readonly repositories$ = this._repositories.asObservable();
 
   urlFactory(instanceId: number, repositoryId: number): string {
     return `${this.t4cInstanceService.urlFactory(
@@ -100,7 +100,7 @@ export class T4CRepoService {
 
   asyncNameValidator(): AsyncValidatorFn {
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
-      return this.repositories.pipe(
+      return this.repositories$.pipe(
         take(1),
         map((t4cRepositories) => {
           const nameExists = t4cRepositories?.find(

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
@@ -34,7 +34,7 @@
         class="flex justify-between my-[10px] mx-[5px]"
         *ngFor="
           let repository of getFilteredRepositories(
-            t4cRepoService.repositories | async
+            t4cRepoService.repositories$ | async
           )
         "
       >

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
@@ -16,7 +16,7 @@
   </a>
 
   <a
-    *ngFor="let instance of t4cInstanceService.t4cInstances | async"
+    *ngFor="let instance of t4cInstanceService.t4cInstances$ | async"
     [routerLink]="['instance', instance.id]"
   >
     <mat-card matRipple class="mat-card-overview">


### PR DESCRIPTION
This PR contains some consistency improvements. 

- All variables containing Observables are suffixed with `$`. This convention was introduced by Cycle.js, but is widely used: https://cycle.js.org/basic-examples.html#basic-examples-increment-a-counter-what-is-the-convention 
- For private BehaviourSubjects in services, the `private` annotation is added.
- For public Observables in services, the `public` and `readonly` annotations are added.