### PR TITLE
Fix pipeline job

### DIFF
--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -736,6 +736,7 @@ class KubernetesOperator:
         image: str,
         job_labels: dict[str, str],
         environment: dict[str, str | None],
+        args: list[str] | None = None,
         timeout=18000,
     ) -> client.V1Job:
         job: client.V1Job = client.V1Job(

--- a/backend/tests/sessions/test_session_operator_k8s.py
+++ b/backend/tests/sessions/test_session_operator_k8s.py
@@ -7,11 +7,10 @@ import os
 import kubernetes.config
 import pytest
 
-if not os.getenv("CI"):
-    from capellacollab.sessions.operators.k8s import (
-        KubernetesOperator,
-        lazy_b64decode,
-    )
+from capellacollab.sessions.operators.k8s import (
+    KubernetesOperator,
+    lazy_b64decode,
+)
 
 hello = base64.b64encode(b"hello")  # aGVsbG8=
 

--- a/backend/tests/sessions/test_session_operator_k8s.py
+++ b/backend/tests/sessions/test_session_operator_k8s.py
@@ -4,6 +4,7 @@
 import base64
 import os
 
+import kubernetes.config
 import pytest
 
 if not os.getenv("CI"):
@@ -61,3 +62,19 @@ class MockStream:
 
     def read_stdout(self, timeout=None):
         return self._blocks.pop(0)
+
+
+def test_create_job(monkeypatch):
+    monkeypatch.setattr(kubernetes.config, "load_config", lambda **_: None)
+    operator = KubernetesOperator()
+    monkeypatch.setattr(
+        operator.v1_batch, "create_namespaced_job", lambda namespace, job: None
+    )
+    result = operator.create_job(
+        image="fakeimage",
+        command="fakecmd",
+        labels={"key": "value"},
+        environment={"ENVVAR": "value"},
+    )
+
+    assert result

--- a/backend/tests/sessions/test_session_operator_k8s.py
+++ b/backend/tests/sessions/test_session_operator_k8s.py
@@ -78,3 +78,20 @@ def test_create_job(monkeypatch):
     )
 
     assert result
+
+
+def test_create_cronjob(monkeypatch):
+    monkeypatch.setattr(kubernetes.config, "load_config", lambda **_: None)
+    operator = KubernetesOperator()
+    monkeypatch.setattr(
+        operator.v1_batch,
+        "create_namespaced_cron_job",
+        lambda namespace, job: None,
+    )
+    result = operator.create_cronjob(
+        image="fakeimage",
+        command="fakecmd",
+        environment={"ENVVAR": "value"},
+    )
+
+    assert result


### PR DESCRIPTION
Due to an incomplete change, pipeline jobs cannot be created in the latest version of Collab manager.

This PR fixes the regression.