### PR TITLE
Guacamole version update

### DIFF
--- a/guacamole/Dockerfile
+++ b/guacamole/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM guacamole/guacamole:1.5.0
+FROM guacamole/guacamole:1.5.2
 
 USER root
 RUN chmod -R 777 \

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,8 +38,8 @@ docker:
 
     guacamole:
       # The registry needs to specified here!
-      guacamole: docker.io/guacamole/guacamole:1.5.0
-      guacd: docker.io/guacamole/guacd:1.5.0
+      guacamole: docker.io/guacamole/guacamole:1.5.2
+      guacd: docker.io/guacamole/guacd:1.5.2
 
     mocks:
       oauth: ghcr.io/navikt/mock-oauth2-server:0.5.8


### PR DESCRIPTION
The current Guacamole version seems to be unstable. There are two new minor versions since 1.5.2 and we should install them.