### PR TITLE
Use new-style t4c/client backup functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ capella:
 	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSIONS="$(CAPELLA_VERSIONS)" capella/remote capella/readonly
 
 t4c-client:
-	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSIONS="$(T4C_CLIENT_VERSIONS)" t4c/client/remote t4c/client/backup
+	$(CAPELLA_DOCKERIMAGES) CAPELLA_VERSIONS="$(T4C_CLIENT_VERSIONS)" t4c/client/remote
 
 jupyter:
 	$(CAPELLA_DOCKERIMAGES) jupyter-notebook

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -98,7 +98,7 @@ def create_tools(db):
         capella = tools_models.Tool(
             name="Capella",
             docker_image_template=f"{registry}/capella/remote:$version-latest",
-            docker_image_backup_template=f"{registry}/t4c/client/backup:$version-latest",
+            docker_image_backup_template=f"{registry}/t4c/client/base:$version-latest",
             readonly_docker_image_template=f"{registry}/capella/readonly:$version-latest",
         )
 

--- a/backend/capellacollab/projects/toolmodels/backups/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/routes.py
@@ -122,6 +122,7 @@ def create_backup(
                 password,
                 body.include_commit_history,
             ),
+            command="backup",
             schedule="0 3 * * *",
         )
     else:

--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -57,6 +57,7 @@ def _schedule_pending_jobs():
                     image=tools_crud.get_backup_image_for_tool_version(
                         db, pending_run.pipeline.model.version_id
                     ),
+                    command="backup",
                     labels={
                         "app.capellacollab/projectSlug": pending_run.pipeline.model.project.slug,
                         "app.capellacollab/projectID": str(

--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -29,6 +29,7 @@ class MockOperator:
     def create_cronjob(
         self,
         image: str,
+        command: str,
         environment: dict[str, str | None],
         schedule="* * * * *",
         timeout=18000,

--- a/backend/tests/sessions/test_sessions_routes.py
+++ b/backend/tests/sessions/test_sessions_routes.py
@@ -170,7 +170,11 @@ class MockOperator:
 
     @classmethod
     def create_cronjob(
-        self, image: str, environment: dict[str, str], schedule="* * * * *"
+        self,
+        image: str,
+        command: str,
+        environment: dict[str, str],
+        schedule="* * * * *",
     ) -> str:
         return ""
 


### PR DESCRIPTION
This allows jobs to work with the new consolidated t4c/client image.
To improve maintainability I changed calls to `_create_job_spec` to
named arguments.
    
I decided to provide the command to the k8s api, instead of hard-coding
it there, to keep the symantics of the methods used --
`create_(cron)job()` -- agnostic.
    
The changes should be compatible with older t4c backup images, since
they just ignore the command (args).

This PR bulds on https://github.com/DSD-DBS/capella-dockerimages/pull/162