### PR TITLE
feat: Introduce session hooks

### DIFF
--- a/backend/capellacollab/alembic/versions/4c58f4db4f54_replace_tool_specific_session_.py
+++ b/backend/capellacollab/alembic/versions/4c58f4db4f54_replace_tool_specific_session_.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replace tool specific session attributes with environment
+
+Revision ID: 4c58f4db4f54
+Revises: 97c7acd616fc
+Create Date: 2023-08-07 20:09:26.524318
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "4c58f4db4f54"
+down_revision = "97c7acd616fc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "sessions",
+        sa.Column(
+            "environment",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    t_sessions = sa.Table(
+        "sessions", sa.MetaData(), autoload_with=op.get_bind()
+    )
+
+    sessions = op.get_bind().execute(sa.select(t_sessions))
+    for session in sessions:
+        op.get_bind().execute(
+            sa.update(t_sessions)
+            .where(t_sessions.c.id == session.id)
+            .values(
+                environment={
+                    "JUPYTER_TOKEN": session.jupyter_token,
+                    "T4C_PASSWORD": session.t4c_password,
+                }
+            )
+        )
+    op.drop_column("sessions", "mac")
+    op.drop_column("sessions", "jupyter_token")
+    op.drop_column("sessions", "t4c_password")

--- a/backend/capellacollab/sessions/hooks/__init__.py
+++ b/backend/capellacollab/sessions/hooks/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from capellacollab.tools import models as tools_models
+
+from . import interface, jupyter, pure_variants, t4c
+
+REGISTERED_HOOKS: dict[str, interface.HookRegistration] = {
+    "jupyter": jupyter.JupyterIntegration(),
+    "t4c": t4c.T4CIntegration(),
+    "pure_variants": pure_variants.PureVariantsIntegration(),
+}
+
+
+def get_activated_integration_hooks(
+    tool: tools_models.DatabaseTool,
+) -> list[interface.HookRegistration]:
+    """Returns a list of all activated integration hooks for a tool."""
+    return [
+        hook
+        for integration, hook in REGISTERED_HOOKS.items()
+        if getattr(tool.integrations, integration, False)
+    ]

--- a/backend/capellacollab/sessions/hooks/interface.py
+++ b/backend/capellacollab/sessions/hooks/interface.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+import typing as t
+
+from sqlalchemy import orm
+
+from capellacollab.core import models as core_models
+from capellacollab.sessions import operators
+from capellacollab.tools import models as tools_models
+from capellacollab.users import models as users_models
+
+from .. import models as sessions_models
+
+
+class HookRegistration(metaclass=abc.ABCMeta):
+    def configuration_hook(
+        self,
+        db: orm.Session,
+        user: users_models.DatabaseUser,
+        tool_version: tools_models.DatabaseVersion,
+        tool: tools_models.DatabaseTool,
+        token: dict[str, t.Any],
+        **kwargs,
+    ) -> tuple[dict[str, str], list[core_models.Message]]:
+        """Hook to determine session configuration
+
+        This hook is executed before session creation.
+
+        Parameters
+        ----------
+        db : sqlalchemy.orm.Session
+            Database session. Can be used to access the database
+        user : users_models.DatabaseUser
+            User who has requested the session
+        tool : tools_models.DatabaseTool
+            Tool of the requested session
+        tool_version : tools_models.DatabaseVersion
+            Tool version of the requested session
+        token : dict[str, t.Any]
+            JWT token used for authentication of the user
+
+
+        Returns
+        -------
+        environment : dict[str, str]
+            Environment variables to be injected into the session.
+        warnings : list[core_models.Message]
+            List of warnings to be displayed to the user.
+        """
+
+    def post_session_creation_hook(
+        self,
+        session_id: str,
+        operator: operators.KubernetesOperator,
+        user: users_models.DatabaseUser,
+        **kwargs,
+    ):
+        """Hook executed after session creation
+
+        This hook is executed after the session was created by the operator.
+
+        Parameters
+        ----------
+        session_id : str
+            ID of the session
+        operator : operators.KubernetesOperator
+            Operator, which is used to spawn the session
+        user : users_models.DatabaseUser
+            User who has requested the session
+        """
+
+    def pre_session_termination_hook(
+        self,
+        db: orm.Session,
+        operator: operators.KubernetesOperator,
+        session: sessions_models.DatabaseSession,
+        **kwargs,
+    ):
+        """Hook executed directly before session termination
+
+        This hook is executed after the session was terminated by the operator.
+
+        Parameters
+        ----------
+        db : sqlalchemy.orm.Session
+            Database session. Can be used to access the database
+        operator : operators.KubernetesOperator
+            Operator, which is used to spawn the session
+        session : sessions_models.DatabaseSession
+            Session which was terminated
+        """

--- a/backend/capellacollab/sessions/hooks/jupyter.py
+++ b/backend/capellacollab/sessions/hooks/jupyter.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import typing as t
+from urllib import parse as urllib_parse
+
+from capellacollab.config import config
+from capellacollab.core import credentials
+from capellacollab.core import models as core_models
+from capellacollab.sessions import operators
+from capellacollab.users import models as users_models
+
+from . import interface
+
+log = logging.getLogger(__name__)
+
+
+class JupyterConfigEnvironment(t.TypedDict):
+    JUPYTER_BASE_URL: str
+    JUPYTER_TOKEN: str
+    JUPYTER_PORT: str
+    CSP_ORIGIN_HOST: str
+
+
+class JupyterIntegration(interface.HookRegistration):
+    def __init__(self):
+        self._jupyter_public_uri: urllib_parse.ParseResult = (
+            urllib_parse.urlparse(config["extensions"]["jupyter"]["publicURI"])
+        )
+        self._general_conf = config["general"]
+
+    def configuration_hook(
+        self,
+        user: users_models.DatabaseUser,
+        **kwargs,
+    ) -> tuple[JupyterConfigEnvironment, list[core_models.Message]]:
+        jupyter_token = credentials.generate_password(length=64)
+
+        environment = {
+            "JUPYTER_TOKEN": jupyter_token,
+            "JUPYTER_BASE_URL": self._determine_base_url(user.name),
+            "JUPYTER_PORT": "8888",
+            "JUPYTER_URI": f'{config["extensions"]["jupyter"]["publicURI"]}/{user.name}/lab?token={jupyter_token}',
+            "CSP_ORIGIN_HOST": f"{self._general_conf.get('scheme')}://{self._general_conf.get('host')}:{self._general_conf.get('port')}",
+        }
+
+        return environment, []
+
+    def post_session_creation_hook(
+        self,
+        session_id: str,
+        operator: operators.KubernetesOperator,
+        user: users_models.DatabaseUser,
+        **kwargs,
+    ):
+        operator.create_public_route(
+            session_id=session_id,
+            host=self._jupyter_public_uri.hostname,
+            path=self._determine_base_url(user.name),
+            port=8888,
+        )
+
+    def _determine_base_url(self, username: str):
+        return f"{self._jupyter_public_uri.path}/{username}"

--- a/backend/capellacollab/sessions/hooks/pure_variants.py
+++ b/backend/capellacollab/sessions/hooks/pure_variants.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import typing as t
+
+from sqlalchemy import orm
+
+from capellacollab.core import models as core_models
+from capellacollab.settings.integrations.purevariants import (
+    crud as purevariants_crud,
+)
+from capellacollab.users import models as users_models
+
+from . import interface
+
+log = logging.getLogger(__name__)
+
+
+class PureVariantsConfigEnvironment(t.TypedDict):
+    PURE_VARIANTS_LICENSE_SERVER: str
+    PURE_VARIANTS_SECRET: str
+
+
+class PureVariantsIntegration(interface.HookRegistration):
+    def configuration_hook(
+        self,
+        db: orm.Session,
+        user: users_models.DatabaseUser,
+        **kwargs,
+    ) -> tuple[PureVariantsConfigEnvironment, list[core_models.Message]]:
+        warnings: list[core_models.Message] = []
+
+        if (
+            not [
+                model
+                for association in user.projects
+                for model in association.project.models
+                if model.restrictions
+                and model.restrictions.allow_pure_variants
+            ]
+            and user.role == users_models.Role.USER
+        ):
+            warnings.append(
+                core_models.Message(
+                    reason=(
+                        "You are trying to create a persistent session with a pure::variants integration.",
+                        "We were not able to find a model with a pure::variants integration.",
+                        "Your session will not be connected to the pure::variants license server.",
+                    )
+                )
+            )
+            return {}, warnings
+
+        if not (
+            pv_license := purevariants_crud.get_pure_variants_configuration(db)
+        ):
+            warnings.append(
+                core_models.Message(
+                    reason=(
+                        "You are trying to create a persistent session with a pure::variants integration.",
+                        "We were not able to find a valid license server URL in our database.",
+                        "Your session will not be connected to the pure::variants license server.",
+                    )
+                )
+            )
+            return {}, warnings
+
+        return {
+            "PURE_VARIANTS_LICENSE_SERVER": pv_license.license_server_url,
+            "PURE_VARIANTS_SECRET": "pure-variants",
+        }, warnings

--- a/backend/capellacollab/sessions/hooks/t4c.py
+++ b/backend/capellacollab/sessions/hooks/t4c.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import typing as t
+
+import requests
+from sqlalchemy import orm
+
+from capellacollab.core import credentials
+from capellacollab.core import models as core_models
+from capellacollab.core.authentication import injectables as auth_injectables
+from capellacollab.sessions import operators
+from capellacollab.settings.modelsources.t4c.repositories import (
+    crud as repo_crud,
+)
+from capellacollab.settings.modelsources.t4c.repositories import (
+    interface as repo_interface,
+)
+from capellacollab.tools import models as tools_models
+from capellacollab.users import models as users_models
+
+from .. import models as sessions_models
+from . import interface
+
+log = logging.getLogger(__name__)
+
+
+class T4CConfigEnvironment(t.TypedDict):
+    T4C_LICENCE_SECRET: str
+    T4C_JSON: str
+    T4C_USERNAME: str
+    T4C_PASSWORD: str
+
+
+class T4CIntegration(interface.HookRegistration):
+    def configuration_hook(
+        self,
+        db: orm.Session,
+        user: users_models.DatabaseUser,
+        tool_version: tools_models.DatabaseVersion,
+        token: dict[str, t.Any],
+        **kwargs,
+    ) -> tuple[T4CConfigEnvironment, list[core_models.Message]]:
+        environment = {}
+        warnings: list[core_models.Message] = []
+
+        # When using a different tool with TeamForCapella support (e.g., Capella + pure::variants),
+        # the version ID doesn't match the version from the T4C integration.
+        # We have to find the matching Capella version by name.
+        t4c_repositories = repo_crud.get_user_t4c_repositories(
+            db, tool_version.name, user
+        )
+
+        environment["T4C_JSON"] = json.dumps(
+            [
+                {
+                    "repository": repository.name,
+                    "protocol": repository.instance.protocol,
+                    "port": repository.instance.http_port
+                    if repository.instance.protocol == "ws"
+                    else repository.instance.port,
+                    "host": repository.instance.host,
+                    "instance": repository.instance.name,
+                }
+                for repository in t4c_repositories
+            ]
+        )
+
+        environment["T4C_LICENCE_SECRET"] = (
+            t4c_repositories[0].instance.license if t4c_repositories else None
+        )
+
+        environment["T4C_USERNAME"] = user.name
+        environment["T4C_PASSWORD"] = credentials.generate_password()
+
+        for repository in t4c_repositories:
+            try:
+                repo_interface.add_user_to_repository(
+                    repository.instance,
+                    repository.name,
+                    username=user.name,
+                    password=environment["T4C_PASSWORD"],
+                    is_admin=auth_injectables.RoleVerification(
+                        required_role=users_models.Role.ADMIN, verify=False
+                    )(token, db),
+                )
+            except requests.RequestException:
+                warnings.append(
+                    core_models.Message(
+                        reason=(
+                            f"The creation of your user in the repository '{repository.name}' of the the instance '{repository.instance.name}' failed.",
+                            "Most likely this is due to a downtime of the corresponding TeamForCapella server.",
+                            "If you don't need access to the repository you can still use the session.",
+                        )
+                    )
+                )
+                log.warning(
+                    "Could not add user to t4c repository '%s' of instance '%s'",
+                    repository.name,
+                    repository.instance.name,
+                    exc_info=True,
+                )
+
+        return environment, warnings
+
+    def pre_session_termination_hook(
+        self,
+        db: orm.Session,
+        operator: operators.KubernetesOperator,
+        session: sessions_models.DatabaseSession,
+        **kwargs,
+    ):
+        if (
+            session.tool.integrations.t4c
+            and session.type == sessions_models.WorkspaceType.PERSISTENT
+        ):
+            self._revoke_session_tokens(db, session)
+        operator.delete_public_route(session_id=session.id)
+
+    def _revoke_session_tokens(
+        self,
+        db: orm.Session,
+        session: sessions_models.DatabaseSession,
+    ):
+        for repository in repo_crud.get_user_t4c_repositories(
+            db, session.version.name, session.owner
+        ):
+            try:
+                repo_interface.remove_user_from_repository(
+                    repository.instance, repository.name, session.owner.name
+                )
+            except requests.RequestException:
+                log.exception(
+                    "Could not delete user '%s' from repository '%s' of instance '%s'. Please delete the user manually.",
+                    session.owner.name,
+                    repository.name,
+                    repository.instance.name,
+                    exc_info=True,
+                )

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -96,18 +96,13 @@ class DatabaseSession(database.Base):
     ports: orm.Mapped[list[int]] = orm.mapped_column(sa.ARRAY(sa.Integer))
     created_at: orm.Mapped[datetime.datetime]
 
-    t4c_password: orm.Mapped[str | None]
-
     rdp_password: orm.Mapped[str | None]
     guacamole_username: orm.Mapped[str | None]
     guacamole_password: orm.Mapped[str | None]
     guacamole_connection_id: orm.Mapped[str | None]
 
-    jupyter_token: orm.Mapped[str | None]
-
     host: orm.Mapped[str]
     type: orm.Mapped[WorkspaceType]
-    mac: orm.Mapped[str]
 
     owner_name: orm.Mapped[str] = orm.mapped_column(
         sa.ForeignKey("users.name")
@@ -126,3 +121,5 @@ class DatabaseSession(database.Base):
         sa.ForeignKey("projects.id")
     )
     project: orm.Mapped[projects_models.DatabaseProject] = orm.relationship()
+
+    environment: orm.Mapped[dict[str, str] | None]

--- a/backend/capellacollab/sessions/sessions.py
+++ b/backend/capellacollab/sessions/sessions.py
@@ -22,11 +22,8 @@ def inject_attrs_in_sessions(
     for session in db_sessions:
         session.state = _determine_session_state(session)
         session.last_seen = get_last_seen(session.id)
-        session.jupyter_uri = (
-            f'{config["extensions"]["jupyter"]["publicURI"]}/{session.owner_name}/lab?token={session.jupyter_token}'
-            if session.jupyter_token
-            else ""
-        )
+        session.jupyter_uri = session.environment.get("JUPYTER_URI")
+        session.t4c_password = session.environment.get("T4C_PASSWORD")
         sessions_list.append(session)
 
     return sessions_list

--- a/backend/capellacollab/sessions/util.py
+++ b/backend/capellacollab/sessions/util.py
@@ -3,18 +3,11 @@
 
 import logging
 
-import requests
 from sqlalchemy import orm
 
 from capellacollab.sessions.operators import k8s
-from capellacollab.settings.modelsources.t4c.repositories import (
-    crud as t4c_repositories_crud,
-)
-from capellacollab.settings.modelsources.t4c.repositories import (
-    interface as settings_t4c_repositories_interface,
-)
 
-from . import crud, models
+from . import crud, hooks, models
 
 log = logging.getLogger(__name__)
 
@@ -24,26 +17,10 @@ def terminate_session(
     session: models.DatabaseSession,
     operator: k8s.KubernetesOperator,
 ):
-    if (
-        session.tool.integrations.t4c
-        and session.type == models.WorkspaceType.PERSISTENT
-    ):
-        revoke_session_tokens(db, session)
+    for hook in hooks.get_activated_integration_hooks(session.tool):
+        hook.pre_session_termination_hook(
+            db=db, session=session, operator=operator, user=session.owner
+        )
 
     crud.delete_session(db, session)
     operator.kill_session(session.id)
-
-
-def revoke_session_tokens(db: orm.Session, session: models.DatabaseSession):
-    for repository in t4c_repositories_crud.get_user_t4c_repositories(
-        db, session.version.name, session.owner
-    ):
-        try:
-            settings_t4c_repositories_interface.remove_user_from_repository(
-                repository.instance, repository.name, session.owner.name
-            )
-        except requests.RequestException:
-            log.exception(
-                "Could not delete user from repository '%s' of instance '%s'. Please delete the user manually.",
-                exc_info=True,
-            )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,9 @@ from capellacollab.__main__ import app
 from capellacollab.core import database
 from capellacollab.core.authentication.jwt_bearer import JWTBearer
 from capellacollab.core.database import migration
+from capellacollab.users import crud as users_crud
+from capellacollab.users import injectables as users_injectables
+from capellacollab.users import models as users_models
 
 os.environ["DEVELOPMENT_MODE"] = "1"
 
@@ -80,6 +83,20 @@ def fixture_executor_name(monkeypatch: pytest.MonkeyPatch) -> str:
 @pytest.fixture(name="unique_username")
 def fixture_unique_username() -> str:
     return str(uuid1())
+
+
+@pytest.fixture(name="user")
+def fixture_user(db, executor_name):
+    user = users_crud.create_user(db, executor_name, users_models.Role.USER)
+
+    def get_mock_own_user():
+        return user
+
+    app.dependency_overrides[
+        users_injectables.get_own_user
+    ] = get_mock_own_user
+    yield user
+    del app.dependency_overrides[users_injectables.get_own_user]
 
 
 @pytest.fixture(name="project")

--- a/backend/tests/sessions/test_session_hooks.py
+++ b/backend/tests/sessions/test_session_hooks.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import typing as t
+
+import pytest
+from sqlalchemy import orm
+
+from capellacollab import __main__
+from capellacollab.core import models as core_models
+from capellacollab.sessions import crud as sessions_crud
+from capellacollab.sessions import hooks as sessions_hooks
+from capellacollab.sessions import models as sessions_models
+from capellacollab.sessions import operators
+from capellacollab.sessions import routes as sessions_routes
+from capellacollab.sessions.hooks import interface as hooks_interface
+from capellacollab.tools import injectables as tools_injectables
+from capellacollab.tools import models as tools_models
+from capellacollab.tools.integrations import models as tools_integration_models
+from capellacollab.users import models as users_models
+
+
+class MockOperator:
+    def start_session(self, *args, **kwargs) -> dict[str, t.Any]:
+        pass
+
+    def kill_session(self, *args, **kwargs) -> None:
+        pass
+
+    def create_persistent_volume(self, *args, **kwargs):
+        return
+
+
+class TestSessionHook(hooks_interface.HookRegistration):
+    configuration_hook_counter = 0
+    post_creation_hook_counter = 0
+    post_termination_hook_counter = 0
+
+    def configuration_hook(
+        self,
+        db: orm.Session,
+        user: users_models.DatabaseUser,
+        tool_version: tools_models.DatabaseVersion,
+        tool: tools_models.DatabaseTool,
+        token: dict[str, t.Any],
+        **kwargs,
+    ) -> tuple[dict[str, str], list[core_models.Message]]:
+        self.configuration_hook_counter += 1
+        return {}, []
+
+    def post_session_creation_hook(
+        self,
+        session_id: str,
+        operator: operators.KubernetesOperator,
+        user: users_models.DatabaseUser,
+        **kwargs,
+    ):
+        self.post_creation_hook_counter += 1
+
+    def pre_session_termination_hook(
+        self,
+        db: orm.Session,
+        operator: operators.KubernetesOperator,
+        session: sessions_models.DatabaseSession,
+        **kwargs,
+    ):
+        self.post_termination_hook_counter += 1
+
+
+@pytest.fixture(autouse=True, name="session_hook")
+def fixture_session_hook(monkeypatch: pytest.MonkeyPatch) -> TestSessionHook:
+    hook = TestSessionHook()
+
+    REGISTERED_HOOKS: dict[str, hooks_interface.HookRegistration] = {
+        "test": hook,
+    }
+
+    monkeypatch.setattr(sessions_hooks, "REGISTERED_HOOKS", REGISTERED_HOOKS)
+    return hook
+
+
+@pytest.fixture(autouse=True, name="mockoperator")
+def fixture_mockoperator() -> MockOperator:
+    mock = MockOperator()
+
+    def get_mock_operator():
+        return mock
+
+    __main__.app.dependency_overrides[
+        operators.get_operator
+    ] = get_mock_operator
+    yield mock
+    del __main__.app.dependency_overrides[operators.get_operator]
+
+
+@pytest.fixture(autouse=True, name="tool_with_test_integration")
+def fixture_tool_with_test_integration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tools_models.DatabaseTool:
+    mock_integration = tools_integration_models.DatabaseToolIntegrations()
+    mock_integration.test = True
+    tool = tools_models.DatabaseTool(
+        id=0,
+        name="test",
+        docker_image_template="test",
+        integrations=mock_integration,
+    )
+
+    def mock_get_existing_tool(*args, **kwargs) -> tools_models.DatabaseTool:
+        return tool
+
+    monkeypatch.setattr(
+        tools_injectables, "get_existing_tool", mock_get_existing_tool
+    )
+    return tool
+
+
+@pytest.fixture(autouse=True, name="tool_version")
+def fixture_tool_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tools_models.DatabaseTool:
+    version = tools_models.DatabaseVersion(
+        id=0,
+        name="test",
+    )
+
+    def get_exisiting_tool_version(
+        *args, **kwargs
+    ) -> tools_models.DatabaseTool:
+        return version
+
+    monkeypatch.setattr(
+        tools_injectables,
+        "get_exisiting_tool_version",
+        get_exisiting_tool_version,
+    )
+    return version
+
+
+@pytest.mark.usefixtures("tool_with_test_integration")
+def test_session_creation_hook_is_called(
+    monkeypatch: pytest.MonkeyPatch,
+    db: orm.Session,
+    user: users_models.DatabaseUser,
+    mockoperator: MockOperator,
+    session_hook: TestSessionHook,
+):
+    monkeypatch.setattr(
+        sessions_routes,
+        "start_persistent_guacamole_session",
+        lambda *args, **kwargs: sessions_models.DatabaseSession(id="test"),
+    )
+
+    sessions_routes.request_persistent_session(
+        sessions_models.PostPersistentSessionRequest(tool_id=0, version_id=0),
+        user,
+        db,
+        mockoperator,
+        {"sub": "testuser"},
+    )
+
+    assert session_hook.configuration_hook_counter == 1
+    assert session_hook.post_creation_hook_counter == 1
+
+
+def test_pre_termination_hook_is_called(
+    monkeypatch: pytest.MonkeyPatch,
+    mockoperator: MockOperator,
+    session_hook: TestSessionHook,
+    tool_with_test_integration: tools_models.DatabaseTool,
+):
+    monkeypatch.setattr(
+        sessions_crud,
+        "delete_session",
+        lambda *args, **kwargs: None,
+    )
+
+    sessions_routes.end_session(
+        sessions_models.PostPersistentSessionRequest(tool_id=0, version_id=0),
+        sessions_models.DatabaseSession(tool=tool_with_test_integration),
+        mockoperator,
+    )
+
+    session_hook.post_termination_hook_counter == 1


### PR DESCRIPTION
The sessions routes and the kubernetes operator grew a lot in the past. These two files can be hard to understand and code quality was rather bad.

A lot of tool-specific logic happened in the two files, e.g., the creation of a T4C session token.
This logic doesn't belong to the operator or the sessions module, the context is tool-specific, but it has a strong connection to the sessions lifecycle.

The solution is session hooks. For the beginning, we support the following hooks:
- configuration_hook (Configuration for the session)
- post_session_creation_hook (Hook executed after session creation)
- post_session_termination_hook (Hook executed after session termination)

The T4C, pure::variants and Jupyter logic was moved to session-hooks.

This is just a start and should make refactoring of the operator easier in the future.