### PR TITLE
fix: Use password for retrieving github artifacts

### DIFF
--- a/backend/capellacollab/projects/toolmodels/modelsources/git/github/handler.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/github/handler.py
@@ -102,7 +102,7 @@ class GithubHandler(handler.GitHandler):
         project_id: str,
     ) -> t.Any:
         headers = None
-        if not self.git_model.password:
+        if self.git_model.password:
             headers = self.__get_headers(self.git_model.password)
 
         response = requests.get(


### PR DESCRIPTION
This somehow seems flaky to me, as it worked before even though this code does not make sense, as we want to use the password if it exists and otherwise leave the headers as none