### PR TITLE
feat: Add project-wide Jupyter notebook "share" for collaboration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: CC0-1.0
-
 * text=auto
-
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
-
 *.{sh,py} text eol=lf
-
 .git_archival.txt  export-subst
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/backend/capellacollab/alembic/versions/97c7acd616fc_add_configuration_to_toolmodels.py
+++ b/backend/capellacollab/alembic/versions/97c7acd616fc_add_configuration_to_toolmodels.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add configuration to toolmodels
+
+Revision ID: 97c7acd616fc
+Revises: d0cbf2813066
+Create Date: 2023-08-04 12:05:53.846434
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "97c7acd616fc"
+down_revision = "d0cbf2813066"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "models",
+        sa.Column(
+            "configuration",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -148,6 +148,7 @@ def create_tools(db):
     tools_crud.create_version(db, capella.id, "5.0.0")
 
     tools_crud.create_version(db, jupyter.id, "python-3.11")
+    tools_crud.create_nature(db, jupyter.id, "notebooks")
 
     default_nature = tools_crud.create_nature(db, capella.id, "model")
     tools_crud.create_nature(db, capella.id, "library")

--- a/backend/capellacollab/projects/toolmodels/crud.py
+++ b/backend/capellacollab/projects/toolmodels/crud.py
@@ -82,6 +82,7 @@ def create_model(
     tool: tools_models.DatabaseTool,
     version: tools_models.DatabaseVersion | None = None,
     nature: tools_models.DatabaseNature | None = None,
+    configuration: dict[str, str] | None = None,
 ) -> models.DatabaseCapellaModel:
     model = models.DatabaseCapellaModel(
         name=post_model.name,
@@ -92,6 +93,7 @@ def create_model(
         version=version,
         nature=nature,
         restrictions=restrictions_models.DatabaseToolModelRestrictions(),
+        configuration=configuration,
     )
     db.add(model)
     db.commit()

--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -73,6 +73,8 @@ class DatabaseCapellaModel(database.Base):
     slug: orm.Mapped[str]
     description: orm.Mapped[str]
 
+    configuration: orm.Mapped[dict[str, str] | None]
+
     project_id: orm.Mapped[int] = orm.mapped_column(
         sa.ForeignKey("projects.id")
     )

--- a/backend/capellacollab/projects/toolmodels/workspace.py
+++ b/backend/capellacollab/projects/toolmodels/workspace.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from capellacollab.sessions import operators
+
+from .. import models as projects_models
+from . import models
+
+
+def create_shared_workspace(
+    name: str,
+    project: projects_models.DatabaseProject,
+    model: models.DatabaseCapellaModel,
+    size: str,
+):
+    operators.get_operator().create_persistent_volume(
+        name="shared-workspace-" + name,
+        size=size,
+        labels={
+            "capellacollab/project_slug": project.slug,
+            "capellacollab/project_id": str(project.id),
+            "capellacollab/model_slug": model.slug,
+            "capellacollab/model_id": str(model.id),
+        },
+    )
+
+
+def delete_shared_workspace(name: str):
+    operators.get_operator().delete_persistent_volume(
+        name="shared-workspace-" + name
+    )

--- a/backend/capellacollab/sessions/workspace.py
+++ b/backend/capellacollab/sessions/workspace.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from .operators import k8s
+
+
+def _get_volume_name(username: str) -> str:
+    return (
+        "persistent-session-"
+        + username.replace("@", "-at-").replace(".", "-dot-").lower()
+    )
+
+
+def create_persistent_workspace(
+    operator: k8s.KubernetesOperator, username: str
+) -> str:
+    persistent_workspace_name = _get_volume_name(username)
+    operator.create_persistent_volume(
+        _get_volume_name(username),
+        "20Gi",
+        labels={
+            "capellacollab/username": username,
+        },
+    )
+    return persistent_workspace_name

--- a/backend/tests/projects/toolmodels/test_jupyter_fileshare.py
+++ b/backend/tests/projects/toolmodels/test_jupyter_fileshare.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from fastapi import testclient
+from sqlalchemy import orm
+
+import capellacollab.sessions.operators
+from capellacollab.projects import models as projects_models
+from capellacollab.projects.toolmodels import crud as toolmodels_crud
+from capellacollab.projects.toolmodels import models as toolmodels_models
+from capellacollab.tools import crud as tools_crud
+from capellacollab.tools import models as tools_models
+
+
+class MockOperator:
+    _created_volumes = 0
+    _deleted_volumes = 0
+
+    def create_persistent_volume(
+        self, name: str, size: str, labels: dict[str, str] = None
+    ):
+        self._created_volumes += 1
+
+    def delete_persistent_volume(self, name: str):
+        self._deleted_volumes += 1
+
+
+@pytest.fixture(name="jupyter_tool")
+def fixture_jupyter_tool(db: orm.Session) -> tools_models.DatabaseTool:
+    return tools_crud.get_tool_by_name(db, "Jupyter")
+
+
+@pytest.fixture(name="jupyter_model")
+def fixture_jupyter_model(
+    db: orm.Session,
+    project: projects_models.DatabaseProject,
+    jupyter_tool: tools_models.DatabaseTool,
+) -> toolmodels_models.CapellaModel:
+    jupyter_model = toolmodels_models.PostCapellaModel(
+        name="Jupyter test",
+        description="",
+        tool_id=jupyter_tool.id,
+    )
+    return toolmodels_crud.create_model(
+        db,
+        project,
+        jupyter_model,
+        tool=jupyter_tool,
+        configuration={"workspace": "test"},
+    )
+
+
+@pytest.fixture(name="mockoperator")
+def fixture_mockoperator(monkeypatch: pytest.MonkeyPatch):
+    mockoperator = MockOperator()
+    monkeypatch.setattr(
+        capellacollab.sessions.operators, "get_operator", lambda: mockoperator
+    )
+    return mockoperator
+
+
+@pytest.mark.usefixtures("project_manager")
+def test_creation_of_jupyter_fileshare(
+    client: testclient.TestClient,
+    project: projects_models.DatabaseProject,
+    jupyter_tool: tools_models.DatabaseTool,
+    mockoperator: MockOperator,
+):
+    response = client.post(
+        f"/api/v1/projects/{project.slug}/models",
+        json={
+            "name": "Jupyter test",
+            "description": "",
+            "tool_id": jupyter_tool.id,
+        },
+    )
+
+    assert response.is_success
+    assert mockoperator._created_volumes == 1
+
+
+@pytest.mark.usefixtures("project_manager")
+def test_deletion_of_jupyter_fileshare(
+    client: testclient.TestClient,
+    project: projects_models.DatabaseProject,
+    jupyter_model: toolmodels_models.CapellaModel,
+    mockoperator: MockOperator,
+):
+    response = client.delete(
+        f"/api/v1/projects/{project.slug}/models/{jupyter_model.slug}"
+    )
+
+    assert response.is_success
+    assert mockoperator._deleted_volumes == 1

--- a/backend/tests/sessions/test_sessions_routes.py
+++ b/backend/tests/sessions/test_sessions_routes.py
@@ -103,6 +103,7 @@ class MockOperator:
         docker_image: str,
         t4c_license_secret: str | None,
         t4c_json: list[dict[str, str | int]] | None,
+        persistent_workspace_claim_name: str,
         pure_variants_license_server: str = None,
         pure_variants_secret_name: str = None,
     ) -> dict[str, t.Any]:
@@ -122,6 +123,7 @@ class MockOperator:
         username: str,
         tool_name: str,
         version_name: str,
+        persistent_workspace_claim_name: str,
         token: str,
         docker_image: str,
     ) -> t.Dict[str, t.Any]:
