### PR TITLE
feat: add inactive alert for jupyter notebooks

### DIFF
--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -65,7 +65,7 @@ def _get_last_seen(idletime: int | float) -> str:
     if (idlehours := idletime / 60) > 1:
         return f"{round(idlehours, 2)} hrs ago"
 
-    return f"{idletime} mins ago"
+    return f"{idletime:0f} mins ago"
 
 
 def _determine_session_state(session: DatabaseSession) -> str:

--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -65,7 +65,7 @@ def _get_last_seen(idletime: int | float) -> str:
     if (idlehours := idletime / 60) > 1:
         return f"{round(idlehours, 2)} hrs ago"
 
-    return f"{idletime:0f} mins ago"
+    return f"{idletime:.0f} mins ago"
 
 
 def _determine_session_state(session: DatabaseSession) -> str:

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -13,6 +13,8 @@ data:
     groups:
       - name: Inactivity
         rules:
+            # This metric adds idle times for jupyter notebooks. pynb does not support an activity metric out of the box.
+            # We check if the request count is over 4 (scrape interval is 30s). If so, we assume activity.
           - record: idletime_minutes
             expr: (time() - (max by (app) (http_request_duration_seconds_created)) or on (app) max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[{{ .Values.sessions.timeout }}m:2m])) / 60
           - alert: Inactive session

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -14,9 +14,9 @@ data:
       - name: Inactivity
         rules:
           - record: idletime_minutes
-            expr: (time() - max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[1d:5m])) / 60
+            expr: (time() - (max by (app) (http_request_duration_seconds_created)) or on (app) max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[{{ .Values.sessions.timeout }}m:2m])) / 60
           - alert: Inactive session
-            expr: idletime_minutes > {{ .Values.sessions.timeout }}
+            expr: idletime_minutes >= {{ .Values.sessions.timeout }}
             for: 1m
             annotations:
               summary: High Idletime

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -16,7 +16,7 @@ data:
             # This metric adds idle times for jupyter notebooks. pynb does not support an activity metric out of the box.
             # We check if the request count is over 4 (scrape interval is 30s). If so, we assume activity.
           - record: idletime_minutes
-            expr: (time() - max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[15m:2m])) / 60 OR ON (app) ((group by (app) (http_request_duration_seconds_created)) * -1)
+            expr: (time() - max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[{{ add .Values.sessions.timeout 5 }}m:2m])) / 60 OR ON (app) ((group by (app) (http_request_duration_seconds_created)) * -1)
           - alert: Inactive session
             expr: idletime_minutes >= {{ .Values.sessions.timeout }}
             for: 1m

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -13,12 +13,17 @@ data:
     groups:
       - name: Inactivity
         rules:
-          - alert: Inactivity session
+          - alert: Inactive Guacamole session
             expr: idletime_minutes > {{ .Values.sessions.timeout }}
             for: 1m
             annotations:
               summary: High Idletime
-          - alert: Unused session
+          - alert: Inactive Jupyter session
+            expr: sum by (app) (increase(http_request_duration_seconds_count[5m])) < 11
+            for: {{ .Values.sessions.timeout }}m
+            annotations:
+              summary: High Idletime
+          - alert: Unused Guacamole session
             expr: idletime_minutes < 0
             for: {{ .Values.sessions.timeout }}m
             annotations:

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -13,14 +13,11 @@ data:
     groups:
       - name: Inactivity
         rules:
-          - alert: Inactive Guacamole session
+          - record: idletime_minutes
+            expr: (time() - max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[1d:5m])) / 60
+          - alert: Inactive session
             expr: idletime_minutes > {{ .Values.sessions.timeout }}
             for: 1m
-            annotations:
-              summary: High Idletime
-          - alert: Inactive Jupyter session
-            expr: sum by (app) (increase(http_request_duration_seconds_count[5m])) < 11
-            for: {{ .Values.sessions.timeout }}m
             annotations:
               summary: High Idletime
           - alert: Unused Guacamole session

--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -16,13 +16,13 @@ data:
             # This metric adds idle times for jupyter notebooks. pynb does not support an activity metric out of the box.
             # We check if the request count is over 4 (scrape interval is 30s). If so, we assume activity.
           - record: idletime_minutes
-            expr: (time() - (max by (app) (http_request_duration_seconds_created)) or on (app) max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[{{ .Values.sessions.timeout }}m:2m])) / 60
+            expr: (time() - max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[15m:2m])) / 60 OR ON (app) ((group by (app) (http_request_duration_seconds_created)) * -1)
           - alert: Inactive session
             expr: idletime_minutes >= {{ .Values.sessions.timeout }}
             for: 1m
             annotations:
               summary: High Idletime
-          - alert: Unused Guacamole session
+          - alert: Unused session
             expr: idletime_minutes < 0
             for: {{ .Values.sessions.timeout }}m
             annotations:


### PR DESCRIPTION
So jupyter notebooks are automatically shut down after being idle for a while.