### PR TITLE
feat: Improve the "logs" experience and reduce number of backend calls

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -18,6 +18,9 @@ import capellacollab.sessions.metrics
 from capellacollab.config import config
 from capellacollab.core import logging as core_logging
 from capellacollab.core.database import engine, migration
+from capellacollab.projects.toolmodels.backups import (
+    exceptions as projects_toolmodels_backups_exceptions,
+)
 from capellacollab.projects.toolmodels.modelsources.git import (
     exceptions as git_exceptions,
 )
@@ -128,6 +131,7 @@ def register_exceptions():
     git_exceptions.register_exceptions(app)
     gitlab_exceptions.register_exceptions(app)
     git_handler_exceptions.register_exceptions(app)
+    projects_toolmodels_backups_exceptions.register_exceptions(app)
 
 
 register_exceptions()

--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -3,6 +3,7 @@
 
 
 import logging
+import os
 
 import fastapi
 import fastapi_pagination
@@ -137,4 +138,13 @@ def register_exceptions():
 register_exceptions()
 
 if __name__ == "__main__":
-    uvicorn.run(app)
+    if os.getenv("FASTAPI_AUTO_RELOAD", "").lower() in ("1", "true", "t"):
+        logging.getLogger("watchfiles.main").setLevel(logging.WARNING)
+        uvicorn.run(
+            "capellacollab.__main__:app",
+            reload=True,
+            reload_dirs=["capellacollab"],
+            reload_includes=["*.py", "*.yaml", "*.yml"],
+        )
+    else:
+        uvicorn.run(app)

--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -19,6 +19,7 @@ import capellacollab.sessions.metrics
 from capellacollab.config import config
 from capellacollab.core import logging as core_logging
 from capellacollab.core.database import engine, migration
+from capellacollab.core.logging import exceptions as logging_exceptions
 from capellacollab.projects.toolmodels.backups import (
     exceptions as projects_toolmodels_backups_exceptions,
 )
@@ -133,6 +134,7 @@ def register_exceptions():
     gitlab_exceptions.register_exceptions(app)
     git_handler_exceptions.register_exceptions(app)
     projects_toolmodels_backups_exceptions.register_exceptions(app)
+    logging_exceptions.register_exceptions(app)
 
 
 register_exceptions()

--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -21,7 +21,7 @@ from capellacollab.core import logging as core_logging
 from capellacollab.core.database import engine, migration
 from capellacollab.core.logging import exceptions as logging_exceptions
 from capellacollab.projects.toolmodels.backups import (
-    exceptions as projects_toolmodels_backups_exceptions,
+    exceptions as backups_exceptions,
 )
 from capellacollab.projects.toolmodels.modelsources.git import (
     exceptions as git_exceptions,
@@ -133,7 +133,7 @@ def register_exceptions():
     git_exceptions.register_exceptions(app)
     gitlab_exceptions.register_exceptions(app)
     git_handler_exceptions.register_exceptions(app)
-    projects_toolmodels_backups_exceptions.register_exceptions(app)
+    backups_exceptions.register_exceptions(app)
     logging_exceptions.register_exceptions(app)
 
 

--- a/backend/capellacollab/alembic/versions/d0cbf2813066_add_end_time_for_pipeline_run.py
+++ b/backend/capellacollab/alembic/versions/d0cbf2813066_add_end_time_for_pipeline_run.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add end_time for pipeline run
+
+Revision ID: d0cbf2813066
+Revises: 90abdec3827e
+Create Date: 2023-07-26 18:16:55.723944
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d0cbf2813066"
+down_revision = "90abdec3827e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "pipeline_run", sa.Column("end_time", sa.DateTime(), nullable=True)
+    )

--- a/backend/capellacollab/config/config_schema.yaml
+++ b/backend/capellacollab/config/config_schema.yaml
@@ -302,3 +302,9 @@ properties:
     properties:
       timeout:
         type: number
+  pipelines:
+    type: object
+    additionalProperties: false
+    properties:
+      timeout:
+        type: number