@@ -193,6 +195,12 @@ class MockOperator:
     @classmethod
     def get_job_logs_or_events(self, _id: str) -> str:
         return ""
+
+    @classmethod
+    def create_persistent_volume(
+        self, name: str, size: str, labels: dict[str, str] = None
+    ):
+        return
 
 
 @pytest.fixture(autouse=True, name="kubernetes")

--- a/docs/development/mkdocs.yml
+++ b/docs/development/mkdocs.yml
@@ -38,4 +38,4 @@ extra:
 
 dev_addr: 127.0.0.1:8081
 
-copyright: Copyright &copy; 2022 DB Netz AG
+copyright: Copyright &copy; 2022-2023 DB Netz AG

--- a/docs/user/docs/sessions/jupyter/collaboration.md
+++ b/docs/user/docs/sessions/jupyter/collaboration.md
@@ -1,0 +1,37 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+# Collaboration with Jupyter Notebooks
+
+Collaborating on Jupyter notebooks is a common requirement in various
+workflows. This guide describes the approach of collaboration in individual
+sessions.
+
+## Collaboration in Individual Sessions
+
+If you have a notebook in your personal workspace and another user wants to
+connect to your sessions, follow these steps:
+
+### Sharing a Notebook Session
+
+1. **Request a Jupyter Session**: As usual, request a Jupyter session to start.
+2. **Connect to the Session**: Open the requested session.
+3. **Share the Session**: Click on the "Share" button on the top right of the
+   Jupyter session interface.
+4. **Include the Token**: Tick the option "Include the token in the URL".
+5. **Warning! Security Risk**: Be aware that anyone with access to the URL can
+   access your Jupyter session until termination. To revoke access, terminate
+   your session in the Capella Collaboration Manager. After restarting it, a
+   new token will be generated, and old sessions will no longer have access.
+6. **Share the Link**: Distribute the link to all users who should have access.
+   They will be able to open your notebooks and concurrently edit them.
+
+#### Instructional Video
+
+Here's a video that visually guides you through these steps:
+
+<video controls>
+  <source src="../jupyter-collaboration.mp4" type="video/mp4">
+</video>

