### PR TITLE
refactor: Cleanup model sources

### DIFF
--- a/frontend/src/app/projects/models/model-detail/model-detail.component.css
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.css
@@ -3,12 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-title {
-  font-size: 2em;
-  margin: 20px;
-  padding-bottom: 20px;
-}
-
 .footer {
   color: grey;
   text-align: end;

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.html
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.html
@@ -7,10 +7,10 @@
   class="wrapper"
   *ngIf="(projectService.project$ | async) && (modelService.model$ | async)"
 >
-  <h1 class="title">Git Models</h1>
-  <div class="flex">
-    <a [routerLink]="['..', 'git-model', 'create']">
-      <mat-card matRipple class="mat-card-overview new">
+  <h1 class="!m-separator">Git repositories</h1>
+  <div class="flex flex-wrap">
+    <a class="m-m-card" [routerLink]="['..', 'git-model', 'create']">
+      <mat-card matRipple class="m-0 mat-card-overview new">
         <div class="content">
           Use existing repository <br />
           <div class="icon">
@@ -20,24 +20,17 @@
       </mat-card>
     </a>
 
-    <mat-card class="mat-card-overview new visually-disabled">
-      <div class="content">
-        Create repository <br />
-        <div class="icon">
-          <app-mat-icon size="70px">add_circle_outline</app-mat-icon>
-        </div>
-      </div>
-    </mat-card>
     <app-mat-card-overview-skeleton-loader
       [rows]="1"
       [reservedCards]="2"
       [loading]="(gitModelService.gitModels$ | async) === undefined"
     ></app-mat-card-overview-skeleton-loader>
     <a
+      class="m-m-card"
       *ngFor="let gitModel of gitModelService.gitModels$ | async"
       [routerLink]="['..', 'git-model', gitModel.id]"
     >
-      <mat-card matRipple class="mat-card-overview">
+      <mat-card matRipple class="m-0 mat-card-overview">
         <div class="header">Integration {{ gitModel.id }}</div>
         <div class="content">
           <div>Path: {{ gitModel.path }}</div>
@@ -50,44 +43,44 @@
       </mat-card>
     </a>
   </div>
-  <h1 class="title">T4C Models</h1>
-  <div class="flex">
-    <a [routerLink]="['..', 't4c-model', 'create']">
-      <mat-card matRipple class="mat-card-overview new">
-        <div class="content">
-          Use existing repository <br />
-          <div class="icon">
-            <app-mat-icon size="70px">add_circle_outline</app-mat-icon>
+  <div
+    *ngIf="
+      (modelService.model$ | async)!.tool?.integrations?.t4c &&
+      userService.user?.role === 'administrator'
+    "
+  >
+    <h1 class="!m-separator">TeamForCapella repositories</h1>
+    <div class="flex flex-wrap">
+      <a class="m-m-card" [routerLink]="['..', 't4c-model', 'create']">
+        <mat-card matRipple class="m-0 mat-card-overview new">
+          <div class="content">
+            Use existing repository <br />
+            <div class="icon">
+              <app-mat-icon size="70px">add_circle_outline</app-mat-icon>
+            </div>
           </div>
-        </div>
-      </mat-card>
-    </a>
+        </mat-card>
+      </a>
 
-    <mat-card class="mat-card-overview new visually-disabled">
-      <div class="content">
-        Create repository <br />
-        <div class="icon">
-          <app-mat-icon size="70px">add_circle_outline</app-mat-icon>
-        </div>
-      </div>
-    </mat-card>
-    <a
-      *ngFor="let t4cModel of t4cModelService.t4cModels$ | async"
-      [routerLink]="['..', 't4c-model', t4cModel.id]"
-    >
-      <mat-card matRipple class="mat-card-overview">
-        <div class="header">Integration {{ t4cModel.id }}</div>
-        <div class="content">
-          <div>Instance: {{ t4cModel.repository.instance.name }}</div>
-          <div>Repository: {{ t4cModel.repository.name }}</div>
-          <div>T4C model name: {{ t4cModel.name }}</div>
-        </div>
-      </mat-card>
-    </a>
-    <app-mat-card-overview-skeleton-loader
-      [rows]="1"
-      [reservedCards]="2"
-      [loading]="(t4cModelService.t4cModels$ | async) === undefined"
-    ></app-mat-card-overview-skeleton-loader>
+      <a
+        class="m-m-card"
+        *ngFor="let t4cModel of t4cModelService.t4cModels$ | async"
+        [routerLink]="['..', 't4c-model', t4cModel.id]"
+      >
+        <mat-card matRipple class="m-0 mat-card-overview">
+          <div class="header">Integration {{ t4cModel.id }}</div>
+          <div class="content">
+            <div>Instance: {{ t4cModel.repository.instance.name }}</div>
+            <div>Repository: {{ t4cModel.repository.name }}</div>
+            <div>T4C model name: {{ t4cModel.name }}</div>
+          </div>
+        </mat-card>
+      </a>
+      <app-mat-card-overview-skeleton-loader
+        [rows]="1"
+        [reservedCards]="2"
+        [loading]="(t4cModelService.t4cModels$ | async) === undefined"
+      ></app-mat-card-overview-skeleton-loader>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/projects/models/model-detail/model-detail.component.ts
+++ b/frontend/src/app/projects/models/model-detail/model-detail.component.ts
@@ -9,6 +9,7 @@ import { combineLatest, filter } from 'rxjs';
 import { T4CModelService } from 'src/app/projects/models/model-source/t4c/service/t4c-model.service';
 import { ModelService } from 'src/app/projects/models/service/model.service';
 import { GitModelService } from 'src/app/projects/project-detail/model-overview/model-detail/git-model.service';
+import { UserService } from 'src/app/services/user/user.service';
 import { ProjectService } from '../../service/project.service';
 
 @UntilDestroy()
@@ -22,7 +23,8 @@ export class ModelDetailComponent implements OnInit, OnDestroy {
     public projectService: ProjectService,
     public modelService: ModelService,
     public gitModelService: GitModelService,
-    public t4cModelService: T4CModelService
+    public t4cModelService: T4CModelService,
+    public userService: UserService
   ) {}
 
   ngOnInit(): void {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -19,6 +19,7 @@ module.exports = {
         button: "0.5rem",
         separator: "0.5rem",
         card: "400px",
+        "m-card": "1rem",
       },
     },
   },


### PR DESCRIPTION
- TeamForCapella repositories are only displayed if the user is administrator and the tool has a TeamForCapella integration.
- The margin was moved from the inner mat-card to the outer a-element. The cursor doesn't trigger in the margin area anymore.
- The never implemented "Create new repository" for Git & T4C were removed.