--- a/backend/capellacollab/core/logging/exceptions.py
+++ b/backend/capellacollab/core/logging/exceptions.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import fastapi
+from fastapi import exception_handlers, status
+
+
+class TooManyOutStandingRequests(Exception):
+    pass
+
+
+async def too_many_outstanding_requests_handler(
+    request: fastapi.Request, _: TooManyOutStandingRequests
+) -> fastapi.Response:
+    return await exception_handlers.http_exception_handler(
+        request,
+        fastapi.HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "err_code": "LOKI_TOO_MANY_OUTSTANDING_REQUESTS",
+                "reason": "Too many outstanding requests. Please try again later.",
+            },
+        ),
+    )
+
+
+def register_exceptions(app: fastapi.FastAPI):
+    app.add_exception_handler(
+        TooManyOutStandingRequests, too_many_outstanding_requests_handler
+    )

--- a/backend/capellacollab/core/logging/loki.py
+++ b/backend/capellacollab/core/logging/loki.py
@@ -68,6 +68,7 @@ def fetch_logs_from_loki(
     # Prepare the query parameters
     params = {
         "query": query,
+        "limit": 5000,
         "start": int(start_time.timestamp()),  # Convert to milliseconds
         "end": int(end_time.timestamp()),  # Convert to milliseconds
         "direction": "forward",

--- a/backend/capellacollab/core/logging/loki.py
+++ b/backend/capellacollab/core/logging/loki.py
@@ -83,7 +83,7 @@ def fetch_logs_from_loki(
                 PROMTAIL_CONFIGURATION["lokiUsername"],
                 PROMTAIL_CONFIGURATION["lokiPassword"],
             ),
-            timeout=10,
+            timeout=5,
         )
 
         if response.status_code == 429:

--- a/backend/capellacollab/core/logging/loki.py
+++ b/backend/capellacollab/core/logging/loki.py
@@ -12,6 +12,8 @@ from requests import auth
 
 from capellacollab.config import config
 
+from . import exceptions
+
 LOGGING_LEVEL = config["logging"]["level"]
 PROMTAIL_CONFIGURATION: dict[str, str] = config["k8s"]["promtail"]
 
@@ -83,6 +85,10 @@ def fetch_logs_from_loki(
             ),
             timeout=10,
         )
+
+        if response.status_code == 429:
+            raise exceptions.TooManyOutStandingRequests
+
         response.raise_for_status()
         logs = response.json()
         return logs["data"]["result"]

--- a/backend/capellacollab/core/logging/loki.py
+++ b/backend/capellacollab/core/logging/loki.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import http
 import json
 import logging
 import logging.handlers
@@ -87,7 +88,7 @@ def fetch_logs_from_loki(
             timeout=5,
         )
 
-        if response.status_code == 429:
+        if response.status_code == http.HTTPStatus.TOO_MANY_REQUESTS:
             raise exceptions.TooManyOutStandingRequests
 
         response.raise_for_status()

--- a/backend/capellacollab/projects/toolmodels/backups/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/backups/exceptions.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import enum
+
+import fastapi
+from fastapi import exception_handlers, status
+
+
+class PipelineOperation(enum.Enum):
+    CREATE = "create"
+    DELETE = "delete"
+
+
+class PipelineOperationFailedT4CServerUnreachable(Exception):
+    def __init__(self, operation: PipelineOperation):
+        self.operation = operation
+
+
+async def pipeline_creation_failed_t4c_server_unreachable_handler(
+    request: fastapi.Request, exc: PipelineOperationFailedT4CServerUnreachable
+) -> fastapi.Response:
+    return await exception_handlers.http_exception_handler(
+        request,
+        fastapi.HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "err_code": "PIPELINE_OPERATION_FAILED_T4C_SERVER_UNREACHABLE",
+                "title": f"The '{exc.operation.value}' operation on the pipeline failed",
+                "reason": (
+                    f"We're not able to connect to the TeamForCapella server and therefore cannot {exc.operation.value} the pipeline.",
+                    "Please try again later or contact your administrator.",
+                ),
+            },
+        ),
+    )
+
+
+def register_exceptions(app: fastapi.FastAPI):
+    app.add_exception_handler(
+        PipelineOperationFailedT4CServerUnreachable,
+        pipeline_creation_failed_t4c_server_unreachable_handler,
+    )

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -91,4 +91,8 @@ class DatabaseBackup(database.Base):
 
     runs: orm.Mapped[
         list["runs_models.DatabasePipelineRun"]
-    ] = orm.relationship("DatabasePipelineRun", back_populates="pipeline")
+    ] = orm.relationship(
+        "DatabasePipelineRun",
+        back_populates="pipeline",
+        cascade="all, delete-orphan",
+    )

