### PR TITLE
feat: Add custom branding of Guacamole

### DIFF
--- a/guacamole/Dockerfile
+++ b/guacamole/Dockerfile
@@ -1,13 +1,30 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+ARG DEBIAN_SLIM_BASE_IMAGE=debian:bookworm-slim
+FROM ${DEBIAN_SLIM_BASE_IMAGE} as build-extension
+USER root
+
+RUN apt-get update && apt-get install -y zip
+COPY ext /tmp/ext
+
+WORKDIR /tmp/ext
+RUN zip -r /tmp/guacamole-capellacollab.jar .
+
 FROM guacamole/guacamole:1.5.2
 
 USER root
-RUN chmod -R 777 \
+
+COPY guacamole.properties /etc/guacamole/guacamole.properties
+COPY --from=build-extension /tmp/guacamole-capellacollab.jar /etc/guacamole/extensions/
+
+RUN mkdir -p /etc/guacamole && \
+    chmod -R 777 \
     /opt/guacamole \
     /usr/local/tomcat/webapps \
-    /home/guacamole
+    /home/guacamole \
+    /etc/guacamole
 
 ENV HOME=/home/guacamole
 ENV JAVA_OPTS="-Duser.home=/home/guacamole"
+ENV GUACAMOLE_HOME=/etc/guacamole

--- a/guacamole/ext/guac-manifest.json
+++ b/guacamole/ext/guac-manifest.json
@@ -1,0 +1,7 @@
+{
+  "guacamoleVersion": "1.5.2",
+
+  "name": "Capella Collaboration Manager extension",
+  "namespace": "capellacollab",
+  "translations": ["translations/en.json"]
+}

--- a/guacamole/ext/guac-manifest.json.license
+++ b/guacamole/ext/guac-manifest.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+SPDX-License-Identifier: Apache-2.0

