### PR TITLE
feat: automatically select the recommended tool version

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
@@ -27,7 +27,7 @@ export class CreatePersistentSessionComponent implements OnInit {
 
   public toolSelectionForm = new FormGroup({
     toolId: new FormControl(null, Validators.required),
-    versionId: new FormControl(null, Validators.required),
+    versionId: new FormControl<number | null>(null, Validators.required),
   });
 
   constructor(
@@ -63,6 +63,11 @@ export class CreatePersistentSessionComponent implements OnInit {
       .getVersionsForTool(toolId)
       .subscribe((res: ToolVersion[]) => {
         this.versions = res;
+        if (res.length) {
+          this.toolSelectionForm.controls.versionId.setValue(
+            (res.filter((value) => value.is_recommended).at(0) || res[0]).id
+          );
+        }
       });
   }
 }


### PR DESCRIPTION
This saves selecting the recommended version by hand.

This fulfills #628 in a minimal way: no need for cookie or local storage.

Also, by selecting the recommended tool by default we nudge users into using those over older versions.