--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -10,6 +10,7 @@ from kubernetes import client as k8s_client
 from kubernetes.client import exceptions as k8s_exceptions
 from starlette import concurrency as starlette_concurrency
 
+from capellacollab.config import config
 from capellacollab.core import database
 from capellacollab.core.logging import loki
 from capellacollab.projects.toolmodels.backups import core as backups_core
@@ -19,6 +20,8 @@ from capellacollab.tools import crud as tools_crud
 from . import crud, models
 
 log = logging.getLogger(__name__)
+
+PIPELINES_TIMEOUT = config.get("pipelines", {}).get("timeout", 60)
 
 
 async def schedule_refresh_and_trigger_pipeline_jobs(interval=5):
@@ -125,7 +128,7 @@ def _transform_kubernetes_event_to_loki_entry(
     )
 
 
-def _fetch_events_of_jobs(run: models.DatabasePipelineRun):
+def _fetch_events_of_job_run(run: models.DatabasePipelineRun):
     log.debug("Fetch events of job %s", run.id)
     operator = operators.get_operator()
     try:
@@ -162,7 +165,7 @@ def _fetch_events_of_jobs(run: models.DatabasePipelineRun):
     run.logs_last_fetched_timestamp = datetime.datetime.now().astimezone()
 
 
-def _fetch_logs_of_jobs(run: models.DatabasePipelineRun):
+def _fetch_logs_of_job_runs(run: models.DatabasePipelineRun):
     log.debug("Fetch logs of job %s", run.id)
     operator = operators.get_operator()
     try:
@@ -196,26 +199,8 @@ def _fetch_logs_of_jobs(run: models.DatabasePipelineRun):
     run.logs_last_fetched_timestamp = datetime.datetime.now().astimezone()
 
 
-def _search_and_kill_timed_out_jobs(run: models.DatabasePipelineRun):
-    if (
-        run.trigger_time.astimezone()
-        < datetime.datetime.now().astimezone() - datetime.timedelta(minutes=60)
-    ):
-        log.info("Timing out job with ID %s", run.id)
-        _terminate_job(run, models.PipelineRunStatus.TIMEOUT)
-
-
-def _terminate_job(
-    run: models.DatabasePipelineRun, updated_status: models.PipelineRunStatus
-):
-    run.status = updated_status
+def _terminate_job(run: models.DatabasePipelineRun):
     run.end_time = datetime.datetime.now()
-    # Fetch logs and events one last time before killing
-    try:
-        _fetch_logs_of_jobs(run)
-        _fetch_events_of_jobs(run)
-    except Exception:
-        pass
 
     try:
         operators.get_operator().delete_job(name=run.reference_id)
