### PR TITLE
fix: Show T4C repository name during backup creation

### DIFF
--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
@@ -16,7 +16,7 @@
           >
             <div mat-line>TeamForCapella model '{{ t4cModel.name }}'</div>
             <div mat-line>
-              repository '{{ t4cModel.name }}', instance '{{
+              repository '{{ t4cModel.repository.name }}', instance '{{
                 t4cModel.repository.instance.name
               }}'
             </div>


### PR DESCRIPTION
The model name was displayed twice, the repository not at all.