### PR TITLE
fix: Temporarily downgrade Grafana to version 9.5.5

### DIFF
--- a/helm/templates/backend/backend.deployment.yaml
+++ b/helm/templates/backend/backend.deployment.yaml
@@ -96,7 +96,7 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
-          image: {{ .Values.docker.registry.external -}}{{- .Values.docker.images.promtail }}
+          image: {{ .Values.docker.registry.external -}}/grafana/promtail
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/frontend/frontend.deployment.yaml
+++ b/helm/templates/frontend/frontend.deployment.yaml
@@ -73,7 +73,7 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
-          image: {{ .Values.docker.registry.external -}}{{- .Values.docker.images.promtail }}
+          image: {{ .Values.docker.registry.external -}}/grafana/promtail
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/grafana/grafana.deployment.yaml
+++ b/helm/templates/grafana/grafana.deployment.yaml
@@ -27,7 +27,7 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: grafana
-          image: {{ .Values.docker.registry.external -}}{{- .Values.docker.images.grafana }}
+          image: {{ .Values.docker.registry.external -}}/grafana/grafana:9.5.5
           ports:
             - containerPort: 3000
           resources:

--- a/helm/templates/guacamole/guacamole.deployment.yaml
+++ b/helm/templates/guacamole/guacamole.deployment.yaml
@@ -108,7 +108,7 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
-          image: {{ .Values.docker.registry.external -}}{{- .Values.docker.images.promtail }}
+          image: {{ .Values.docker.registry.external -}}/grafana/promtail
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/guacamole/guacd.deployment.yaml
+++ b/helm/templates/guacamole/guacd.deployment.yaml
@@ -80,7 +80,7 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
-          image: {{ .Values.docker.registry.external -}}{{- .Values.docker.images.promtail }}
+          image: {{ .Values.docker.registry.external -}}/grafana/promtail
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: prometheus
-          image: {{ .Values.docker.registry.external }}{{ .Values.docker.images.prometheus }}
+          image: {{ .Values.docker.registry.external }}/prom/prometheus
           args:
             - "--storage.tsdb.retention.time=12h"
             - "--config.file=/etc/prometheus/prometheus.yml"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,11 +41,6 @@ docker:
       guacamole: docker.io/guacamole/guacamole:1.5.0
       guacd: docker.io/guacamole/guacd:1.5.0
 
-    prometheus: /prom/prometheus
-
-    promtail: /grafana/promtail
-    grafana: /grafana/grafana
-
     mocks:
       oauth: ghcr.io/navikt/mock-oauth2-server:0.5.8
 


### PR DESCRIPTION
Grafana stopped working with version 10.0.0 in our setup. It is producing TOO_MANY_REDIRECTS errors and sometimes redirects to "http://localhost:8080/grafana".

Until we found the root cause, we'll downgrade the version as a quick-fix.

Resolves #804