### PR TITLE
fix: Failing backups for Capella >= 6.0.0 without HTTP port

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -39,10 +39,12 @@ def get_environment(
             "HTTP_LOGIN": t4c_model.repository.instance.username,
             "HTTP_PASSWORD": t4c_model.repository.instance.password,
             "HTTP_PORT": str(http_port),
+            "CONNECTION_TYPE": "http",
         }
     else:
         env |= env | {
-            "T4C_CDO_PORT": str(t4c_model.repository.instance.cdo_port)
+            "T4C_CDO_PORT": str(t4c_model.repository.instance.cdo_port),
+            "CONNECTION_TYPE": "telnet",
         }
 
     return env


### PR DESCRIPTION
Our backup image defauls to the HTTP connection method for all Capella versions >= 6.0.0.
However, the Collaboration Manager is not passing the HTTP_PORT, HTTP_USERNAME and HTTP_PASSWORD variables when the http port in not set on corresponding TeamForCapella instance.

If the HTTP port is not set, we should fall back to the telnet connection method.
Therefore, we're now passing the CONNECTION_TYPE variable explicitly.