### PR TITLE
Feat add t4c http ws port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@ certs/*
 /node_modules
 .idea
 .vscode
-/backend/log/*
 /helm/charts/*
 /logs/*

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -12,6 +12,7 @@ config/*
 build
 .git_archival.txt
 logs
+backend.log*
 
 htmlcov
 .coverage

--- a/backend/capellacollab/alembic/versions/3442c1b545e3_add_http_port_to_t4c_instance.py
+++ b/backend/capellacollab/alembic/versions/3442c1b545e3_add_http_port_to_t4c_instance.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add http port to t4c instance
+
+Revision ID: 3442c1b545e3
+Revises: c6d27bd8cf6e
+Create Date: 2023-06-26 17:04:34.613373
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3442c1b545e3"
+down_revision = "c6d27bd8cf6e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "t4c_instances", sa.Column("http_port", sa.Integer(), nullable=True)
+    )

--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -13,25 +13,36 @@ from capellacollab.projects.toolmodels.modelsources.t4c import (
 
 
 def get_environment(
-    gitmodel: git_models.DatabaseGitModel,
-    t4cmodel: t4c_models.DatabaseT4CModel,
+    git_model: git_models.DatabaseGitModel,
+    t4c_model: t4c_models.DatabaseT4CModel,
     t4c_username: str,
     t4c_password: str,
     include_commit_history: bool = False,
 ) -> dict[str, str]:
-    return {
-        "GIT_REPO_URL": gitmodel.path,
-        "GIT_REPO_BRANCH": gitmodel.revision,
-        "GIT_USERNAME": gitmodel.username,
-        "GIT_PASSWORD": gitmodel.password,
-        "T4C_REPO_HOST": t4cmodel.repository.instance.host,
-        "T4C_REPO_PORT": str(t4cmodel.repository.instance.port),
-        "T4C_CDO_PORT": str(t4cmodel.repository.instance.cdo_port),
-        "T4C_REPO_NAME": t4cmodel.repository.name,
-        "T4C_PROJECT_NAME": t4cmodel.name,
+    env = {
+        "GIT_REPO_URL": git_model.path,
+        "GIT_REPO_BRANCH": git_model.revision,
+        "GIT_USERNAME": git_model.username,
+        "GIT_PASSWORD": git_model.password,
+        "T4C_REPO_HOST": t4c_model.repository.instance.host,
+        "T4C_REPO_PORT": str(t4c_model.repository.instance.port),
+        "T4C_REPO_NAME": t4c_model.repository.name,
+        "T4C_PROJECT_NAME": t4c_model.name,
         "T4C_USERNAME": t4c_username,
         "T4C_PASSWORD": t4c_password,
         "LOG_LEVEL": "INFO",
         "INCLUDE_COMMIT_HISTORY": json.dumps(include_commit_history),
-        "CONNECTION_TYPE": "telnet",
     }
+
+    if http_port := t4c_model.repository.instance.http_port:
+        env = env | {
+            "HTTP_LOGIN": t4c_model.repository.instance.username,
+            "HTTP_PASSWORD": t4c_model.repository.instance.password,
+            "HTTP_PORT": str(http_port),
+        }
+    else:
+        env = env | {
+            "T4C_CDO_PORT": str(t4c_model.repository.instance.cdo_port)
+        }
+
+    return env

--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -35,13 +35,13 @@ def get_environment(
     }
 
     if http_port := t4c_model.repository.instance.http_port:
-        env = env | {
+        env |= {
             "HTTP_LOGIN": t4c_model.repository.instance.username,
             "HTTP_PASSWORD": t4c_model.repository.instance.password,
             "HTTP_PORT": str(http_port),
         }
     else:
-        env = env | {
+        env |= env | {
             "T4C_CDO_PORT": str(t4c_model.repository.instance.cdo_port)
         }
 

--- a/backend/capellacollab/projects/toolmodels/backups/runs/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/injectables.py
@@ -11,7 +11,7 @@ from capellacollab.projects.toolmodels.backups import (
 )
 from capellacollab.projects.toolmodels.backups import models as backups_models
 
-from . import crud
+from . import crud, models
 
 
 def get_existing_pipeline_run(
@@ -20,7 +20,7 @@ def get_existing_pipeline_run(
         backups_injectables.get_existing_pipeline
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> backups_models.DatabaseBackup:
+) -> models.DatabasePipelineRun:
     if pipeline_run := crud.get_pipeline_run_by_id(db, pipeline_run_id):
         if pipeline_run.pipeline.id != pipeline.id:
             raise fastapi.HTTPException(

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -155,7 +155,10 @@ def get_logs(
         ]
     )
 
-    masked_values = [pipeline_run.pipeline.t4c_password]
+    masked_values = [
+        pipeline_run.pipeline.t4c_password,
+        pipeline_run.pipeline.t4c_model.repository.instance.password,
+    ]
     masked_values_generated = []
 
     # Also mask derivated, e.g. base64 encoded credentials

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -127,10 +127,7 @@ def _transform_unix_nanoseconds_to_human_readable_format(
     )
 
 
-@router.get(
-    "/{pipeline_run_id}/logs",
-    response_model=str,
-)
+@router.get("/{pipeline_run_id}/logs", response_model=str)
 def get_logs(
     pipeline_run: models.DatabasePipelineRun = fastapi.Depends(
         injectables.get_existing_pipeline_run

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -81,10 +81,11 @@ def get_pipeline_runs(
     response_model=models.PipelineRun,
 )
 def get_pipeline_run(
-    pipeline_run: pipeline_models.DatabaseBackup = fastapi.Depends(
+    pipeline_run: models.DatabasePipelineRun = fastapi.Depends(
         injectables.get_existing_pipeline_run
     ),
-) -> list[models.DatabasePipelineRun]:
+) -> models.DatabasePipelineRun:
+    print(pipeline_run.status)
     return pipeline_run
 
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -377,7 +377,9 @@ def start_persistent_guacamole_session(
             {
                 "repository": repository.name,
                 "protocol": repository.instance.protocol,
-                "port": repository.instance.port,
+                "port": repository.instance.http_port
+                if repository.instance.protocol == "ws"
+                else repository.instance.port,
                 "host": repository.instance.host,
                 "instance": repository.instance.name,
             }

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -60,6 +60,9 @@ class DatabaseT4CInstance(database.Base):
         sa.CheckConstraint("cdo_port >= 0 AND cdo_port <= 65535"),
         default=12036,
     )
+    http_port: orm.Mapped[int | None] = orm.mapped_column(
+        sa.CheckConstraint("http_port >= 0 AND http_port <= 65535"),
+    )
     usage_api: orm.Mapped[str]
     rest_api: orm.Mapped[str]
     username: orm.Mapped[str]
@@ -89,6 +92,7 @@ class T4CInstanceBase(pydantic.BaseModel):
     host: str
     port: int
     cdo_port: int
+    http_port: int | None
     usage_api: str
     rest_api: str
     username: str
@@ -107,6 +111,10 @@ class T4CInstanceBase(pydantic.BaseModel):
         port_validator
     )
 
+    _validate_http_port = pydantic.validator("http_port", allow_reuse=True)(
+        port_validator
+    )
+
     class Config:
         orm_mode = True
 
@@ -117,6 +125,7 @@ class PatchT4CInstance(pydantic.BaseModel):
     host: str | None
     port: int | None
     cdo_port: int | None
+    http_port: int | None
     usage_api: str | None
     rest_api: str | None
     username: str | None
@@ -134,6 +143,10 @@ class PatchT4CInstance(pydantic.BaseModel):
     )
 
     _validate_cdo_port = pydantic.validator("cdo_port", allow_reuse=True)(
+        port_validator
+    )
+
+    _validate_http_port = pydantic.validator("http_port", allow_reuse=True)(
         port_validator
     )
 

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -16,6 +16,7 @@ export type BaseT4CInstance = {
   host: string;
   port: number;
   cdo_port: number;
+  http_port?: number;
   usage_api: string;
   rest_api: string;
   username: string;

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.css
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.css
@@ -2,27 +2,3 @@
  * SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
-#submit-button-wrapper {
-  text-align: right;
-}
-
-.space-evenly {
-  display: flex;
-  justify-content: space-evenly;
-}
-
-#protocol {
-  width: 6em;
-  max-width: 85vw;
-}
-
-#host {
-  width: 15em;
-  max-width: 85vw;
-}
-
-#port {
-  width: 8em;
-  max-width: 85vw;
-}

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -64,8 +64,9 @@
             <input matInput formControlName="host" />
           </mat-form-field>
         </fieldset>
+
         <fieldset class="flex flex-wrap gap-2">
-          <mat-form-field appearance="fill">
+          <mat-form-field appearance="fill" class="w-[124px]">
             <mat-label>Port</mat-label>
             <input matInput inputmode="numeric" formControlName="port" />
             <mat-error
@@ -82,7 +83,8 @@
               The port is required.
             </mat-error>
           </mat-form-field>
-          <mat-form-field appearance="fill">
+
+          <mat-form-field appearance="fill" class="w-[124px]">
             <mat-label>CDO port</mat-label>
             <input matInput inputmode="numeric" formControlName="cdo_port" />
             <mat-error
@@ -98,6 +100,22 @@
             </mat-error>
             <mat-error *ngIf="form.controls.cdo_port.errors?.required">
               The CDO port is required.
+            </mat-error>
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" class="w-[124px]">
+            <mat-label>Http Port</mat-label>
+            <input matInput inputmode="numeric" formControlName="http_port" />
+            <mat-error
+              *ngIf="
+                form.controls.http_port.errors?.min ||
+                form.controls.http_port.errors?.max
+              "
+            >
+              Valid ports are between 0 and 65535.
+            </mat-error>
+            <mat-error *ngIf="form.controls.http_port.errors?.pattern">
+              We only support numerical ports :(
             </mat-error>
           </mat-form-field>
         </fieldset>
@@ -148,7 +166,12 @@
           </mat-form-field>
         </fieldset>
         <div *ngIf="editing" class="flex justify-between">
-          <button mat-flat-button color="warn" (click)="cancelEditing()">
+          <button
+            mat-flat-button
+            type="button"
+            color="warn"
+            (click)="cancelEditing()"
+          >
             Cancel
           </button>
           <button mat-flat-button type="submit" color="primary">Submit</button>
@@ -162,7 +185,7 @@
             Edit
           </button>
         </div>
-        <div *ngIf="!existing" id="submit-button-wrapper">
+        <div *ngIf="!existing" class="text-right">
           <button
             mat-flat-button
             color="primary"

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -104,7 +104,7 @@
           </mat-form-field>
 
           <mat-form-field appearance="fill" class="w-[124px]">
-            <mat-label>Http Port</mat-label>
+            <mat-label>HTTP port</mat-label>
             <input matInput inputmode="numeric" formControlName="http_port" />
             <mat-error
               *ngIf="

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -40,18 +40,9 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
     license: new FormControl('', Validators.required),
     protocol: new FormControl<Protocol>('tcp', Validators.required),
     host: new FormControl('', Validators.required),
-    port: new FormControl(2036, [
-      Validators.required,
-      Validators.pattern(/^\d*$/),
-      Validators.min(0),
-      Validators.max(65535),
-    ]),
-    cdo_port: new FormControl(12036, [
-      Validators.required,
-      Validators.pattern(/^\d*$/),
-      Validators.min(0),
-      Validators.max(65535),
-    ]),
+    port: this.createPortControl(2036, true),
+    cdo_port: this.createPortControl(12036, true),
+    http_port: this.createPortControl(null, false),
     usage_api: new FormControl('', [
       Validators.required,
       Validators.pattern(/^https?:\/\//),
@@ -63,6 +54,18 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
     username: new FormControl('', [Validators.required]),
     password: new FormControl('', [Validators.required]),
   });
+
+  private createPortControl(
+    defaultValue: number | null,
+    isRequired = true
+  ): FormControl {
+    return new FormControl(defaultValue, [
+      ...(isRequired ? [Validators.required] : []),
+      Validators.pattern(/^\d*$/),
+      Validators.min(0),
+      Validators.max(65535),
+    ]);
+  }
 
   constructor(
     public t4cInstanceService: T4CInstanceService,

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -34,15 +34,24 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
   instanceId?: number;
   capellaVersions?: ToolVersion[];
 
+  portValidators = [
+    Validators.pattern(/^\d*$/),
+    Validators.min(0),
+    Validators.max(65535),
+  ];
+
   public form = new FormGroup({
     name: new FormControl('', Validators.required),
     version_id: new FormControl(-1, Validators.required),
     license: new FormControl('', Validators.required),
     protocol: new FormControl<Protocol>('tcp', Validators.required),
     host: new FormControl('', Validators.required),
-    port: this.createPortControl(2036, true),
-    cdo_port: this.createPortControl(12036, true),
-    http_port: this.createPortControl(null, false),
+    port: new FormControl(2036, [Validators.required, ...this.portValidators]),
+    cdo_port: new FormControl(12036, [
+      Validators.required,
+      ...this.portValidators,
+    ]),
+    http_port: new FormControl<number | null>(null, this.portValidators),
     usage_api: new FormControl('', [
       Validators.required,
       Validators.pattern(/^https?:\/\//),
@@ -54,18 +63,6 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
     username: new FormControl('', [Validators.required]),
     password: new FormControl('', [Validators.required]),
   });
-
-  private createPortControl(
-    defaultValue: number | null,
-    isRequired = true
-  ): FormControl {
-    return new FormControl(defaultValue, [
-      ...(isRequired ? [Validators.required] : []),
-      Validators.pattern(/^\d*$/),
-      Validators.min(0),
-      Validators.max(65535),
-    ]);
-  }
 
   constructor(
     public t4cInstanceService: T4CInstanceService,

--- a/frontend/src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service.ts
@@ -32,7 +32,9 @@ export class T4CRepoService {
   readonly repositories = this._repositories.asObservable();
 
   urlFactory(instanceId: number, repositoryId: number): string {
-    return `${this.t4cInstanceService.urlFactory(instanceId)}/${repositoryId}`;
+    return `${this.t4cInstanceService.urlFactory(
+      instanceId
+    )}/repositories/${repositoryId}`;
   }
 
   loadRepositories(instanceId: number): void {

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.css
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.css
@@ -2,13 +2,3 @@
  * SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
-mat-list-option {
-  display: flex;
-  flex-direction: column;
-}
-
-mat-list-option {
-  display: flex;
-  flex-direction: column;
-}

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
@@ -4,7 +4,7 @@
  -->
 
 <div>
-  <div class="flex justify-between mr-[10px]">
+  <div class="flex justify-between mr-2.5">
     <h2>Repositories</h2>
     <button
       mat-stroked-button
@@ -15,36 +15,9 @@
     </button>
   </div>
 
-  <mat-card>
-    <form [formGroup]="form">
-      <div class="flex items-center">
-        <mat-form-field class="mb-[-1.25em]" appearance="fill">
-          <mat-label>Repository name</mat-label>
-          <input matInput formControlName="name" />
-          <mat-error *ngIf="form.controls.name.errors?.required"
-            >Please enter a name</mat-error
-          >
-          <mat-error *ngIf="form.controls.name.errors?.projectExistsError"
-            >Name already used</mat-error
-          >
-          <mat-error *ngIf="form.controls.name.errors?.pattern"
-            >The following characters are allowed: A-Z, a-z, 0-9, _, -
-          </mat-error>
-        </mat-form-field>
-        <div class="field-separator"></div>
-        <button
-          mat-stroked-button
-          color="primary"
-          [disabled]="!form.valid"
-          (click)="createRepository()"
-        >
-          <mat-icon>add</mat-icon>
-        </button>
-      </div>
-    </form>
-
-    <div class="mt-[1.25em] mb-[-1.25em]">
-      <mat-form-field id="search" appearance="outline">
+  <mat-card class="w-full md:w-96">
+    <div>
+      <mat-form-field class="w-full" appearance="outline">
         <mat-label>Search</mat-label>
         <input
           [(ngModel)]="search"
@@ -90,7 +63,7 @@
           </div>
 
           <div>
-            <div class="text-xl">
+            <div class="text-lg break-all">
               {{ repository.name }}
             </div>
             <div>
@@ -115,7 +88,7 @@
             (click)="startRepository(repository)"
             matTooltip="Start repository"
           >
-            <mat-icon class="text-[#5CB85C]">power_settings_new</mat-icon>
+            <mat-icon class="text-green-500">power_settings_new</mat-icon>
           </button>
 
           <button
@@ -140,5 +113,32 @@
         </div>
       </div>
     </div>
+
+    <form [formGroup]="form">
+      <div class="flex items-center justify-between w-full pt-[18px] gap-8">
+        <mat-form-field appearance="fill" class="w-full">
+          <mat-label>Repository name</mat-label>
+          <input matInput formControlName="name" />
+          <mat-error *ngIf="form.controls.name.errors?.required"
+            >Please enter a name</mat-error
+          >
+          <mat-error *ngIf="form.controls.name.errors?.uniqueName"
+            >Repository already exists</mat-error
+          >
+          <mat-error *ngIf="form.controls.name.errors?.pattern"
+            >The following characters are allowed: A-Z, a-z, 0-9, _, -
+          </mat-error>
+        </mat-form-field>
+        <button
+          class="relative bottom-[7.5px]"
+          mat-stroked-button
+          color="primary"
+          [disabled]="!form.valid"
+          (click)="createRepository()"
+        >
+          <mat-icon>add</mat-icon>
+        </button>
+      </div>
+    </form>
   </mat-card>
 </div>

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.html
@@ -3,108 +3,142 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<mat-card>
-  <div class="flex justify-between flex-wrap">
-    <mat-card-title><h2>Manage T4C repositories</h2></mat-card-title>
+<div>
+  <div class="flex justify-between mr-[10px]">
+    <h2>Repositories</h2>
     <button
-      mat-icon-button
+      mat-stroked-button
       [disabled]="!instance"
       (click)="this.t4cRepoService.refreshRepositories(instance!.id)"
     >
       <mat-icon>sync</mat-icon>
     </button>
   </div>
-  <form [formGroup]="form" #formDirective="ngForm">
-    <mat-form-field appearance="fill">
-      <mat-label>Repository name</mat-label>
-      <input matInput formControlName="name" />
-      <mat-error *ngIf="form.controls.name.errors?.required"
-        >Please enter a name</mat-error
-      >
-      <mat-error *ngIf="form.controls.name.errors?.projectExistsError"
-        >Name already used</mat-error
-      >
-      <mat-error *ngIf="form.controls.name.errors?.pattern"
-        >The following characters are allowed: A-Z, a-z, 0-9, _, -
-      </mat-error>
-    </mat-form-field>
-    <div class="field-separator"></div>
-    <button
-      mat-flat-button
-      color="primary"
-      [disabled]="!form.valid"
-      (click)="createRepository()"
-    >
-      Add T4C repository
-    </button>
-  </form>
-  <mat-selection-list #repositoryList [multiple]="false" class="user-selection">
-    <mat-list-option
-      *ngFor="let repository of t4cRepoService.repositories | async"
-      [value]="repository"
-    >
-      <mat-icon mat-list-icon *ngIf="repository.status === 'LOADING'"
-        >sync</mat-icon
-      >
-      <mat-icon mat-list-icon *ngIf="repository.status === 'OFFLINE'"
-        >cloud_off</mat-icon
-      >
-      <mat-icon mat-list-icon *ngIf="repository.status === 'ONLINE'"
-        >cloud_queue</mat-icon
-      >
-      <mat-icon mat-list-icon *ngIf="repository.status === 'NOT_FOUND'"
-        >block</mat-icon
-      >
-      <mat-icon mat-list-icon *ngIf="repository.status === 'INITIAL'"
-        >cloud_upload</mat-icon
-      >
-      <mat-icon
-        mat-list-icon
-        *ngIf="repository.status === 'INSTANCE_UNREACHABLE'"
-        >sync_problem</mat-icon
-      >
-      <div>
-        <div mat-line>{{ repository.name }}</div>
-        <div mat-line>Repository ID: {{ repository.id }}</div>
-        <div mat-line>status: {{ repository.status }}</div>
-      </div>
-    </mat-list-option>
-  </mat-selection-list>
 
-  <div *ngIf="repositoryList.selectedOptions.selected.length">
-    <div class="field-separator"></div>
-    <div class="flex justify-between">
-      <button
-        mat-flat-button
-        color="warn"
-        (click)="deleteRepository(selectedRepository)"
-      >
-        <mat-icon>delete</mat-icon> Remove {{ selectedRepository.name }}
-      </button>
-      <button
-        mat-flat-button
-        color="warn"
-        *ngIf="selectedRepository.status === 'ONLINE'"
-        (click)="stopRepository(selectedRepository)"
-      >
-        Stop repository
-      </button>
-      <button
-        mat-flat-button
-        color="primary"
-        *ngIf="selectedRepository.status === 'OFFLINE'"
-        (click)="startRepository(selectedRepository)"
-      >
-        Start repository
-      </button>
-      <button
-        mat-flat-button
-        color="primary"
-        *ngIf="selectedRepository.status === 'NOT_FOUND'"
-        (click)="recreateRepository(selectedRepository)"
-      >
-        Create on instance {{ instance!.name }}
-      </button>
+  <mat-card>
+    <form [formGroup]="form">
+      <div class="flex items-center">
+        <mat-form-field class="mb-[-1.25em]" appearance="fill">
+          <mat-label>Repository name</mat-label>
+          <input matInput formControlName="name" />
+          <mat-error *ngIf="form.controls.name.errors?.required"
+            >Please enter a name</mat-error
+          >
+          <mat-error *ngIf="form.controls.name.errors?.projectExistsError"
+            >Name already used</mat-error
+          >
+          <mat-error *ngIf="form.controls.name.errors?.pattern"
+            >The following characters are allowed: A-Z, a-z, 0-9, _, -
+          </mat-error>
+        </mat-form-field>
+        <div class="field-separator"></div>
+        <button
+          mat-stroked-button
+          color="primary"
+          [disabled]="!form.valid"
+          (click)="createRepository()"
+        >
+          <mat-icon>add</mat-icon>
+        </button>
+      </div>
+    </form>
+
+    <div class="mt-[1.25em] mb-[-1.25em]">
+      <mat-form-field id="search" appearance="outline">
+        <mat-label>Search</mat-label>
+        <input
+          [(ngModel)]="search"
+          autocomplete="off"
+          matInput
+          placeholder="Repository"
+        />
+        <mat-icon matSuffix>search</mat-icon>
+      </mat-form-field>
     </div>
-  </div>
-</mat-card>
+
+    <div class="max-h-[50vh] overflow-y-scroll">
+      <div
+        class="flex justify-between my-[10px] mx-[5px]"
+        *ngFor="
+          let repository of getFilteredRepositories(
+            t4cRepoService.repositories | async
+          )
+        "
+      >
+        <div class="flex">
+          <div class="h-[30px] w-[30px] mr-[15px] ml-[0px] my-auto">
+            <mat-icon mat-list-icon *ngIf="repository.status === 'LOADING'"
+              >sync</mat-icon
+            >
+            <mat-icon mat-list-icon *ngIf="repository.status === 'OFFLINE'"
+              >cloud_off</mat-icon
+            >
+            <mat-icon mat-list-icon *ngIf="repository.status === 'ONLINE'"
+              >cloud_queue</mat-icon
+            >
+            <mat-icon mat-list-icon *ngIf="repository.status === 'NOT_FOUND'"
+              >block</mat-icon
+            >
+            <mat-icon mat-list-icon *ngIf="repository.status === 'INITIAL'"
+              >cloud_upload</mat-icon
+            >
+            <mat-icon
+              mat-list-icon
+              *ngIf="repository.status === 'INSTANCE_UNREACHABLE'"
+              >sync_problem</mat-icon
+            >
+          </div>
+
+          <div>
+            <div class="text-xl">
+              {{ repository.name }}
+            </div>
+            <div>
+              Repository ID: {{ repository.id }} <br />
+              status: {{ repository.status }}
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-row my-auto">
+          <button
+            mat-icon-button
+            color="error"
+            (click)="deleteRepository(repository)"
+            matTooltip="Delete repository"
+          >
+            <mat-icon>delete</mat-icon>
+          </button>
+
+          <button
+            mat-icon-button
+            *ngIf="repository.status === 'OFFLINE'"
+            (click)="startRepository(repository)"
+            matTooltip="Start repository"
+          >
+            <mat-icon class="text-[#5CB85C]">power_settings_new</mat-icon>
+          </button>
+
+          <button
+            mat-icon-button
+            color="warn"
+            *ngIf="repository.status === 'ONLINE'"
+            (click)="stopRepository(repository)"
+            matTooltip="Stop repository"
+          >
+            <mat-icon>power_settings_new</mat-icon>
+          </button>
+
+          <button
+            mat-icon-button
+            color="primary"
+            *ngIf="repository.status === 'NOT_FOUND'"
+            (click)="recreateRepository(repository)"
+            matTooltip="Recreate repository on instance"
+          >
+            <mat-icon>sync</mat-icon>
+          </button>
+        </div>
+      </div>
+    </div>
+  </mat-card>
+</div>

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-instance-settings.component.ts
@@ -31,6 +31,8 @@ import { T4CRepoDeletionDialogComponent } from './t4c-repo-deletion-dialog/t4c-r
 export class T4CInstanceSettingsComponent implements OnChanges, OnDestroy {
   @Input() instance?: T4CInstance;
 
+  search = '';
+
   constructor(
     public t4cRepoService: T4CRepoService,
     private dialog: MatDialog
@@ -55,6 +57,18 @@ export class T4CInstanceSettingsComponent implements OnChanges, OnDestroy {
     }),
   });
 
+  getFilteredRepositories(
+    repositories: T4CServerRepository[] | undefined | null
+  ): T4CServerRepository[] | undefined {
+    if (repositories === undefined || repositories === null) {
+      return undefined;
+    }
+
+    return repositories.filter((repository) =>
+      repository.name.toLowerCase().includes(this.search.toLowerCase())
+    );
+  }
+
   createRepository(): void {
     if (this.form.valid) {
       this.t4cRepoService
@@ -73,27 +87,20 @@ export class T4CInstanceSettingsComponent implements OnChanges, OnDestroy {
   }
 
   startRepository(repository: T4CServerRepository): void {
-    this.repositoryList.selectedOptions.clear();
     this.t4cRepoService
       .startRepository(repository.instance.id, repository.id)
       .subscribe();
   }
 
   stopRepository(repository: T4CServerRepository): void {
-    this.repositoryList.selectedOptions.clear();
     this.t4cRepoService
       .stopRepository(repository.instance.id, repository.id)
       .subscribe();
   }
 
   recreateRepository(repository: T4CServerRepository): void {
-    this.repositoryList.selectedOptions.clear();
     this.t4cRepoService
       .recreateRepository(repository.instance.id, repository.id)
       .subscribe();
-  }
-
-  get selectedRepository(): T4CRepository & T4CServerRepository {
-    return this.repositoryList.selectedOptions.selected[0].value;
   }
 }

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
@@ -3,11 +3,6 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<!--
- ~ Copyright DB Netz AG and the capella-collab-manager contributors
- ~ SPDX-License-Identifier: Apache-2.0
- -->
-
 <article class="flex flex-wrap">
   <a [routerLink]="['create']">
     <mat-card matRipple class="mat-card-overview new">


### PR DESCRIPTION
This PR includes two main things:

1. It adds a new field to our t4c instances, the `http_port`. This port is used as the port when using the *ws* protocol and when set, we also use the http method of t4c for our backups. Therefore, it is **important** to carefully check whether the `HTTP_PASSWORD` is correctly masked in the logs before deploying to production
2. Rework of the repository list: Up to now, we had to click on a repository and then scroll down to be able to delete, start, stop, or recreate a repository. This PR applys the new style where each element has its own buttons. By doing so, we also decrease the code complexity as we do not have to maintain a `selectedRepository` anymore.

Resolves #485 #596 #759