### PR TITLE
fix: Display log out button in mobile view

### DIFF
--- a/frontend/src/app/general/nav-bar-menu/nav-bar-menu.component.html
+++ b/frontend/src/app/general/nav-bar-menu/nav-bar-menu.component.html
@@ -50,8 +50,10 @@
   <a
     mat-list-item
     (click)="navBarService.toggle()"
-    *ngIf="userService.user?.role === 'administrator'"
     routerLink="logout/redirect"
-    >Log out</a
+    [queryParams]="{ reason: 'logout' }"
+    *ngIf="authService.isLoggedIn()"
   >
+    Log out <mat-icon class="ml-2.5">logout</mat-icon>
+  </a>
 </mat-list>

--- a/frontend/src/app/general/nav-bar-menu/nav-bar-menu.component.ts
+++ b/frontend/src/app/general/nav-bar-menu/nav-bar-menu.component.ts
@@ -5,6 +5,7 @@
 
 import { Component } from '@angular/core';
 import { NavBarService } from 'src/app/general/nav-bar/nav-bar.service';
+import { AuthService } from 'src/app/services/auth/auth.service';
 import { UserService } from 'src/app/services/user/user.service';
 
 @Component({
@@ -14,6 +15,7 @@ import { UserService } from 'src/app/services/user/user.service';
 })
 export class NavBarMenuComponent {
   constructor(
+    public authService: AuthService,
     public navBarService: NavBarService,
     public userService: UserService
   ) {}


### PR DESCRIPTION
In the mobile view, the log out button was only
displayed for administrators, not for users.

This commit adds the Log out button for all users
in the mobile navigation.