### PR TITLE
fix: Add timezone awareness in frontend and backend

### DIFF
--- a/backend/capellacollab/core/pydantic.py
+++ b/backend/capellacollab/core/pydantic.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+
+
+def datetime_serializer(dt: datetime.datetime) -> datetime.datetime:
+    return dt.replace(tzinfo=datetime.UTC)

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import datetime
 import typing as t
 
 import pydantic
@@ -36,16 +35,6 @@ class CreateBackup(pydantic.BaseModel):
 
     class Config:
         orm_mode = True
-
-
-class BackupJob(pydantic.BaseModel):
-    id: str
-    date: datetime.datetime | None
-    state: str
-
-
-class Job(pydantic.BaseModel):
-    include_commit_history: bool
 
 
 class Backup(pydantic.BaseModel):

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -4,11 +4,13 @@
 import datetime
 import enum
 
+import pydantic
 import sqlalchemy as sa
 from pydantic import BaseModel
 from sqlalchemy import orm
 
 import capellacollab.users.models as users_models
+from capellacollab.core import pydantic as core_pydantic
 from capellacollab.core.database import Base
 
 from .. import models as pipeline_models
@@ -50,6 +52,16 @@ class DatabasePipelineRun(Base):
     trigger_time: orm.Mapped[datetime.datetime]
     end_time: orm.Mapped[datetime.datetime | None]
     logs_last_fetched_timestamp: orm.Mapped[datetime.datetime | None]
+
+    _validate_trigger_time = pydantic.validator(
+        "trigger_time", allow_reuse=True
+    )(core_pydantic.datetime_serializer)
+    _validate_end_time = pydantic.validator("end_time", allow_reuse=True)(
+        core_pydantic.datetime_serializer
+    )
+    _validate_logs_last_fetched_timestamp = pydantic.validator(
+        "logs_last_fetched_timestamp", allow_reuse=True
+    )(core_pydantic.datetime_serializer)
 
     environment: orm.Mapped[dict[str, str]]
 

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -56,7 +56,7 @@ def create_pipeline_run(
             status=models.PipelineRunStatus.PENDING,
             pipeline=pipeline,
             triggerer=triggerer,
-            trigger_time=datetime.datetime.now(),
+            trigger_time=datetime.datetime.now(datetime.UTC),
             environment=environment,
         ),
     )
@@ -125,8 +125,11 @@ def _determine_end_time_from_pipeline_run(
         minutes=interface.PIPELINES_TIMEOUT + 5
     )  # Add 5 minutes tolerance to pipeline timeout
     return min(
-        pipeline_run.trigger_time + max_pipeline_run_duration,
-        pipeline_run.end_time or datetime.datetime.now(),
+        pipeline_run.trigger_time.replace(tzinfo=datetime.UTC)
+        + max_pipeline_run_duration,
+        (pipeline_run.end_time or datetime.datetime.now(datetime.UTC)).replace(
+            tzinfo=datetime.UTC
+        ),
     )
 
 

--- a/backend/capellacollab/projects/toolmodels/diagrams/models.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/models.py
@@ -6,6 +6,8 @@ import datetime
 
 import pydantic
 
+from capellacollab.core import pydantic as core_pydantic
+
 
 class DiagramMetadata(pydantic.BaseModel):
     name: str
@@ -19,6 +21,10 @@ class DiagramMetadata(pydantic.BaseModel):
 class DiagramCacheMetadata(pydantic.BaseModel):
     diagrams: list[DiagramMetadata]
     last_updated: datetime.datetime
+
+    _validate_last_updated = pydantic.validator(
+        "last_updated", allow_reuse=True
+    )(core_pydantic.datetime_serializer)
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/sessions/crud.py
+++ b/backend/capellacollab/sessions/crud.py
@@ -86,7 +86,7 @@ def create_session(
     db: orm.Session, session: models.DatabaseSession
 ) -> models.DatabaseSession:
     if not session.created_at:
