### PR TITLE
fix: Delete public route in Jupyter hook instead T4C hooks

### DIFF
--- a/backend/capellacollab/sessions/hooks/jupyter.py
+++ b/backend/capellacollab/sessions/hooks/jupyter.py
@@ -11,6 +11,7 @@ from capellacollab.core import models as core_models
 from capellacollab.sessions import operators
 from capellacollab.users import models as users_models
 
+from .. import models as sessions_models
 from . import interface
 
 log = logging.getLogger(__name__)
@@ -60,6 +61,14 @@ class JupyterIntegration(interface.HookRegistration):
             path=self._determine_base_url(user.name),
             port=8888,
         )
+
+    def pre_session_termination_hook(
+        self,
+        operator: operators.KubernetesOperator,
+        session: sessions_models.DatabaseSession,
+        **kwargs,
+    ):
+        operator.delete_public_route(session_id=session.id)
 
     def _determine_base_url(self, username: str):
         return f"{self._jupyter_public_uri.path}/{username}"

--- a/backend/capellacollab/sessions/hooks/t4c.py
+++ b/backend/capellacollab/sessions/hooks/t4c.py
@@ -11,7 +11,6 @@ from sqlalchemy import orm
 from capellacollab.core import credentials
 from capellacollab.core import models as core_models
 from capellacollab.core.authentication import injectables as auth_injectables
-from capellacollab.sessions import operators
 from capellacollab.settings.modelsources.t4c.repositories import (
     crud as repo_crud,
 )
@@ -108,7 +107,6 @@ class T4CIntegration(interface.HookRegistration):
     def pre_session_termination_hook(
         self,
         db: orm.Session,
-        operator: operators.KubernetesOperator,
         session: sessions_models.DatabaseSession,
         **kwargs,
     ):
@@ -117,7 +115,6 @@ class T4CIntegration(interface.HookRegistration):
             and session.type == sessions_models.WorkspaceType.PERSISTENT
         ):
             self._revoke_session_tokens(db, session)
-        operator.delete_public_route(session_id=session.id)
 
     def _revoke_session_tokens(
         self,


### PR DESCRIPTION
The public route for Juypter was deleted if the T4C integration was enabled and not if the Jupyter extension was enabled.

This bug may lead to some additional action, as some routes may not be deleted properly since the release v1.18.2 yesterday. Please check for dangling Ingress or OpenShift routes in your cluster.