### PR TITLE
fix: Only display model badge for Capella models

### DIFF
--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -72,6 +72,7 @@
           {{ model.description || "This model has no description." }}
         </div>
         <app-model-complexity-badge
+          *ngIf="model.tool.name === 'Capella'"
           [modelSlug]="model.slug"
         ></app-model-complexity-badge>
         <div class="actions">


### PR DESCRIPTION
The model badge is Capella exclusive and should
not be displayed for other tools.