### PR TITLE
fix(pure-variants): Handle missing restrictions table

### DIFF
--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -102,7 +102,9 @@ class DatabaseCapellaModel(database.Base):
         back_populates="model"
     )
 
-    restrictions: orm.Mapped[DatabaseToolModelRestrictions] = orm.relationship(
+    restrictions: orm.Mapped[
+        DatabaseToolModelRestrictions | None
+    ] = orm.relationship(
         back_populates="model", uselist=False, cascade="delete"
     )
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -471,7 +471,7 @@ def determine_pure_variants_configuration(
             model
             for association in user.projects
             for model in association.project.models
-            if model.restrictions.allow_pure_variants
+            if model.restrictions and model.restrictions.allow_pure_variants
         ]
         and user.role == users_models.Role.USER
     ):


### PR DESCRIPTION
The `restrictions` table doesn't always exist.
This was not considered in the type annotation and wasn't checked properly when accesing the `allow_pure_variants` restriction.

Resolves https://github.com/DSD-DBS/capella-collab-manager/issues/866