### PR TITLE
Fix: Set fastapi version to `<0.100.0`

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "alembic==1.10.4",
   "appdirs",
   "cachetools",
-  "fastapi>=0.89.1",
+  "fastapi<0.100.0",
   "kubernetes",
   "msal",
   "psycopg2-binary",
@@ -43,7 +43,7 @@ dependencies = [
   "openshift",
   "starlette-prometheus",
   "pytz",
-  "fastapi-pagination"
+  "fastapi-pagination",
 ]
 
 [project.urls]
@@ -77,13 +77,10 @@ line-length = 79
 target-version = ["py311"]
 
 [tool.coverage.run]
-source = [ "capellacollab" ]
+source = ["capellacollab"]
 branch = true
 command_line = "-m pytest"
-omit = [
-  "tests/*",
-  "capellacollab/alembic/*"
-]
+omit = ["tests/*", "capellacollab/alembic/*"]
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
In fastapi version 0.100.0 pydantic v2 where introduced. Even though there shouldn't be that many breaking changes, when running `make deploy` locally I get the following error: `AttributeError: module 'pydantic._migration' has no attribute 'GenericModel'`. This PR resolves this for the moment by setting the fastapi version to `<0.100.0`.

Migration to pydantic v2 is tracked in #833 