### PR TITLE
fix: Remove trailing '/' from fastapi routes

### DIFF
--- a/backend/capellacollab/core/authentication/provider/azure/routes.py
+++ b/backend/capellacollab/core/authentication/provider/azure/routes.py
@@ -39,7 +39,7 @@ def ad_session():
 global_session_data = TTLCache(maxsize=128, ttl=3600)
 
 
-@router.get("/", name="Get redirect URL for azure authentication")
+@router.get("", name="Get redirect URL for azure authentication")
 async def get_redirect_url():
     state = secrets.token_hex(32)
     assert state not in global_session_data

--- a/backend/capellacollab/core/authentication/provider/oauth/routes.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/routes.py
@@ -20,7 +20,7 @@ from .flow import get_auth_redirect_url, get_token, refresh_token
 router = fastapi.APIRouter()
 
 
-@router.get("/", name="Get redirect URL for OAuth")
+@router.get("", name="Get redirect URL for OAuth")
 async def get_redirect_url():
     return get_auth_redirect_url()
 

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -39,9 +39,7 @@ router = fastapi.APIRouter(
 )
 
 
-@router.get(
-    "/", response_model=abc.Sequence[models.Project], tags=["Projects"]
-)
+@router.get("", response_model=abc.Sequence[models.Project], tags=["Projects"])
 def get_projects(
     user: users_models.DatabaseUser = fastapi.Depends(
         users_injectables.get_own_user
@@ -119,7 +117,7 @@ def get_project_by_slug(
     return db_project
 
 
-@router.post("/", response_model=models.Project, tags=["Projects"])
+@router.post("", response_model=models.Project, tags=["Projects"])
 def create_project(
     post_project: models.PostProjectRequest,
     user: users_models.DatabaseUser = fastapi.Depends(

--- a/backend/capellacollab/projects/toolmodels/routes.py
+++ b/backend/capellacollab/projects/toolmodels/routes.py
@@ -40,7 +40,7 @@ router = fastapi.APIRouter(
 )
 
 
-@router.get("/", response_model=list[CapellaModel], tags=["Projects - Models"])
+@router.get("", response_model=list[CapellaModel], tags=["Projects - Models"])
 def get_models(
     project: DatabaseProject = fastapi.Depends(
         projects_injectables.get_existing_project
@@ -59,7 +59,7 @@ def get_model_by_slug(
 
 
 @router.post(
-    "/",
+    "",
     response_model=CapellaModel,
     dependencies=[
         fastapi.Depends(

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -80,7 +80,7 @@ users_router = fastapi.APIRouter(
 log = logging.getLogger(__name__)
 
 
-@router.get("/", response_model=list[models.GetSessionsResponse])
+@router.get("", response_model=list[models.GetSessionsResponse])
 def get_current_sessions(
     db_user: users_models.DatabaseUser = fastapi.Depends(
         users_injectables.get_own_user

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -28,7 +28,7 @@ T4CRepositoriesResponseModel: t.TypeAlias = core_models.PayloadResponseModel[
 ]
 
 
-@router.get("/", response_model=T4CRepositoriesResponseModel)
+@router.get("", response_model=T4CRepositoriesResponseModel)
 def list_t4c_repositories(
     db: orm.Session = fastapi.Depends(database.get_db),
     instance: settings_t4c_models.DatabaseT4CInstance = fastapi.Depends(
@@ -67,7 +67,7 @@ def list_t4c_repositories(
     return T4CRepositoriesResponseModel(payload=repositories)
 
 
-@router.post("/", response_model=models.T4CRepository)
+@router.post("", response_model=models.T4CRepository)
 def create_t4c_repository(
     body: models.CreateT4CRepository,
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/users/events/routes.py
+++ b/backend/capellacollab/users/events/routes.py
@@ -31,7 +31,7 @@ def get_events(
     return crud.get_events(db)
 
 
-@router.get("/{user_id}/history/", response_model=models.UserHistory)
+@router.get("/{user_id}/history", response_model=models.UserHistory)
 def get_user_history(
     user: users_model.DatabaseUser = fastapi.Depends(
         users_injectables.get_existing_user

--- a/backend/capellacollab/users/routes.py
+++ b/backend/capellacollab/users/routes.py
@@ -48,7 +48,7 @@ def get_user(
 
 
 @router.get(
-    "/",
+    "",
     response_model=list[models.User],
     dependencies=[
         fastapi.Depends(
@@ -63,7 +63,7 @@ def get_users(
 
 
 @router.post(
-    "/",
+    "",
     response_model=models.User,
     dependencies=[
         fastapi.Depends(


### PR DESCRIPTION
A trailing slash leads to a temporary redirect when calling the route without trailing '/'.

This in unwanted behaviour and slows down the frontend.