### PR TITLE
fix: Reset audit log on project change and display user

### DIFF
--- a/frontend/src/app/projects/project-detail/project-users/project-audit-log/project-audit-log.component.html
+++ b/frontend/src/app/projects/project-detail/project-users/project-audit-log/project-audit-log.component.html
@@ -8,6 +8,7 @@
     <thead>
       <tr class="font-semibold text-base">
         <td>Event type</td>
+        <td>User</td>
         <td>Executor name</td>
         <td>Execution time</td>
         <td>Project slug</td>
@@ -38,6 +39,9 @@
           <tr>
             <td>
               {{ run.event_type }}
+            </td>
+            <td>
+              {{ run.user.name || "system" }}
             </td>
             <td>
               {{ run.executor?.name || "system" }}

--- a/frontend/src/app/projects/project-detail/project-users/project-audit-log/service/project-audit-log.service.ts
+++ b/frontend/src/app/projects/project-detail/project-users/project-audit-log/service/project-audit-log.service.ts
@@ -6,10 +6,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, map } from 'rxjs';
-import {
-  EventsService,
-  HistoryEvent,
-} from 'src/app/events/service/events.service';
+import { HistoryEvent } from 'src/app/events/service/events.service';
+import { ProjectService } from 'src/app/projects/service/project.service';
 import { Page, PageWrapper } from 'src/app/schemes';
 import { environment } from 'src/environments/environment';
 
@@ -26,7 +24,18 @@ export class ProjectAuditLogService {
   readonly projectHistoryEventsPages$ =
     this._projectHistoryEventPages.asObservable();
 
-  constructor(private http: HttpClient, private eventService: EventsService) {}
+  constructor(
+    private http: HttpClient,
+    private projectService: ProjectService
+  ) {
+    this.resetProjectAuditLogOnPipelineChange();
+  }
+
+  resetProjectAuditLogOnPipelineChange() {
+    this.projectService.project.subscribe(() => {
+      this.resetProjectHistoryEvents();
+    });
+  }
 
   getProjectHistoryEventPage(
     pageNumber: number
@@ -72,6 +81,13 @@ export class ProjectAuditLogService {
 
         this._projectHistoryEventPages.next(projectHistoryEventPages);
       });
+  }
+
+  resetProjectHistoryEvents(): void {
+    this._projectHistoryEventPages.next({
+      pages: [],
+      total: undefined,
+    });
   }
 
   private initalizeProjectHistoryEventWrapper(


### PR DESCRIPTION
The audit log was not cleared when changing the project. It was displaying the results from the old project. 
Also, the affected user was not shown, only the person who produced the event.