### PR TITLE
feat: Add option to skip source linking

### DIFF
--- a/frontend/src/app/projects/models/create-model/create-model.component.ts
+++ b/frontend/src/app/projects/models/create-model/create-model.component.ts
@@ -67,6 +67,10 @@ export class CreateModelComponent implements OnInit {
 
   onSourceClick(value: string): void {
     this.stepper.steps.get(1)!.completed = true;
+    if (value === 'skip') {
+      this.stepper.next();
+      this.stepper.steps.get(2)!.completed = true;
+    }
     this.source = value;
     this.stepper.next();
   }

--- a/frontend/src/app/projects/models/model-source/choose-source.component.html
+++ b/frontend/src/app/projects/models/model-source/choose-source.component.html
@@ -35,4 +35,14 @@
       </a>
     </div>
   </div>
+
+  <h2 class="title text-center">Other</h2>
+  <div class="flex justify-center flex-wrap">
+    <a (click)="modelSourceSelection.emit('skip')">
+      <mat-card class="option-card">
+        <p class="subtitle">Skip this step</p>
+        <app-mat-icon size="50px">skip_next</app-mat-icon>
+      </mat-card>
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
Sometimes, users don't have a source ready during model creation. In these cases, they now can skip the source creation.