### PR TITLE
refactor: Rename Capella models to tool models

### DIFF
--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -193,7 +193,7 @@ def create_models(db: orm.Session):
         capella_model = toolmodels_crud.create_model(
             db=db,
             project=projects_crud.get_project_by_slug(db, "default"),
-            post_model=toolmodels_models.PostCapellaModel(
+            post_model=toolmodels_models.PostToolModel(
                 name=f"Meldody Model Test {version}",
                 description="",
                 tool_id=capella_tool.id,

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -14,7 +14,7 @@ from capellacollab.core import database
 from capellacollab.projects.users import models as project_users_models
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
     from capellacollab.projects.users.models import ProjectUserAssociation
 
 
@@ -106,6 +106,6 @@ class DatabaseProject(database.Base):
     users: orm.Mapped[list[ProjectUserAssociation]] = orm.relationship(
         back_populates="project"
     )
-    models: orm.Mapped[list[DatabaseCapellaModel]] = orm.relationship(
+    models: orm.Mapped[list[DatabaseToolModel]] = orm.relationship(
         back_populates="project"
     )

--- a/backend/capellacollab/projects/toolmodels/backups/crud.py
+++ b/backend/capellacollab/projects/toolmodels/backups/crud.py
@@ -28,7 +28,7 @@ def get_pipeline_by_id(
 
 
 def get_pipelines_for_tool_model(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodels_models.DatabaseToolModel
 ) -> abc.Sequence[models.DatabaseBackup]:
     return (
         db.execute(
@@ -42,7 +42,7 @@ def get_pipelines_for_tool_model(
 
 
 def get_first_pipeline_for_tool_model(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodels_models.DatabaseToolModel
 ) -> models.DatabaseBackup | None:
     return (
         db.execute(

--- a/backend/capellacollab/projects/toolmodels/backups/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/backups/injectables.py
@@ -16,8 +16,8 @@ from . import crud, models
 
 def get_existing_pipeline(
     pipeline_id: int,
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseBackup:

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -17,7 +17,7 @@ from capellacollab.projects.toolmodels.modelsources.t4c import (
 )
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
     from capellacollab.projects.toolmodels.modelsources.git.models import (
         DatabaseGitModel,
     )
@@ -87,7 +87,7 @@ class DatabaseBackup(database.Base):
     t4c_model: orm.Mapped["DatabaseT4CModel"] = orm.relationship()
 
     model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped["DatabaseCapellaModel"] = orm.relationship()
+    model: orm.Mapped["DatabaseToolModel"] = orm.relationship()
 
     runs: orm.Mapped[
         list["runs_models.DatabasePipelineRun"]

--- a/backend/capellacollab/projects/toolmodels/backups/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/routes.py
@@ -46,8 +46,8 @@ log = logging.getLogger(__name__)
 
 @router.get("", response_model=list[models.Backup])
 def get_pipelines(
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ):
@@ -69,8 +69,8 @@ def get_pipeline(
 @router.post("", response_model=models.Backup)
 def create_backup(
     body: models.CreateBackup,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
     token=fastapi.Depends(jwt_bearer.JWTBearer()),

--- a/backend/capellacollab/projects/toolmodels/backups/validation.py
+++ b/backend/capellacollab/projects/toolmodels/backups/validation.py
@@ -10,7 +10,7 @@ from .runs import models as runs_models
 
 
 def check_last_pipeline_run_status(
-    db: orm.Session, model: toolmodel_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodel_models.DatabaseToolModel
 ) -> runs_models.PipelineRunStatus:
     if pipeline := crud.get_first_pipeline_for_tool_model(db, model):
         # Only consider first pipeline for monitoring, usually there is only one pipeline.

--- a/backend/capellacollab/projects/toolmodels/crud.py
+++ b/backend/capellacollab/projects/toolmodels/crud.py
@@ -14,17 +14,17 @@ from . import models
 from .restrictions import models as restrictions_models
 
 
-def get_models(db: orm.Session) -> abc.Sequence[models.DatabaseCapellaModel]:
-    return db.execute(sa.select(models.DatabaseCapellaModel)).scalars().all()
+def get_models(db: orm.Session) -> abc.Sequence[models.DatabaseToolModel]:
+    return db.execute(sa.select(models.DatabaseToolModel)).scalars().all()
 
 
 def get_models_by_version(
     db: orm.Session, version_id: int
-) -> abc.Sequence[models.DatabaseCapellaModel]:
+) -> abc.Sequence[models.DatabaseToolModel]:
     return (
         db.execute(
-            sa.select(models.DatabaseCapellaModel).where(
-                models.DatabaseCapellaModel.version_id == version_id
+            sa.select(models.DatabaseToolModel).where(
+                models.DatabaseToolModel.version_id == version_id
             )
         )
         .scalars()
@@ -34,11 +34,11 @@ def get_models_by_version(
 
 def get_models_by_nature(
     db: orm.Session, nature_id: int
-) -> abc.Sequence[models.DatabaseCapellaModel]:
+) -> abc.Sequence[models.DatabaseToolModel]:
     return (
         db.execute(
-            sa.select(models.DatabaseCapellaModel).where(
-                models.DatabaseCapellaModel.nature_id == nature_id
+            sa.select(models.DatabaseToolModel).where(
+                models.DatabaseToolModel.nature_id == nature_id
             )
         )
         .scalars()
@@ -48,11 +48,11 @@ def get_models_by_nature(
 
 def get_models_by_tool(
     db: orm.Session, tool_id: int
-) -> abc.Sequence[models.DatabaseCapellaModel]:
+) -> abc.Sequence[models.DatabaseToolModel]:
     return (
         db.execute(
-            sa.select(models.DatabaseCapellaModel).where(
-                models.DatabaseCapellaModel.tool_id == tool_id
+            sa.select(models.DatabaseToolModel).where(
+                models.DatabaseToolModel.tool_id == tool_id
             )
         )
         .scalars()
@@ -62,28 +62,28 @@ def get_models_by_tool(
 
 def get_model_by_slugs(
     db: orm.Session, project_slug: str, model_slug: str
-) -> models.DatabaseCapellaModel | None:
+) -> models.DatabaseToolModel | None:
     return db.execute(
-        sa.select(models.DatabaseCapellaModel)
-        .options(orm.joinedload(models.DatabaseCapellaModel.project))
+        sa.select(models.DatabaseToolModel)
+        .options(orm.joinedload(models.DatabaseToolModel.project))
         .where(
-            models.DatabaseCapellaModel.project.has(
+            models.DatabaseToolModel.project.has(
                 projects_model.DatabaseProject.slug == project_slug
             )
         )
-        .where(models.DatabaseCapellaModel.slug == model_slug)
+        .where(models.DatabaseToolModel.slug == model_slug)
     ).scalar_one_or_none()
 
 
 def create_model(
     db: orm.Session,
     project: projects_model.DatabaseProject,
-    post_model: models.PostCapellaModel,
+    post_model: models.PostToolModel,
     tool: tools_models.DatabaseTool,
     version: tools_models.DatabaseVersion | None = None,
     nature: tools_models.DatabaseNature | None = None,
-) -> models.DatabaseCapellaModel:
-    model = models.DatabaseCapellaModel(
+) -> models.DatabaseToolModel:
+    model = models.DatabaseToolModel(
         name=post_model.name,
         slug=slugify.slugify(post_model.name),
         description=post_model.description if post_model.description else "",
@@ -100,9 +100,9 @@ def create_model(
 
 def set_tool_for_model(
     db: orm.Session,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     tool: tools_models.DatabaseTool,
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model.tool = tool
     db.commit()
     return model
@@ -110,10 +110,10 @@ def set_tool_for_model(
 
 def set_tool_details_for_model(
     db: orm.Session,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     version: tools_models.DatabaseVersion,
     nature: tools_models.DatabaseNature,
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model.version = version
     model.nature = nature
     db.commit()
@@ -122,11 +122,11 @@ def set_tool_details_for_model(
 
 def update_model(
     db: orm.Session,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     description: str | None,
     version: tools_models.DatabaseVersion,
     nature: tools_models.DatabaseNature,
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model.version = version
     model.nature = nature
     if description:
@@ -135,6 +135,6 @@ def update_model(
     return model
 
 
-def delete_model(db: orm.Session, model: models.DatabaseCapellaModel):
+def delete_model(db: orm.Session, model: models.DatabaseToolModel):
     db.delete(model)
     db.commit()

--- a/backend/capellacollab/projects/toolmodels/diagrams/validation.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/validation.py
@@ -12,7 +12,7 @@ import capellacollab.projects.toolmodels.modelsources.git.validation as git_vali
 
 async def check_diagram_cache_health(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     logger: logging.LoggerAdapter,
 ) -> git_models.ModelArtifactStatus:
     return await git_validation.check_pipeline_health(

--- a/backend/capellacollab/projects/toolmodels/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/injectables.py
@@ -12,13 +12,13 @@ from capellacollab.projects import models as projects_models
 from . import crud, models
 
 
-def get_existing_capella_model(
+def get_existing_tool_model(
     model_slug: str,
     project: projects_models.DatabaseProject = fastapi.Depends(
         projects_injectables.get_existing_project
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model = crud.get_model_by_slugs(db, project.slug, model_slug)
     if not model:
         raise fastapi.HTTPException(

--- a/backend/capellacollab/projects/toolmodels/modelbadge/validation.py
+++ b/backend/capellacollab/projects/toolmodels/modelbadge/validation.py
@@ -12,7 +12,7 @@ import capellacollab.projects.toolmodels.modelsources.git.validation as git_vali
 
 async def check_model_badge_health(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     logger: logging.LoggerAdapter,
 ) -> git_models.ModelArtifactStatus:
     return await git_validation.check_pipeline_health(

--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -44,13 +44,13 @@ class EditingMode(enum.Enum):
     GIT = "git"
 
 
-class PostCapellaModel(pydantic.BaseModel):
+class PostToolModel(pydantic.BaseModel):
     name: str
     description: str | None
     tool_id: int
 
 
-class PatchCapellaModel(pydantic.BaseModel):
+class PatchToolModel(pydantic.BaseModel):
     description: str | None
     version_id: int
     nature_id: int
@@ -61,7 +61,7 @@ class ToolDetails(pydantic.BaseModel):
     nature_id: int
 
 
-class DatabaseCapellaModel(database.Base):
+class DatabaseToolModel(database.Base):
     __tablename__ = "models"
     __table_args__ = (sa.UniqueConstraint("project_id", "slug"),)
 
@@ -109,7 +109,7 @@ class DatabaseCapellaModel(database.Base):
     )
 
 
-class CapellaModel(pydantic.BaseModel):
+class ToolModel(pydantic.BaseModel):
     id: int
     slug: str
     name: str

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
@@ -30,7 +30,7 @@ def get_primary_git_model_of_capellamodel(
 
 def add_git_model_to_capellamodel(
     db: orm.Session,
-    capella_model: toolsmodels_models.DatabaseCapellaModel,
+    capella_model: toolsmodels_models.DatabaseToolModel,
     post_git_model: models.PostGitModel,
 ) -> models.DatabaseGitModel:
     primary = not get_primary_git_model_of_capellamodel(db, capella_model.id)

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/injectables.py
@@ -20,8 +20,8 @@ from .handler import factory, handler
 
 def get_existing_git_model(
     git_model_id: int,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> git_models.DatabaseGitModel:
@@ -39,8 +39,8 @@ def get_existing_git_model(
 
 
 def get_existing_primary_git_model(
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> git_models.DatabaseGitModel:

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -12,7 +12,7 @@ from sqlalchemy import orm
 from capellacollab.core import database
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
 
 
 class PostGitModel(pydantic.BaseModel):
@@ -61,7 +61,7 @@ class DatabaseGitModel(database.Base):
     primary: orm.Mapped[bool]
 
     model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped["DatabaseCapellaModel"] = orm.relationship(
+    model: orm.Mapped["DatabaseToolModel"] = orm.relationship(
         back_populates="git_models"
     )
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
@@ -70,8 +70,8 @@ def validate_path(
 
 @router.get("", response_model=list[git_models.GitModel])
 def get_git_models(
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
 ) -> list[git_models.DatabaseGitModel]:
     return capella_model.git_models
@@ -155,8 +155,8 @@ async def get_revisions_with_model_credentials(
 )
 def create_git_model(
     post_git_model: git_models.PostGitModel,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> git_models.DatabaseGitModel:

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/validation.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/validation.py
@@ -15,7 +15,7 @@ from .handler import factory
 
 async def check_primary_git_repository(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     log: logging.LoggerAdapter,
 ) -> models.GitModelStatus:
     primary_repo = crud.get_primary_git_model_of_capellamodel(db, model.id)
@@ -43,7 +43,7 @@ async def check_primary_git_repository(
 
 async def check_pipeline_health(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     job_name: str,
     logger: logging.LoggerAdapter,
 ) -> models.ModelArtifactStatus:

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/crud.py
@@ -29,7 +29,7 @@ def get_t4c_models(db: orm.Session) -> abc.Sequence[models.DatabaseT4CModel]:
 
 
 def get_t4c_models_for_tool_model(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodels_models.DatabaseToolModel
 ) -> abc.Sequence[models.DatabaseT4CModel]:
     return (
         db.execute(
@@ -44,7 +44,7 @@ def get_t4c_models_for_tool_model(
 
 def create_t4c_model(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     repository: repositories_models.DatabaseT4CRepository,
     name: str,
 ) -> models.DatabaseT4CModel:

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/injectables.py
@@ -16,8 +16,8 @@ from . import crud, models
 
 def get_existing_t4c_model(
     t4c_model_id: int,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseT4CModel:

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
@@ -15,7 +15,7 @@ from capellacollab.settings.modelsources.t4c.repositories import (
 )
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
     from capellacollab.settings.modelsources.t4c.repositories.models import (
         DatabaseT4CRepository,
     )
@@ -40,7 +40,7 @@ class DatabaseT4CModel(database.Base):
     )
 
     model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped[DatabaseCapellaModel] = orm.relationship(
+    model: orm.Mapped[DatabaseToolModel] = orm.relationship(
         back_populates="t4c_models"
     )
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
@@ -41,8 +41,8 @@ router = fastapi.APIRouter(
     response_model=list[models.T4CModel],
 )
 def list_t4c_models(
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> abc.Sequence[models.DatabaseT4CModel]:
@@ -74,8 +74,8 @@ def get_t4c_model(
 )
 def create_t4c_model(
     body: models.SubmitT4CModel,
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ):

--- a/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
@@ -10,8 +10,8 @@ from . import models
 
 
 def get_model_restrictions(
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
 ) -> models.DatabaseToolModelRestrictions:
     return model.restrictions

--- a/backend/capellacollab/projects/toolmodels/restrictions/models.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/models.py
@@ -12,7 +12,7 @@ from sqlalchemy import orm
 from capellacollab.core import database
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
 
 
 class ToolModelRestrictions(pydantic.BaseModel):
@@ -33,7 +33,7 @@ class DatabaseToolModelRestrictions(database.Base):
     )
 
     model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped[DatabaseCapellaModel] = orm.relationship(
+    model: orm.Mapped[DatabaseToolModel] = orm.relationship(
         back_populates="restrictions"
     )
 

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -41,8 +41,8 @@ def update_restrictions(
     restrictions: models.DatabaseToolModelRestrictions = fastapi.Depends(
         injectables.get_model_restrictions
     ),
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
-        toolmodels_injectables.get_existing_capella_model
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
+        toolmodels_injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseToolModelRestrictions:

--- a/backend/capellacollab/projects/toolmodels/routes.py
+++ b/backend/capellacollab/projects/toolmodels/routes.py
@@ -33,32 +33,32 @@ router = fastapi.APIRouter(
 
 
 @router.get(
-    "/", response_model=list[models.CapellaModel], tags=["Projects - Models"]
+    "/", response_model=list[models.ToolModel], tags=["Projects - Models"]
 )
 def get_models(
     project: projects_models.DatabaseProject = fastapi.Depends(
         projects_injectables.get_existing_project
     ),
-) -> list[models.DatabaseCapellaModel]:
+) -> list[models.DatabaseToolModel]:
     return project.models
 
 
 @router.get(
     "/{model_slug}",
-    response_model=models.CapellaModel,
+    response_model=models.ToolModel,
     tags=["Projects - Models"],
 )
 def get_model_by_slug(
-    model: models.DatabaseCapellaModel = fastapi.Depends(
-        injectables.get_existing_capella_model
+    model: models.DatabaseToolModel = fastapi.Depends(
+        injectables.get_existing_tool_model
     ),
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     return model
 
 
 @router.post(
     "/",
-    response_model=models.CapellaModel,
+    response_model=models.ToolModel,
     dependencies=[
         fastapi.Depends(
             auth_injectables.ProjectRoleVerification(
@@ -68,13 +68,13 @@ def get_model_by_slug(
     ],
     tags=["Projects - Models"],
 )
-def create_new(
-    new_model: models.PostCapellaModel,
+def create_new_tool_model(
+    new_model: models.PostToolModel,
     project: projects_models.DatabaseProject = fastapi.Depends(
         projects_injectables.get_existing_project
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     tool = tools_injectables.get_existing_tool(
         tool_id=new_model.tool_id, db=db
     )
@@ -93,7 +93,7 @@ def create_new(
 
 @router.patch(
     "/{model_slug}",
-    response_model=models.CapellaModel,
+    response_model=models.ToolModel,
     dependencies=[
         fastapi.Depends(
             auth_injectables.ProjectRoleVerification(
@@ -103,13 +103,13 @@ def create_new(
     ],
     tags=["Projects - Models"],
 )
-def patch_capella_model(
-    body: models.PatchCapellaModel,
-    model: models.DatabaseCapellaModel = fastapi.Depends(
-        injectables.get_existing_capella_model
+def patch_tool_model(
+    body: models.PatchToolModel,
+    model: models.DatabaseToolModel = fastapi.Depends(
+        injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     version = get_version_by_id_or_raise(db, body.version_id)
     if version.tool != model.tool:
         raise fastapi.HTTPException(
@@ -143,9 +143,9 @@ def patch_capella_model(
     ],
     tags=["Projects - Models"],
 )
-def delete_capella_model(
-    model: models.DatabaseCapellaModel = fastapi.Depends(
-        injectables.get_existing_capella_model
+def delete_tool_model(
+    model: models.DatabaseToolModel = fastapi.Depends(
+        injectables.get_existing_tool_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ):

--- a/backend/capellacollab/projects/toolmodels/validation.py
+++ b/backend/capellacollab/projects/toolmodels/validation.py
@@ -5,7 +5,7 @@ from . import models
 
 
 def calculate_model_warnings(
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
 ) -> list[str]:
     warnings = []
     if not model.nature:

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -156,7 +156,7 @@ def request_session(
     entries_with_models = [
         (
             entry,
-            toolmodels_injectables.get_existing_capella_model(
+            toolmodels_injectables.get_existing_tool_model(
                 entry.model_slug, project, db
             ),
         )
@@ -235,7 +235,7 @@ def models_as_json(
     session_model_list: list[
         tuple[
             models.PostReadonlySessionEntry,
-            toolmodels_models.DatabaseCapellaModel,
+            toolmodels_models.DatabaseToolModel,
         ]
     ]
 ):

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
@@ -82,9 +82,9 @@ def _get_user_write_t4c_repositories(
         sa.select(models.DatabaseT4CRepository)
         .join(models.DatabaseT4CRepository.models)
         .join(t4c_models.DatabaseT4CModel.model)
-        .join(toolmodels_models.DatabaseCapellaModel.version)
+        .join(toolmodels_models.DatabaseToolModel.version)
         .where(tools_models.DatabaseVersion.name == version_name)
-        .join(toolmodels_models.DatabaseCapellaModel.project)
+        .join(toolmodels_models.DatabaseToolModel.project)
         .join(projects_models.DatabaseProject.users)
         .where(
             projects_users_models.ProjectUserAssociation.permission
@@ -103,7 +103,7 @@ def _get_admin_t4c_repositories(
         sa.select(models.DatabaseT4CRepository)
         .join(models.DatabaseT4CRepository.models)
         .join(t4c_models.DatabaseT4CModel.model)
-        .join(toolmodels_models.DatabaseCapellaModel.version)
+        .join(toolmodels_models.DatabaseToolModel.version)
         .where(tools_models.DatabaseVersion.name == version_name)
     )
 

--- a/backend/tests/projects/toolmodels/conftest.py
+++ b/backend/tests/projects/toolmodels/conftest.py
@@ -41,8 +41,8 @@ def fixture_capella_model(
     db: orm.Session,
     project: project_models.DatabaseProject,
     capella_tool_version: tools_models.DatabaseVersion,
-) -> toolmodels_models.DatabaseCapellaModel:
-    model = toolmodels_models.PostCapellaModel(
+) -> toolmodels_models.DatabaseToolModel:
+    model = toolmodels_models.PostToolModel(
         name="test", description="test", tool_id=capella_tool_version.tool.id
     )
     return toolmodels_crud.create_model(
@@ -82,7 +82,7 @@ def fixture_git_instance(
 
 @pytest.fixture(name="git_model")
 def fixture_git_models(
-    db: orm.Session, capella_model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, capella_model: toolmodels_models.DatabaseToolModel
 ) -> project_git_models.DatabaseGitModel:
     git_model = project_git_models.PostGitModel(
         path="https://example.com/test/project",
@@ -185,7 +185,7 @@ def fixture_t4c_repository(
 @pytest.fixture(name="t4c_model")
 def fixture_t4c_model(
     db: orm.Session,
-    capella_model: toolmodels_models.DatabaseCapellaModel,
+    capella_model: toolmodels_models.DatabaseToolModel,
     t4c_repository: settings_t4c_repositories_models.DatabaseT4CRepository,
 ) -> models_t4c_models.DatabaseT4CModel:
     return models_t4c_crud.create_t4c_model(

--- a/backend/tests/projects/toolmodels/pipelines/conftest.py
+++ b/backend/tests/projects/toolmodels/pipelines/conftest.py
@@ -34,7 +34,7 @@ def fixture_include_commit_history(
 @pytest.fixture(name="pipeline")
 def fixture_pipeline(
     db: orm.Session,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     git_model: git_models.DatabaseGitModel,
     t4c_model: t4c_models.T4CModel,
     executor_name: str,

--- a/backend/tests/projects/toolmodels/pipelines/pipeline-runs/test_pipeline_runs.py
+++ b/backend/tests/projects/toolmodels/pipelines/pipeline-runs/test_pipeline_runs.py
@@ -53,7 +53,7 @@ def fixture_patch_loki(monkeypatch: pytest.MonkeyPatch, unix_time_in_ns: int):
 def test_create_pipeline_run(
     db: orm.Session,
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     pipeline: pipelines_models.DatabaseBackup,
 ):
@@ -72,7 +72,7 @@ def test_create_pipeline_run(
 @pytest.mark.usefixtures("project_manager")
 def test_create_pipeline_run_with_custom_environment(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     pipeline: pipelines_models.DatabaseBackup,
 ):
@@ -89,7 +89,7 @@ def test_create_pipeline_run_with_custom_environment(
 
 def test_get_pipeline_runs(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     pipeline: pipelines_models.DatabaseBackup,
     pipeline_run: pipeline_runs_models.DatabasePipelineRun,
@@ -105,7 +105,7 @@ def test_get_pipeline_runs(
 
 def test_get_pipeline_run(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     pipeline: pipelines_models.DatabaseBackup,
     pipeline_run: pipeline_runs_models.DatabasePipelineRun,
@@ -121,7 +121,7 @@ def test_get_pipeline_run(
 @pytest.mark.usefixtures("patch_loki")
 def test_get_events(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     pipeline: pipelines_models.DatabaseBackup,
     pipeline_run: pipeline_runs_models.DatabasePipelineRun,
@@ -136,7 +136,7 @@ def test_get_events(
 @pytest.mark.usefixtures("patch_loki")
 def def_get_logs(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     pipeline: pipelines_models.DatabaseBackup,
     pipeline_run: pipeline_runs_models.DatabasePipelineRun,

--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -57,7 +57,7 @@ def fixture_mockoperator(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.usefixtures("project_manager", "mockoperator", "pipeline")
 def test_get_all_pipelines_of_capellamodel(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     run_nightly: bool,
     include_commit_history: bool,
@@ -77,7 +77,7 @@ def test_get_all_pipelines_of_capellamodel(
 )
 def test_create_pipeline_of_capellamodel_git_model_does_not_exist(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     t4c_model: models_t4c_models.T4CModel,
     client: testclient.TestClient,
 ):
@@ -103,7 +103,7 @@ def test_create_pipeline_of_capellamodel_git_model_does_not_exist(
 def test_create_pipeline(
     db: orm.Session,
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     t4c_model: models_t4c_models.T4CModel,
     git_model: git_models.GitModel,
     client: testclient.TestClient,
@@ -133,7 +133,7 @@ def test_create_pipeline(
 )
 def test_pipeline_creation_fails_if_t4c_server_not_available(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     t4c_model: models_t4c_models.T4CModel,
     git_model: git_models.GitModel,
     client: testclient.TestClient,
@@ -178,7 +178,7 @@ def test_pipeline_creation_fails_if_t4c_server_not_available(
 def test_delete_pipeline(
     db: orm.Session,
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     pipeline: pipelines_models.DatabaseBackup,
     client: testclient.TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/projects/toolmodels/test_diagrams.py
+++ b/backend/tests/projects/toolmodels/test_diagrams.py
@@ -99,7 +99,7 @@ def fixture_mock_gitlab_diagram_cache_svg(git_type: git_models.GitType):
 )
 def test_get_diagram_metadata(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -121,7 +121,7 @@ def test_get_diagram_metadata(
 )
 def test_get_diagrams_fails_without_git_instance(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -144,7 +144,7 @@ def test_get_diagrams_fails_without_git_instance(
 )
 def test_get_diagrams_fails_without_api_endpoint(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -174,7 +174,7 @@ def test_get_diagrams_fails_without_api_endpoint(
 )
 def test_get_diagrams_no_diagram_cache_job_found(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -200,7 +200,7 @@ def test_get_diagrams_no_diagram_cache_job_found(
 @pytest.mark.usefixtures("project_user", "git_instance", "git_model")
 def test_get_single_diagram(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(

--- a/backend/tests/projects/toolmodels/test_model_badge.py
+++ b/backend/tests/projects/toolmodels/test_model_badge.py
@@ -120,7 +120,7 @@ def fixture_mock_get_model_badge_from_artifacts_api(
 @pytest.mark.usefixtures("project_user", "git_type", "git_model")
 def test_model_has_no_git_instance(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -138,7 +138,7 @@ def test_model_has_no_git_instance(
 @pytest.mark.usefixtures("project_user", "git_instance", "git_model")
 def test_get_model_badge_fails_with_unsupported_git_instance(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -160,7 +160,7 @@ def test_get_model_badge_fails_with_unsupported_git_instance(
 )
 def test_get_model_badge_fails_without_api_endpoint(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -187,7 +187,7 @@ def test_get_model_badge_fails_without_api_endpoint(
 )
 def test_get_model_badge(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(
@@ -216,7 +216,7 @@ def test_get_model_badge(
 )
 def test_get_model_badge_from_artifacts(
     project: project_models.DatabaseProject,
-    capella_model: toolmodels_models.CapellaModel,
+    capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
 ):
     response = client.get(

--- a/backend/tests/sessions/test_sessions_routes.py
+++ b/backend/tests/sessions/test_sessions_routes.py
@@ -13,7 +13,7 @@ import capellacollab.sessions.guacamole
 from capellacollab.__main__ import app
 from capellacollab.projects.crud import create_project
 from capellacollab.projects.toolmodels.crud import create_model
-from capellacollab.projects.toolmodels.models import PostCapellaModel
+from capellacollab.projects.toolmodels.models import PostToolModel
 from capellacollab.projects.toolmodels.modelsources.git.crud import (
     add_git_model_to_capellamodel,
 )
@@ -337,7 +337,7 @@ def setup_git_model_for_user(db, user, version):
     model = create_model(
         db,
         project,
-        PostCapellaModel(
+        PostToolModel(
             name=str(uuid1()), description="", tool_id=version.tool.id
         ),
         tool=version.tool,


### PR DESCRIPTION
Capella models is still a legacy naming from v1,
before the tool abstraction was introduced.

In v2, tool models can link to any registered tool, not just Capella. Therefore, Capella is removed from the name.