### PR TITLE
refactor: Rename `request_session` to `request_readonly_session`

### DIFF
--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -131,7 +131,7 @@ def get_current_sessions(
         )
     ],
 )
-def request_session(
+def request_readonly_session(
     body: models.PostReadonlySessionRequest,
     db_user: users_models.DatabaseUser = fastapi.Depends(
         users_injectables.get_own_user


### PR DESCRIPTION
To be consistent with `request_persistent_session`.

Should be merged after https://github.com/DSD-DBS/capella-collab-manager/pull/912 is merged.