-        session.created_at = datetime.datetime.now()
+        session.created_at = datetime.datetime.now(datetime.UTC)
 
     db.add(session)
     db.commit()

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import orm
 
 from capellacollab.core import database
 from capellacollab.core import models as core_models
+from capellacollab.core import pydantic as core_pydantic
 from capellacollab.projects import models as projects_models
 from capellacollab.tools import models as tools_models
 from capellacollab.users import models as users_models
@@ -40,6 +41,10 @@ class GetSessionsResponse(pydantic.BaseModel):
     last_seen: str
     project: projects_models.Project | None
     version: tools_models.ToolVersionWithTool | None
+
+    _validate_created_at = pydantic.validator("created_at", allow_reuse=True)(
+        core_pydantic.datetime_serializer
+    )
 
     class Config:
         orm_mode = True

--- a/backend/capellacollab/users/crud.py
+++ b/backend/capellacollab/users/crud.py
@@ -50,7 +50,7 @@ def create_user(
     user = models.DatabaseUser(
         name=username,
         role=role,
-        created=datetime.datetime.now(),
+        created=datetime.datetime.now(datetime.UTC),
         projects=[],
         events=[],
     )
@@ -74,7 +74,7 @@ def update_last_login(
     last_login: datetime.datetime | None = None,
 ) -> models.DatabaseUser:
     if not last_login:
-        last_login = datetime.datetime.now()
+        last_login = datetime.datetime.now(datetime.UTC)
     user.last_login = last_login
     db.commit()
     return user

--- a/backend/capellacollab/users/events/crud.py
+++ b/backend/capellacollab/users/events/crud.py
@@ -28,7 +28,7 @@ def create_event(
     event = models.DatabaseUserHistoryEvent(
         user_id=user.id,
         event_type=event_type,
-        execution_time=datetime.datetime.now(),
+        execution_time=datetime.datetime.now(datetime.UTC),
         executor_id=executor.id if executor else None,
         project_id=project.id if project else None,
         reason=reason,

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy import orm
 
 from capellacollab.core import database
+from capellacollab.core import pydantic as core_pydantic
 from capellacollab.projects import models as projects_models
 from capellacollab.users import models as users_models
 
@@ -40,6 +41,10 @@ class BaseHistoryEvent(pydantic.BaseModel):
     event_type: EventType
     reason: str | None
 
+    _validate_execution_time = pydantic.validator(
+        "execution_time", allow_reuse=True
+    )(core_pydantic.datetime_serializer)
+
     class Config:
         orm_mode = True
 
@@ -52,6 +57,13 @@ class UserHistory(users_models.User):
     created: datetime.datetime | None
     last_login: datetime.datetime | None
     events: list[HistoryEvent] | None
+
+    _validate_created = pydantic.validator("created", allow_reuse=True)(
+        core_pydantic.datetime_serializer
+    )
+    _validate_last_login = pydantic.validator("last_login", allow_reuse=True)(
+        core_pydantic.datetime_serializer
+    )
 
 
 class DatabaseUserHistoryEvent(database.Base):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
   "jsonschema",
   "openshift",
   "starlette-prometheus",
-  "pytz",
   "fastapi-pagination",
   "aiohttp"
 ]

--- a/backend/tests/projects/toolmodels/pipelines/pipeline-runs/conftest.py
+++ b/backend/tests/projects/toolmodels/pipelines/pipeline-runs/conftest.py
@@ -23,7 +23,7 @@ def fixture_pipeline_run(
         status=pipeline_runs_models.PipelineRunStatus.PENDING,
         pipeline=pipeline,
         triggerer=project_manager,
-        trigger_time=datetime.datetime.now(),
+        trigger_time=datetime.datetime.now(datetime.UTC),
         logs_last_fetched_timestamp=None,
         environment={},
     )


### PR DESCRIPTION
The backend has used different timezones to store datetimes. Sometimes, the local ast timezone was used, sometimes UTC.

In this commit, all datetime objects are now stored in UTC. The backend adds the timezone information to all backend responses.

With the new timezone in the response, Angular automatically maps the datetime to the client timezone.

Thanks to @Wuestengecko for finding this bug.