--- a/docs/user/docs/sessions/jupyter/jupyter-collaboration.mp4
+++ b/docs/user/docs/sessions/jupyter/jupyter-collaboration.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1eb20daddfb070885869dfff861f3a4fcd34fc8cdc196e8b3fdbd1cd9a5c7f9
+size 2285837

--- a/docs/user/docs/sessions/jupyter/jupyter-collaboration.mp4.license
+++ b/docs/user/docs/sessions/jupyter/jupyter-collaboration.mp4.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+SPDX-License-Identifier: Apache-2.0

--- a/docs/user/mkdocs.yml
+++ b/docs/user/mkdocs.yml
@@ -43,6 +43,8 @@ nav:
           - TeamForCapella: sessions/flows/t4c.md
       - Files (Upload): sessions/files/files.md
       - Troubleshooting: sessions/troubleshooting.md
+      - Jupyter:
+          - Collaboration: sessions/jupyter/collaboration.md
   - Settings:
       - Monitoring: settings/monitoring.md
       - Tools:
@@ -81,4 +83,4 @@ markdown_extensions:
 extra:
   generator: false
 
-copyright: Copyright &copy; 2022 DB Netz AG
+copyright: Copyright &copy; 2022-2023 DB Netz AG


### PR DESCRIPTION
During creation of a Jupyter model in a project, a file-share is created. This feature enables project-wide file-shares. Together with internal projects, it can even serve as global file-share. Per default, the size of the volume is 2GB.

To delete a file-share, just delete the model from the project.

The feature is not complete yet. File-shares are created, but not mounted. The state of the Kubernetes operator is currently not good enough for mounting. We have another PR open to improve the situation. Once the `session hooks` PR is merged, we can build the mounting-feature for Jupyter file-shares: https://github.com/DSD-DBS/capella-collab-manager/pull/912.
Nevertheless, I would merge this PR and implement mounting in a later PR.

Depends on #900, #901, #902, #903, #904 and #905.