### PR TITLE
refactor: Add custom ExistingDependenciesError

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -17,6 +17,7 @@ import capellacollab.sessions.metrics
 
 # This import statement is required and should not be removed! (Alembic will not work otherwise)
 from capellacollab.config import config
+from capellacollab.core import exceptions as core_exceptions
 from capellacollab.core import logging as core_logging
 from capellacollab.core.database import engine, migration
 from capellacollab.core.logging import exceptions as logging_exceptions
@@ -135,6 +136,7 @@ def register_exceptions():
     git_handler_exceptions.register_exceptions(app)
     backups_exceptions.register_exceptions(app)
     logging_exceptions.register_exceptions(app)
+    core_exceptions.register_exceptions(app)
 
 
 register_exceptions()

--- a/backend/capellacollab/core/exceptions.py
+++ b/backend/capellacollab/core/exceptions.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+
+import fastapi
+from fastapi import exception_handlers, status
+
+
+@dataclasses.dataclass
+class ExistingDependenciesError(Exception):
+    entity_name: str
+    entity_type: str
+    dependencies: list[str]
+
+
+async def existing_dependencies_exception_handler(
+    request: fastapi.Request, exc: ExistingDependenciesError
+) -> fastapi.Response:
+    dependencies_str = ", ".join(exc.dependencies)
+    return await exception_handlers.http_exception_handler(
+        request,
+        fastapi.HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "reason": [
+                    f"The {exc.entity_type} '{exc.entity_name}' can not be deleted. Please remove the following dependencies first: {dependencies_str}"
+                ]
+            },
+        ),
+    )
+
+
+def register_exceptions(app: fastapi.FastAPI):
+    app.add_exception_handler(
+        ExistingDependenciesError, existing_dependencies_exception_handler
+    )

--- a/backend/capellacollab/tools/routes.py
+++ b/backend/capellacollab/tools/routes.py
@@ -10,6 +10,7 @@ from sqlalchemy import orm
 import capellacollab.projects.toolmodels.crud as projects_models_crud
 import capellacollab.settings.modelsources.t4c.crud as settings_t4c_crud
 from capellacollab.core import database
+from capellacollab.core import exceptions as core_exceptions
 from capellacollab.core.authentication import injectables as auth_injectables
 from capellacollab.tools.integrations import (
     routes as tools_integrations_routes,
@@ -313,7 +314,11 @@ def raise_when_tool_version_dependency_exist(
         for model in version_models
     )
 
-    raise_if_dependencies_exist(dependencies, version.name, "version")
+    raise core_exceptions.ExistingDependenciesError(
+        entity_name=version.name,
+        entity_type="version",
+        dependencies=dependencies,
+    )
 
 
 def raise_when_tool_nature_dependency_exist(
@@ -336,31 +341,8 @@ def raise_when_tool_nature_dependency_exist(
         for model in nature_models
     )
 
-    raise_if_dependencies_exist(dependencies, nature.name, "nature")
-
-
-def raise_if_dependencies_exist(
-    dependencies: list[str], entity_name: str, entity_type: str
-) -> None:
-    """Raise HTTPException if there are any dependencies.
-
-    Parameters
-    ----------
-    dependencies : list[str]
-        List of dependency descriptions
-    entity_name : str
-        Name of the entity with dependencies
-    entity_type : str
-        Type of the entity with dependencies
-    """
-
-    if dependencies:
-        dependencies_str = ", ".join(dependencies)
-        raise fastapi.HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": [
-                    f"The {entity_type} '{entity_name}' can not be deleted. Please remove the following dependencies first: {dependencies_str}"
-                ]
-            },
-        )
+    raise core_exceptions.ExistingDependenciesError(
+        entity_name=nature.name,
+        entity_type="nature",
+        dependencies=dependencies,
+    )


### PR DESCRIPTION
Some elements can only be deleted or modified if
no objects depend on the object to delete.

If this rule is not met, we throw the new
ExistingDependenciesError.