@@ -262,10 +247,18 @@ def _map_k8s_to_internal_status(
     return models.PipelineRunStatus.UNKNOWN
 
 
-def _update_status_of_job(
+def _update_status_of_job_run(
     run: models.DatabasePipelineRun,
 ):
     log.debug("Update status of pipeline", extra={"run_id": run.id})
+    if (
+        run.trigger_time.astimezone()
+        < datetime.datetime.now().astimezone()
+        - datetime.timedelta(minutes=PIPELINES_TIMEOUT)
+    ):
+        run.status = models.PipelineRunStatus.TIMEOUT
+        return
+
     try:
         job = operators.get_operator().get_job_by_name(run.reference_id)
     except k8s_exceptions.ApiException:
@@ -274,11 +267,8 @@ def _update_status_of_job(
         )
         run.status = models.PipelineRunStatus.UNKNOWN
         return
-    current_status = _map_k8s_to_internal_status(job)
 
-    if _job_is_finished(current_status):
-        _terminate_job(run, current_status)
-        return
+    current_status = _map_k8s_to_internal_status(job)
 
     if current_status != run.status:
         log.debug("Update status of pipeline %s to %s", run.id, run.status)
@@ -290,6 +280,7 @@ def _job_is_finished(status: models.PipelineRunStatus):
         models.PipelineRunStatus.FAILURE,
         models.PipelineRunStatus.SUCCESS,
         models.PipelineRunStatus.UNKNOWN,
+        models.PipelineRunStatus.TIMEOUT,
     )
 
 
@@ -298,12 +289,7 @@ def _refresh_and_trigger_pipeline_jobs():
     with database.SessionLocal() as db:
         for run in crud.get_scheduled_or_running_pipelines(db):
             try:
-                _search_and_kill_timed_out_jobs(run)
-            except:  # pylint: disable=bare-except
-                log.error("Failed timeout of jobs", exc_info=True)
-
-            try:
-                _update_status_of_job(run)
+                _update_status_of_job_run(run)
             except:  # pylint: disable=bare-except
                 log.error(
                     "Failed updating the status of running and scheduled jobs",
@@ -311,7 +297,7 @@ def _refresh_and_trigger_pipeline_jobs():
                 )
 
             try:
-                _fetch_events_of_jobs(run)
+                _fetch_events_of_job_run(run)
             except:  # pylint: disable=bare-except
                 log.error(
                     "Failed fetching events of jobs",
@@ -319,10 +305,14 @@ def _refresh_and_trigger_pipeline_jobs():
                 )
 
             try:
-                _fetch_logs_of_jobs(run)
+                _fetch_logs_of_job_runs(run)
             except:  # pylint: disable=bare-except
                 log.error(
                     "Failed fetching logs of jobs",
                     exc_info=True,
                 )
+
+            if _job_is_finished(run.status):
+                _terminate_job(run)
+
             db.commit()

--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -105,7 +105,7 @@ def _transform_kubernetes_logline_to_loki_entry(
 
     # Transform UTC from kubernetes to local timezone
     timestamp = _transform_utc_to_local_timestamp(timestamp)
-    return loki.LogEntry(timestamp=timestamp, line=" ".join(line.split()[1:]))
+    return loki.LogEntry(timestamp=timestamp, line=line[31:])
 
 
 def _transform_kubernetes_event_to_loki_entry(

--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -113,8 +113,10 @@ def _transform_kubernetes_event_to_loki_entry(
 ) -> loki.LogEntry:
     # Transform UTC from kubernetes to local timezone
     timestamp = (
-        _transform_utc_to_local_timestamp(event.last_timestamp)
-        if event.last_timestamp
+        _transform_utc_to_local_timestamp(
+            event.last_timestamp or event.event_time
+        )
+        if event.last_timestamp or event.event_time
         else datetime.datetime.now()
     )
     return loki.LogEntry(

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -48,6 +48,7 @@ class DatabasePipelineRun(Base):
     )
 
     trigger_time: orm.Mapped[datetime.datetime]
+    end_time: orm.Mapped[datetime.datetime | None]
     logs_last_fetched_timestamp: orm.Mapped[datetime.datetime | None]
 
     environment: orm.Mapped[dict[str, str]]

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -147,7 +147,7 @@ def get_logs(
     logs = loki.fetch_logs_from_loki(
         query=f'{{pipeline_run_id="{pipeline_run.id}", job_name="{pipeline_run.reference_id}", log_type="logs"}}',
         start_time=pipeline_run.trigger_time,
-        end_time=datetime.datetime.now().astimezone(),
+        end_time=_determine_end_time_from_pipeline_run(pipeline_run),
     )
     if not logs:
         return ""

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -18,7 +18,7 @@ from capellacollab.users import models as user_models
 
 from .. import injectables as pipeline_injectables
 from .. import models as pipeline_models
-from . import crud, helper, injectables, models
+from . import crud, helper, injectables, interface, models
 
 router = fastapi.APIRouter(
     dependencies=[
@@ -122,8 +122,8 @@ def _determine_end_time_from_pipeline_run(
     pipeline_run: models.DatabasePipelineRun,
 ) -> datetime.datetime:
     max_pipeline_run_duration = datetime.timedelta(
-        minutes=65
-    )  # Pipelines are timed out after 60 minutes + 5 minutes tolerance
+        minutes=interface.PIPELINES_TIMEOUT + 5
+    )  # Add 5 minutes tolerance to pipeline timeout
     return min(
         pipeline_run.trigger_time + max_pipeline_run_duration,
         pipeline_run.end_time or datetime.datetime.now(),

--- a/backend/config/config_template.yaml
+++ b/backend/config/config_template.yaml
@@ -81,6 +81,9 @@ authentication:
   #   audience: tbd
   #   redirectURI: http://localhost:4200/oauth2/callback
 
+pipelines:
+  timeout: 60
+
 database:
   url: postgresql://dev:dev@localhost:5432/dev
 

--- a/backend/tests/projects/toolmodels/pipelines/pipeline-runs/test_pipeline_runs.py
+++ b/backend/tests/projects/toolmodels/pipelines/pipeline-runs/test_pipeline_runs.py
@@ -156,7 +156,10 @@ def fixture_mock_pipeline_run():
     # Assign the values you want the mock object to return
     mock_pipeline_run.id = "mock_id"
     mock_pipeline_run.reference_id = "mock_reference_id"
-    mock_pipeline_run.trigger_time = "mock_time"
+    mock_pipeline_run.trigger_time = (
+        datetime.datetime.now() - datetime.timedelta(minutes=1)
+    )
+    mock_pipeline_run.end_time = datetime.datetime.now()
 
     # These values will be masked
     mock_pipeline_run.pipeline.t4c_password = "secret_pipeline_t4c_password"

--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -167,7 +167,7 @@ def test_pipeline_creation_fails_if_t4c_server_not_available(
     assert response.status_code == 503
     assert (
         response.json()["detail"]["err_code"]
-        == "PIPELINE_CREATION_FAILED_T4C_SERVER_UNREACHABLE"
+        == "PIPELINE_OPERATION_FAILED_T4C_SERVER_UNREACHABLE"
     )
 
 

--- a/frontend/src/app/projects/models/backup-settings/pipeline-runs/wrapper/pipeline-run-wrapper/pipeline-run-wrapper.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/pipeline-runs/wrapper/pipeline-run-wrapper/pipeline-run-wrapper.component.ts
@@ -34,20 +34,22 @@ export class PipelineRunWrapperComponent implements OnDestroy {
         filter((pipeline) => pipeline === undefined)
       ),
       this.route.params.pipe(
-        map((params) => params.pipelineRun as number),
-        filter((pipelineRun) => pipelineRun === undefined)
+        filter((params) => params?.pipelineRun === undefined)
       ),
     ]).subscribe(() => {
       this.pipelineRunService.resetPipelineRun();
     });
 
+    // If the last pipeline run was finished, don't update anymore.
     timer(0, 2000)
       .pipe(
         switchMap(() => this.pipelineRunService.pipelineRun$.pipe(take(1))),
         filter(
           (pipelineRun) =>
-            !pipelineRun ||
-            !this.pipelineRunService.pipelineRunIsFinished(pipelineRun?.status)
+            !(
+              pipelineRun &&
+              this.pipelineRunService.pipelineRunIsFinished(pipelineRun.status)
+            )
         ),
         tap(() => this.updatePipelineRun()),
         untilDestroyed(this)
@@ -65,9 +67,9 @@ export class PipelineRunWrapperComponent implements OnDestroy {
       .pipe(untilDestroyed(this), take(1))
       .subscribe(([project, model, pipeline, pipelineRunID]) =>
         this.pipelineRunService.loadPipelineRun(
-          project!.slug,
-          model!.slug,
-          pipeline!.id,
+          project.slug,
+          model.slug,
+          pipeline.id,
           pipelineRunID
         )
       );

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.css
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.css
@@ -20,3 +20,7 @@
   flex-direction: row;
   justify-content: space-between;
 }
+
+pre {
+  white-space: pre-wrap;
+}

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div class="wrapper dialog" *ngIf="pipelineRunService.pipelineRun$ | async">
+<div *ngIf="pipelineRunService.pipelineRun$ | async">
   <div class="header">
     <h1>
       Logs for pipeline run
@@ -11,7 +11,7 @@
     </h1>
   </div>
 
-  <div class="content">
+  <div>
     <h2>Status</h2>
     <div>
       The current pipeline status is '{{
@@ -19,9 +19,10 @@
       }}'
     </div>
     <h2>Events</h2>
-    <div [innerText]="events"></div>
+    <pre><span [innerText]="events"></span></pre>
+
     <h2>Logs</h2>
-    <div [innerText]="logs"></div>
+    <pre><span [innerText]="logs"></span></pre>
     <div
       *ngIf="
         pipelineRunService.pipelineRunIsNotReady(

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
@@ -19,10 +19,24 @@
       }}'
     </div>
     <h2>Events</h2>
-    <pre><span [innerText]="events"></span></pre>
+    <pre *ngIf="events !== undefined"><span [innerText]="events"></span></pre>
 
+    <div
+      *ngIf="
+        events === undefined ||
+        !pipelineRunService.pipelineRunIsFinished(
+          (pipelineRunService.pipelineRun$ | async)!.status
+        )
+      "
+    >
+      <div *ngFor="let width of ['50%', '70%', '30%']">
+        <app-text-line-skeleton-loader
+          [width]="width"
+        ></app-text-line-skeleton-loader>
+      </div>
+    </div>
     <h2>Logs</h2>
-    <pre><span [innerText]="logs"></span></pre>
+    <pre *ngIf="logs !== undefined"><span [innerText]="logs"></span></pre>
     <div
       *ngIf="
         pipelineRunService.pipelineRunIsNotReady(
@@ -34,12 +48,13 @@
     </div>
     <div
       *ngIf="
-        !pipelineRunService.pipelineRunIsFinished(
+        logs === undefined ||
+        (!pipelineRunService.pipelineRunIsFinished(
           (pipelineRunService.pipelineRun$ | async)!.status
         ) &&
-        !pipelineRunService.pipelineRunIsNotReady(
-          (pipelineRunService.pipelineRun$ | async)!.status
-        )
+          !pipelineRunService.pipelineRunIsNotReady(
+            (pipelineRunService.pipelineRun$ | async)!.status
+          ))
       "
     >
       <div *ngFor="let width of ['50%', '70%', '30%']">

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.ts
@@ -6,7 +6,7 @@
 import { Component } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { combineLatest } from 'rxjs';
-import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { filter, switchMap, take } from 'rxjs/operators';
 import { PipelineRunService } from 'src/app/projects/models/backup-settings/pipeline-runs/service/pipeline-run.service';
 import { PipelineService } from 'src/app/projects/models/backup-settings/service/pipeline.service';
 import { ModelService } from 'src/app/projects/models/service/model.service';
@@ -41,11 +41,6 @@ export class ViewLogsDialogComponent {
     ])
       .pipe(
         untilDestroyed(this),
-        filter(
-          ([_project, _model, _pipeline, pipelineRun]) =>
-            this.logs === undefined ||
-            !this.pipelineRunService.pipelineRunIsFinished(pipelineRun.status)
-        ),
         switchMap(([project, model, pipeline, pipelineRun]) => {
           return this.pipelineRunService.getEvents(
             project.slug,
@@ -56,12 +51,8 @@ export class ViewLogsDialogComponent {
         })
       )
       .subscribe({
-        next: (res: string) => {
-          this.events = res;
-        },
-        error: () => {
-          this.events = "Couldn't fetch events";
-        },
+        next: (res: string) => (this.events = res),
+        error: () => (this.events = "Couldn't fetch events"),
       });
   }
 
@@ -74,11 +65,6 @@ export class ViewLogsDialogComponent {
     ])
       .pipe(
         untilDestroyed(this),
-        filter(
-          ([_project, _model, _pipeline, pipelineRun]) =>
-            this.logs === undefined ||
-            !this.pipelineRunService.pipelineRunIsFinished(pipelineRun.status)
-        ),
         switchMap(([project, model, pipeline, pipelineRun]) =>
           this.pipelineRunService.getLogs(
             project.slug,
@@ -89,12 +75,8 @@ export class ViewLogsDialogComponent {
         )
       )
       .subscribe({
-        next: (res: string) => {
-          this.logs = res;
-        },
-        error: () => {
-          this.logs = "Couldn't fetch logs";
-        },
+        next: (res: string) => (this.logs = res),
+        error: () => (this.logs = "Couldn't fetch logs"),
       });
   }
 }

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.ts
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.ts
@@ -6,7 +6,7 @@
 import { Component } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { combineLatest } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import { filter, switchMap, take, tap } from 'rxjs/operators';
 import { PipelineRunService } from 'src/app/projects/models/backup-settings/pipeline-runs/service/pipeline-run.service';
 import { PipelineService } from 'src/app/projects/models/backup-settings/service/pipeline.service';
 import { ModelService } from 'src/app/projects/models/service/model.service';
@@ -29,26 +29,31 @@ export class ViewLogsDialogComponent {
     this.refreshEvents();
   }
 
-  logs = '';
-  events = '';
+  logs?: string = undefined;
+  events?: string = undefined;
 
   refreshEvents(): void {
     combineLatest([
-      this.projectService.project$.pipe(filter(Boolean)),
-      this.modelService.model$.pipe(filter(Boolean)),
-      this.pipelineService.pipeline$.pipe(filter(Boolean)),
+      this.projectService.project$.pipe(filter(Boolean), take(1)),
+      this.modelService.model$.pipe(filter(Boolean), take(1)),
+      this.pipelineService.pipeline$.pipe(filter(Boolean), take(1)),
       this.pipelineRunService.pipelineRun$.pipe(filter(Boolean)),
     ])
       .pipe(
         untilDestroyed(this),
-        switchMap(([project, model, pipeline, pipelineRun]) =>
-          this.pipelineRunService.getEvents(
+        filter(
+          ([_project, _model, _pipeline, pipelineRun]) =>
+            this.logs === undefined ||
+            !this.pipelineRunService.pipelineRunIsFinished(pipelineRun.status)
+        ),
+        switchMap(([project, model, pipeline, pipelineRun]) => {
+          return this.pipelineRunService.getEvents(
             project.slug,
             model.slug,
             pipeline.id,
             pipelineRun.id
-          )
-        )
+          );
+        })
       )
       .subscribe({
         next: (res: string) => {
@@ -69,6 +74,11 @@ export class ViewLogsDialogComponent {
     ])
       .pipe(
         untilDestroyed(this),
+        filter(
+          ([_project, _model, _pipeline, pipelineRun]) =>
+            this.logs === undefined ||
+            !this.pipelineRunService.pipelineRunIsFinished(pipelineRun.status)
+        ),
         switchMap(([project, model, pipeline, pipelineRun]) =>
           this.pipelineRunService.getLogs(
             project.slug,

--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -89,6 +89,8 @@ database:
   url: "{{ .Values.database.backend.external.uri }}"
   {{ end }}
 
+pipelines:
+  timeout: {{ .Values.pipelines.timeout }}
 
 initial:
   admin: "{{ .Values.database.backend.initialAdmin }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -54,6 +54,10 @@ sessions:
   # Session timeout in minutes for unused and idle sessions
   timeout: 90
 
+pipelines:
+  # Pipeline timeout in minutes
+  timeout: 60
+
 database:
   # Database Configuration for Guacamole
   guacamole:


### PR DESCRIPTION
Please check the commit messages for detailed information.

The main improvements are: 

- Logs and events for finished jobs are only fetched once, not every two seconds (they won't change anymore)
- The query time range for Grafana Loki calls was reduced, leading to less calls inside of Grafana Loki
- Add handling of TooManyRequests error in Grafana Loki 
- Jobs are properly terminated. Logs and events are fetched before termination. 

Resolves #852
Resolves #864