--- a/guacamole/ext/translations/en.json
+++ b/guacamole/ext/translations/en.json
@@ -1,0 +1,57 @@
+{
+  "NAME": "English",
+
+  "APP": {
+    "NAME": "Session viewer (Capella Collaboration Manager)",
+    "INFO_LOGGED_OUT": "You have been logged out. Please continue in the Capella Collaboration Manager to reconnect."
+  },
+
+  "CLIENT": {
+    "ERROR_CLIENT_201": "This connection has been closed because the server is busy. Please wait a few minutes and try again.",
+    "ERROR_CLIENT_202": "The Capella Collaboration Manager session is taking too long to respond. Please check the session status in the Capella Collaboration Manager, try again or contact your system administrator.",
+    "ERROR_CLIENT_203": "The Capella Collaboration Manager session encountered an error and has closed the connection. Please check the session status in the Capella Collaboration Manager, try again or contact your system administrator.",
+    "ERROR_CLIENT_207": "The Capella Collaboration Manager session is currently unreachable. Please check the status of your session in the Capella Collaboration Manager.",
+    "ERROR_CLIENT_208": "The Capella Collaboration Manager session is currently unavailable. Please check the status of your session in the Capella Collaboration Manager.",
+    "ERROR_CLIENT_209": "The Capella Collaboration Manager session has closed the connection because it conflicts with another connection. Please try again later.",
+    "ERROR_CLIENT_20A": "The Capella Collaboration Manager session has closed the connection because it appeared to be inactive. If this is undesired or unexpected, please notify your system administrator, or check your system settings.",
+    "ERROR_CLIENT_20B": "The Capella Collaboration Manager session has forcibly closed the connection. If this is undesired or unexpected, please notify your system administrator, or check your system logs.",
+    "ERROR_CLIENT_301": "Log in failed. Please reconnect and try again.",
+    "ERROR_CLIENT_303": "The Capella Collaboration Manager session has denied access to this connection. If you require access, please ask your system administrator to grant your account access, or check your system settings.",
+    "ERROR_CLIENT_308": "The Capella Collaboration Manager server has closed the connection because there has been no response from your browser for long enough that it appeared to be disconnected. This is commonly caused by network problems, such as spotty wireless signal, or simply very slow network speeds. Please check your network and try again.",
+    "ERROR_CLIENT_31D": "The Capella Collaboration Manager server is denying access to this connection because you have exhausted the limit for simultaneous connection. Please close one or more connections and try again.",
+    "ERROR_CLIENT_DEFAULT": "An internal error has occurred within the Capella Collaboration Manager server, and the connection has been terminated. If the problem persists, please notify your system administrator, or check your system logs.",
+
+    "ERROR_TUNNEL_201": "The Capella Collaboration Manager server has rejected this connection attempt because there are too many active connections. Please wait a few minutes and try again.",
+    "ERROR_TUNNEL_202": "The connection has been closed because the server is taking too long to respond. This is usually caused by network problems, such as a spotty wireless signal, or slow network speeds. Please check your network connection and try again or contact your system administrator.",
+    "ERROR_TUNNEL_203": "The server encountered an error and has closed the connection. Please try again or contact your system administrator.",
+    "ERROR_TUNNEL_204": "The requested connection does not exist. Please check the connection name and try again.",
+    "ERROR_TUNNEL_205": "This connection is currently in use, and concurrent access to this connection is not allowed. Please try again later.",
+    "ERROR_TUNNEL_207": "The Capella Collaboration Manager server is not currently reachable. Please check your network and try again.",
+    "ERROR_TUNNEL_208": "The Capella Collaboration Manager server is not accepting connections. Please check your network and try again.",
+    "ERROR_TUNNEL_301": "You do not have permission to access this connection because you are not logged in. Please log in and try again.",
+    "ERROR_TUNNEL_303": "You do not have permission to access this connection. If you require access, please ask your system administrator to add you the list of allowed users, or check your system settings.",
+    "ERROR_TUNNEL_308": "The Capella Collaboration Manager server has closed the connection because there has been no response from your browser for long enough that it appeared to be disconnected. This is commonly caused by network problems, such as spotty wireless signal, or simply very slow network speeds. Please check your network and try again.",
+    "ERROR_TUNNEL_31D": "The Capella Collaboration Manager server is denying access to this connection because you have exhausted the limit for simultaneous connection use by an individual user. Please close one or more connections and try again.",
+    "ERROR_TUNNEL_DEFAULT": "An internal error has occurred within the Capella Collaboration Manager server, and the connection has been terminated. If the problem persists, please notify your system administrator, or check your system logs.",
+
+    "ERROR_UPLOAD_100": "File transfer is either not supported or not enabled. Please contact your system administrator, or check your system logs.",
+    "ERROR_UPLOAD_201": "Too many files are currently being transferred. Please wait for existing transfers to complete, and then try again.",
+    "ERROR_UPLOAD_202": "The file cannot be transferred because the remote desktop server is taking too long to respond. Please try again or contact your system administrator.",
+    "ERROR_UPLOAD_203": "The remote desktop server encountered an error during transfer. Please try again or contact your system administrator.",
+    "ERROR_UPLOAD_204": "The destination for the file transfer does not exist. Please check that the destination exists and try again.",
+    "ERROR_UPLOAD_205": "The destination for the file transfer is currently locked. Please wait for any in-progress tasks to complete and try again.",
+    "ERROR_UPLOAD_301": "You do not have permission to upload this file because you are not logged in. Please log in and try again.",
+    "ERROR_UPLOAD_303": "You do not have permission to upload this file. If you require access, please check your system settings, or check with your system administrator.",
+    "ERROR_UPLOAD_308": "The file transfer has stalled. This is commonly caused by network problems, such as spotty wireless signal, or simply very slow network speeds. Please check your network and try again.",
+    "ERROR_UPLOAD_31D": "Too many files are currently being transferred. Please wait for existing transfers to complete, and then try again.",
+    "ERROR_UPLOAD_DEFAULT": "An internal error has occurred within the Capella Collaboration Manager server, and the connection has been terminated. If the problem persists, please notify your system administrator, or check your system logs.",
+
+    "HELP_CLIPBOARD": "Text copied/cut within the Capella Collaboration Manager will appear here. Changes to the text below will affect the remote clipboard.",
+    "HELP_INPUT_METHOD_OSK": "Display and accept input from the built-in Capella Collaboration Manager on-screen keyboard. The on-screen keyboard allows typing of key combinations that may otherwise be impossible (such as Ctrl-Alt-Del).",
+
+    "TEXT_CLIENT_STATUS_CONNECTING": "Connecting to your Capella Collaboration Manager session...",
+    "TEXT_CLIENT_STATUS_DISCONNECTED": "You have been disconnected from your session. Please continue in the Capella Collaboration Manager.",
+    "TEXT_CLIENT_STATUS_UNSTABLE": "The network connection to the server appears unstable. Please check your internet connection.",
+    "TEXT_CLIENT_STATUS_WAITING": "Connected to the Capella Collaboration Manager server. Waiting for response..."
+  }
+}

--- a/guacamole/ext/translations/en.json.license
+++ b/guacamole/ext/translations/en.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+SPDX-License-Identifier: Apache-2.0

--- a/guacamole/guacamole.properties
+++ b/guacamole/guacamole.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+allowed-languages: en


### PR DESCRIPTION
During container startup, the new Capella Collaboration Manager extension for Guacamole is loaded: 
```
18:35:11.023 [localhost-startStop-1] INFO  o.a.g.extension.ExtensionModule - Extension "Capella Collaboration Manager extension" (capellacollab) loaded.
```

At the beginning, it's just changing the english translation, mostly to replace Guacamole with "Capella Collaboration Manager session".

For example, this is the message during connection: 
![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/ee6922d5-f8a8-4df4-a413-d9dada5c1006)

Error handling can now give the hint to check the current session status in the Collaboration Manager: 
![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/deef8c53-2499-4531-91b6-e9be627945cd)


Also, the Guacamole logout screen provides more information how to continue: 
![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/ed0760f4-31bd-4485-b33f-c734f4fafc0e)