### PR TITLE
feat: Make loading of monitoring overview async

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -18,6 +18,9 @@ import capellacollab.sessions.metrics
 from capellacollab.config import config
 from capellacollab.core import logging as core_logging
 from capellacollab.core.database import engine, migration
+from capellacollab.projects.toolmodels.modelsources.git.gitlab import (
+    exceptions as gitlab_exceptions,
+)
 from capellacollab.routes import router
 from capellacollab.sessions import idletimeout, operators
 from capellacollab.tools import exceptions as tools_exceptions
@@ -116,6 +119,7 @@ app.include_router(router, prefix="/api/v1")
 
 def register_exceptions():
     tools_exceptions.register_exceptions(app)
+    gitlab_exceptions.register_exceptions(app)
 
 
 register_exceptions()

--- a/backend/capellacollab/projects/toolmodels/diagrams/routes.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/routes.py
@@ -34,7 +34,7 @@ router = fastapi.APIRouter(
 
 
 @router.get("", response_model=models.DiagramCacheMetadata)
-def get_diagram_metadata(
+async def get_diagram_metadata(
     git_model: git_models.DatabaseGitModel = fastapi.Depends(
         git_injectables.get_existing_primary_git_model
     ),
@@ -45,7 +45,7 @@ def get_diagram_metadata(
         git_instance,
         project_id,
         last_successful_job,
-    ) = gitlab_interface.get_last_job_run_id_for_git_model(
+    ) = await gitlab_interface.get_last_job_run_id_for_git_model(
         db, "update_capella_diagram_cache", git_model
     )
 
@@ -75,7 +75,7 @@ def get_diagram_metadata(
 
 
 @router.get("/{diagram_uuid}", response_class=fastapi.responses.Response)
-def get_diagram(
+async def get_diagram(
     diagram_uuid: str,
     git_model: git_models.DatabaseGitModel = fastapi.Depends(
         git_injectables.get_existing_primary_git_model
@@ -87,7 +87,7 @@ def get_diagram(
         git_instance,
         project_id,
         last_successful_job,
-    ) = gitlab_interface.get_last_job_run_id_for_git_model(
+    ) = await gitlab_interface.get_last_job_run_id_for_git_model(
         db, "update_capella_diagram_cache", git_model
     )
 

--- a/backend/capellacollab/projects/toolmodels/diagrams/validation.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/validation.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from sqlalchemy import orm
 
 import capellacollab.projects.toolmodels.models as toolmodels_models
@@ -9,8 +11,10 @@ import capellacollab.projects.toolmodels.modelsources.git.gitlab.validation as g
 
 
 def check_diagram_cache_health(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session,
+    model: toolmodels_models.DatabaseCapellaModel,
+    logger: logging.LoggerAdapter,
 ) -> gitlab_models.ModelArtifactStatus:
     return gitlab_validation.check_pipeline_health(
-        db, model, "update_capella_diagram_cache"
+        db, model, "update_capella_diagram_cache", logger
     )

--- a/backend/capellacollab/projects/toolmodels/modelbadge/validation.py
+++ b/backend/capellacollab/projects/toolmodels/modelbadge/validation.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from sqlalchemy import orm
 
 import capellacollab.projects.toolmodels.models as toolmodels_models
@@ -8,9 +10,11 @@ import capellacollab.projects.toolmodels.modelsources.git.gitlab.models as gitla
 import capellacollab.projects.toolmodels.modelsources.git.gitlab.validation as gitlab_validation
 
 
-def check_model_badge_health(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+async def check_model_badge_health(
+    db: orm.Session,
+    model: toolmodels_models.DatabaseCapellaModel,
+    logger: logging.LoggerAdapter,
 ) -> gitlab_models.ModelArtifactStatus:
-    return gitlab_validation.check_pipeline_health(
-        db, model, "generate-model-badge"
+    return await gitlab_validation.check_pipeline_health(
+        db, model, "generate-model-badge", logger
     )

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import fastapi
+from fastapi import exception_handlers, status
+
+
+class GitRepositoryFileNotFoundError(Exception):
+    def __init__(self, filename: str):
+        self.filename = filename
+
+
+class GitInstanceAPIEndpointNotFoundError(Exception):
+    pass
+
+
+async def git_repository_file_not_found_handler(
+    request: fastapi.Request, exc: GitRepositoryFileNotFoundError
+) -> fastapi.Response:
+    return await exception_handlers.http_exception_handler(
+        request,
+        fastapi.HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "err_code": "FILE_NOT_FOUND",
+                "reason": (
+                    f"No file with the name '{exc.filename}' found in the linked Git repository."
+                    "Please contact your administrator.",
+                ),
+            },
+        ),
+    )
+
+
+async def git_instance_api_endpoint_not_found_handler(
+    request: fastapi.Request, _: GitInstanceAPIEndpointNotFoundError
+) -> fastapi.Response:
+    return await exception_handlers.http_exception_handler(
+        request,
+        fastapi.HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "err_code": "GIT_INSTANCE_NO_API_ENDPOINT_DEFINED",
+                "reason": (
+                    "The used Git instance has no API endpoint defined.",
+                    "Please contact your administrator.",
+                ),
+            },
+        ),
+    )
+
+
+def register_exceptions(app: fastapi.FastAPI):
+    app.add_exception_handler(
+        GitRepositoryFileNotFoundError,
+        git_repository_file_not_found_handler,
+    )
+    app.add_exception_handler(
+        GitInstanceAPIEndpointNotFoundError,
+        git_instance_api_endpoint_not_found_handler,
+    )

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/interface.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/interface.py
@@ -4,6 +4,7 @@
 import base64
 from urllib import parse
 
+import aiohttp
 import fastapi
 import requests
 from fastapi import status
@@ -13,18 +14,21 @@ import capellacollab.projects.toolmodels.modelsources.git.models as git_models
 import capellacollab.settings.modelsources.git.crud as settings_git_crud
 import capellacollab.settings.modelsources.git.models as settings_git_models
 
+from . import exceptions
 
-def get_last_job_run_id_for_git_model(
+
+async def get_last_job_run_id_for_git_model(
     db: orm.Session, job_name: str, git_model: git_models.DatabaseGitModel
 ) -> tuple[settings_git_models.DatabaseGitInstance, str, tuple[str, str]]:
-    git_instance = get_git_instance_for_git_model(db, git_model)
-    check_git_instance_is_gitlab(git_instance)
-    check_git_instance_has_api_url(git_instance)
-    project_id = get_project_id_by_git_url(git_model, git_instance)
-    for pipeline_id in get_last_pipeline_run_ids(
+    git_instance = await get_git_instance_for_git_model(db, git_model)
+    await check_git_instance_is_gitlab(git_instance)
+    await check_git_instance_has_api_url(git_instance)
+
+    project_id = await get_project_id_by_git_url(git_model, git_instance)
+    for pipeline_id in await get_last_pipeline_run_ids(
         project_id, git_model, git_instance
     ):
-        if job := get_job_id_for_job_name(
+        if job := await get_job_id_for_job_name(
             project_id, pipeline_id, job_name, git_model, git_instance
         ):
             return git_instance, project_id, job
@@ -41,7 +45,7 @@ def get_last_job_run_id_for_git_model(
     )
 
 
-def get_git_instance_for_git_model(
+async def get_git_instance_for_git_model(
     db: orm.Session, git_model: git_models.DatabaseGitModel
 ) -> settings_git_models.DatabaseGitInstance:
     """Get the corresponding git instance for a git model
@@ -69,7 +73,7 @@ def get_git_instance_for_git_model(
     )
 
 
-def check_git_instance_is_gitlab(
+async def check_git_instance_is_gitlab(
     git_instance: settings_git_models.DatabaseGitInstance,
 ):
     if git_instance.type != settings_git_models.GitType.GITLAB:
@@ -85,23 +89,14 @@ def check_git_instance_is_gitlab(
         )
 
 
-def check_git_instance_has_api_url(
+async def check_git_instance_has_api_url(
     git_instance: settings_git_models.DatabaseGitInstance,
 ):
     if not git_instance.api_url:
-        raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={
-                "err_code": "GIT_INSTANCE_NO_API_ENDPOINT_DEFINED",
-                "reason": (
-                    "The used Git instance has no API endpoint defined.",
-                    "Please contact your administrator.",
-                ),
-            },
-        )
+        raise exceptions.GitInstanceAPIEndpointNotFoundError()
 
 
-def get_project_id_by_git_url(
+async def get_project_id_by_git_url(
     git_model: git_models.DatabaseGitModel,
     git_instance: settings_git_models.DatabaseGitInstance,
 ) -> str:
@@ -109,55 +104,56 @@ def get_project_id_by_git_url(
         parse.urlparse(git_model.path).path.lstrip("/").removesuffix(".git"),
         safe="",
     )
-    response = requests.get(
-        f"{git_instance.api_url}/projects/{project_name_encoded}",
-        headers={"PRIVATE-TOKEN": git_model.password},
-        timeout=2,
-    )
-    if response.status_code == 403:
-        raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={
-                "err_code": "GITLAB_ACCESS_DENIED",
-                "reason": (
-                    "The registered token has not enough permissions to access the Gitlab API.",
-                    "Access scope 'read_api' is required. Please contact your project lead.",
-                ),
-            },
-        )
-    if response.status_code == 404:
-        raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={
-                "err_code": "PROJECT_NOT_FOUND",
-                "reason": (
-                    "We couldn't find the project in your Gitlab instance.",
-                    f"Please make sure that a project with the encoded name '{project_name_encoded}' does exist.",
-                ),
-            },
-        )
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{git_instance.api_url}/projects/{project_name_encoded}",
+            headers={"PRIVATE-TOKEN": git_model.password},
+            timeout=2,
+        ) as response:
+            if response.status == 403:
+                raise fastapi.HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail={
+                        "err_code": "GITLAB_ACCESS_DENIED",
+                        "reason": (
+                            "The registered token has not enough permissions to access the Gitlab API.",
+                            "Access scope 'read_api' is required. Please contact your project lead.",
+                        ),
+                    },
+                )
+            if response.status == 404:
+                raise fastapi.HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail={
+                        "err_code": "PROJECT_NOT_FOUND",
+                        "reason": (
+                            "We couldn't find the project in your Gitlab instance.",
+                            f"Please make sure that a project with the encoded name '{project_name_encoded}' does exist.",
+                        ),
+                    },
+                )
 
-    response.raise_for_status()
+            response.raise_for_status()
+            return (await response.json())["id"]
 
-    return response.json()["id"]
 
-
-def get_last_pipeline_run_ids(
+async def get_last_pipeline_run_ids(
     project_id: str,
     git_model: git_models.DatabaseGitModel,
     git_instance: settings_git_models.DatabaseGitInstance,
 ) -> list[str]:
-    response = requests.get(
-        f"{git_instance.api_url}/projects/{project_id}/pipelines?ref={parse.quote(git_model.revision, safe='')}&per_page=20",
-        headers={"PRIVATE-TOKEN": git_model.password},
-        timeout=2,
-    )
-    response.raise_for_status()
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{git_instance.api_url}/projects/{project_id}/pipelines?ref={parse.quote(git_model.revision, safe='')}&per_page=20",
+            headers={"PRIVATE-TOKEN": git_model.password},
+            timeout=2,
+        ) as response:
+            response.raise_for_status()
 
-    return [pipeline["id"] for pipeline in response.json()]
+            return [pipeline["id"] for pipeline in await response.json()]
 
 
-def get_job_id_for_job_name(
+async def get_job_id_for_job_name(
     project_id: str,
     pipeline_id: str,
     job_name: str,
@@ -165,30 +161,31 @@ def get_job_id_for_job_name(
     git_instance: settings_git_models.DatabaseGitInstance,
 ) -> tuple[str, str] | None:
     """Search for a job by name in a pipeline"""
-    response = requests.get(
-        f"{git_instance.api_url}/projects/{project_id}/pipelines/{pipeline_id}/jobs",
-        headers={"PRIVATE-TOKEN": git_model.password},
-        timeout=2,
-    )
-    response.raise_for_status()
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+            f"{git_instance.api_url}/projects/{project_id}/pipelines/{pipeline_id}/jobs",
+            headers={"PRIVATE-TOKEN": git_model.password},
+            timeout=2,
+        ) as response:
+            response.raise_for_status()
 
-    for job in response.json():
-        if job["name"] == job_name:
-            if job["status"] == "success":
-                return job["id"], job["started_at"]
-            if job["status"] == "failed":
-                raise fastapi.HTTPException(
-                    status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail={
-                        "err_code": "FAILED_JOB_FOUND",
-                        "reason": (
-                            f"The last job with the name '{job_name}' has failed.",
-                            "Please contact your administrator.",
-                        ),
-                    },
-                )
+            for job in await response.json():
+                if job["name"] == job_name:
+                    if job["status"] == "success":
+                        return job["id"], job["started_at"]
+                    if job["status"] == "failed":
+                        raise fastapi.HTTPException(
+                            status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+                            detail={
+                                "err_code": "FAILED_JOB_FOUND",
+                                "reason": (
+                                    f"The last job with the name '{job_name}' has failed.",
+                                    "Please contact your administrator.",
+                                ),
+                            },
+                        )
 
-    return None
+            return None
 
 
 def get_artifact_from_job_as_json(
@@ -242,19 +239,24 @@ def __get_file_from_repository(
         headers={"PRIVATE-TOKEN": git_model.password},
         timeout=2,
     )
+    if response.status_code == 404:
+        raise exceptions.GitRepositoryFileNotFoundError(
+            filename=trusted_file_path
+        )
+
     response.raise_for_status()
     return base64.b64decode(response.json()["content"])
 
 
-def get_file_from_repository(
+async def get_file_from_repository(
     db: orm.Session,
     trusted_file_path: str,
     git_model: git_models.DatabaseGitModel,
 ) -> requests.Response:
-    git_instance = get_git_instance_for_git_model(db, git_model)
-    check_git_instance_is_gitlab(git_instance)
-    check_git_instance_has_api_url(git_instance)
-    project_id = get_project_id_by_git_url(git_model, git_instance)
+    git_instance = await get_git_instance_for_git_model(db, git_model)
+    await check_git_instance_is_gitlab(git_instance)
+    await check_git_instance_has_api_url(git_instance)
+    project_id = await get_project_id_by_git_url(git_model, git_instance)
     return __get_file_from_repository(
         project_id, trusted_file_path, git_model, git_instance
     )

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
@@ -109,12 +109,12 @@ def get_git_model_by_id(
         )
     ],
 )
-def get_revisions_of_primary_git_model(
+async def get_revisions_of_primary_git_model(
     primary_git_model: DatabaseGitModel = fastapi.Depends(
         get_existing_primary_git_model
     ),
 ) -> GetRevisionsResponseModel:
-    return get_remote_refs(
+    return await get_remote_refs(
         primary_git_model.path,
         primary_git_model.username,
         primary_git_model.password,
@@ -133,11 +133,11 @@ def get_revisions_of_primary_git_model(
         )
     ],
 )
-def get_revisions_with_model_credentials(
+async def get_revisions_with_model_credentials(
     url: str = fastapi.Body(),
     git_model: DatabaseGitModel = fastapi.Depends(get_existing_git_model),
 ):
-    return get_remote_refs(url, git_model.username, git_model.password)
+    return await get_remote_refs(url, git_model.username, git_model.password)
 
 
 @router.post(

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/validation.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/validation.py
@@ -11,7 +11,7 @@ from ... import models as toolmodels_models
 from . import crud, models
 
 
-def check_primary_git_repository(
+async def check_primary_git_repository(
     db: orm.Session,
     model: toolmodels_models.DatabaseCapellaModel,
     log: logging.LoggerAdapter,
@@ -21,7 +21,7 @@ def check_primary_git_repository(
         return models.GitModelStatus.UNSET
 
     try:
-        git_core.get_remote_refs(
+        await git_core.get_remote_refs(
             primary_repo.path,
             primary_repo.username,
             primary_repo.password,

--- a/backend/capellacollab/settings/modelsources/git/routes.py
+++ b/backend/capellacollab/settings/modelsources/git/routes.py
@@ -104,11 +104,11 @@ def delete_git_instances(
 # and if so, use it instead of POST
 # (https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-02.html)
 @router.post("/revisions", response_model=models.GetRevisionsResponseModel)
-def get_revisions(
+async def get_revisions(
     body: models.GetRevisionModel,
 ) -> models.GetRevisionsResponseModel:
     url = body.url
     username = body.credentials.username
     password = body.credentials.password
 
-    return settings_git_core.get_remote_refs(url, username, password)
+    return await settings_git_core.get_remote_refs(url, username, password)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "starlette-prometheus",
   "pytz",
   "fastapi-pagination",
+  "aiohttp"
 ]
 
 [project.urls]
@@ -63,6 +64,7 @@ dev = [
   "responses",
   "sqlalchemy[mypy]",
   "pytest-cov",
+  "aioresponses"
 ]
 psycopg2 = [
   "psycopg2", # Need when running in a Docker container with AArch64: https://github.com/psycopg/psycopg2/issues/1360

--- a/backend/tests/projects/toolmodels/test_model_badge.py
+++ b/backend/tests/projects/toolmodels/test_model_badge.py
@@ -6,6 +6,7 @@ import base64
 
 import pytest
 import responses
+from aioresponses import aioresponses
 from fastapi import testclient
 from sqlalchemy import orm
 
@@ -47,11 +48,13 @@ def fixture_gitlab_instance(
 
 @pytest.fixture()
 def mock_gitlab_rest_api():
-    responses.get(
-        "https://example.com/api/v4/projects/test%2Fproject",
-        status=200,
-        json={"id": "10000"},
-    )
+    with aioresponses() as mocked:
+        mocked.get(
+            "https://example.com/api/v4/projects/test%2Fproject",
+            status=200,
+            payload={"id": "10000"},
+        )
+        yield mocked
 
 
 @pytest.fixture
@@ -155,9 +158,7 @@ def test_get_model_badge_not_found(
     )
 
     assert response.status_code == 404
-    assert (
-        response.json()["detail"]["err_code"] == "COMPLEXITY_BADGE_NOT_FOUND"
-    )
+    assert response.json()["detail"]["err_code"] == "FILE_NOT_FOUND"
 
 
 @responses.activate

--- a/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.html
@@ -7,7 +7,7 @@
   <div
     (click)="openModelComplexityBadgeDocs()"
     class="model-complexity-error model-complexity-create"
-    *ngIf="errorCode === 'COMPLEXITY_BADGE_NOT_FOUND'"
+    *ngIf="errorCode === 'FILE_NOT_FOUND'"
   >
     <mat-icon class="model-complexity-error-icon">open_in_new</mat-icon>
     <span class="model-complexity-error-text"
@@ -21,7 +21,7 @@
     *ngIf="
       !loadingComplexityBadge &&
       !complexityBadge &&
-      errorCode !== 'COMPLEXITY_BADGE_NOT_FOUND'
+      errorCode !== 'FILE_NOT_FOUND'
     "
   >
     <mat-icon class="model-complexity-error-icon">error</mat-icon>


### PR DESCRIPTION
Loading the monitoring overview can take minutes when having many models.
We're waiting a lot for responses from the Gitlab API. This PR adds support for asynchronous calls in the Gitlab interface.

Tested it against a production database of our largest instance. Loading time of the monitoring view is reduced from 2.5 minutes to 8 seconds.