### PR TITLE
Clean up status codes

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/backups/exceptions.py
@@ -23,7 +23,7 @@ async def pipeline_creation_failed_t4c_server_unreachable_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "err_code": "PIPELINE_OPERATION_FAILED_T4C_SERVER_UNREACHABLE",
                 "title": f"The '{exc.operation.value}' operation on the pipeline failed",

--- a/backend/capellacollab/projects/toolmodels/backups/runs/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/injectables.py
@@ -24,7 +24,7 @@ def get_existing_pipeline_run(
     if pipeline_run := crud.get_pipeline_run_by_id(db, pipeline_run_id):
         if pipeline_run.pipeline.id != pipeline.id:
             raise fastapi.HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail={
                     "reason": f"The pipeline run with the id {pipeline_run.id} does not belong to the pipeline with id {pipeline.id}.",
                 },

--- a/backend/capellacollab/projects/toolmodels/diagrams/routes.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/routes.py
@@ -52,7 +52,7 @@ async def get_diagram_metadata(
     except requests.exceptions.HTTPError:
         logger.info("Failed fetching diagram metadata", exc_info=True)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": (
                     "The diagram cache is not configured properly.",
@@ -90,7 +90,7 @@ async def get_diagram(
     except requests.exceptions.HTTPError:
         logger.info("Failed fetching diagram", exc_info=True)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": (
                     "The diagram cache is not configured properly.",

--- a/backend/capellacollab/projects/toolmodels/diagrams/routes.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/routes.py
@@ -52,7 +52,7 @@ async def get_diagram_metadata(
     except requests.exceptions.HTTPError:
         logger.info("Failed fetching diagram metadata", exc_info=True)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": (
                     "The diagram cache is not configured properly.",
@@ -90,7 +90,7 @@ async def get_diagram(
     except requests.exceptions.HTTPError:
         logger.info("Failed fetching diagram", exc_info=True)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": (
                     "The diagram cache is not configured properly.",

--- a/backend/capellacollab/projects/toolmodels/modelbadge/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelbadge/routes.py
@@ -44,7 +44,7 @@ async def get_model_complexity_badge(
     except (aiohttp.web.HTTPException, requests.exceptions.HTTPError):
         logger.info("Failed fetching model complexity badge", exc_info=True)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": (
                     "The model complexity badge integration is not configured properly.",

--- a/backend/capellacollab/projects/toolmodels/modelbadge/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelbadge/routes.py
@@ -44,7 +44,7 @@ async def get_model_complexity_badge(
     except (aiohttp.web.HTTPException, requests.exceptions.HTTPError):
         logger.info("Failed fetching model complexity badge", exc_info=True)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": (
                     "The model complexity badge integration is not configured properly.",

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/exceptions.py
@@ -116,7 +116,7 @@ async def github_artifact_expired_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "err_code": "ARTIFACT_EXPIRED",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/exceptions.py
@@ -62,7 +62,7 @@ async def git_instance_api_endpoint_not_found_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "err_code": "GIT_INSTANCE_NO_API_ENDPOINT_DEFINED",
                 "reason": (
@@ -98,7 +98,7 @@ async def git_pipeline_job_failed_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
             detail={
                 "err_code": "FAILED_JOB_FOUND",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/exceptions.py
@@ -80,11 +80,11 @@ async def git_pipeline_job_not_found_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "err_code": "PIPELINE_JOB_NOT_FOUND",
                 "reason": (
-                    f"There was no job with the name '{exc.job_name}' within the last 20 runs of the pipeline",
+                    f"There was no job with the name '{exc.job_name}' in the last 20 runs of the pipeline",
                     "Please contact your administrator.",
                 ),
             },
@@ -116,7 +116,7 @@ async def github_artifact_expired_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_409_CONFLICT,
             detail={
                 "err_code": "ARTIFACT_EXPIRED",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
@@ -24,7 +24,7 @@ async def gitlab_access_denied_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "err_code": "GITLAB_ACCESS_DENIED",
                 "reason": (
@@ -42,7 +42,7 @@ async def gitlab_project_not_found_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "err_code": "PROJECT_NOT_FOUND",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
@@ -42,7 +42,7 @@ async def gitlab_project_not_found_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "err_code": "PROJECT_NOT_FOUND",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/handler/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/handler/exceptions.py
@@ -22,7 +22,7 @@ async def git_instance_unsupported_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
             detail={
                 "err_code": "GIT_INSTANCE_UNSUPPORTED",
                 "reason": (
@@ -39,7 +39,7 @@ async def no_matching_git_instance_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "err_code": "NO_MATCHING_GIT_INSTANCE",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/handler/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/handler/exceptions.py
@@ -22,7 +22,7 @@ async def git_instance_unsupported_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "err_code": "GIT_INSTANCE_UNSUPPORTED",
                 "reason": (
@@ -39,7 +39,7 @@ async def no_matching_git_instance_handler(
     return await exception_handlers.http_exception_handler(
         request,
         fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_409_CONFLICT,
             detail={
                 "err_code": "NO_MATCHING_GIT_INSTANCE",
                 "reason": (

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/injectables.py
@@ -30,7 +30,7 @@ def get_existing_git_model(
         return git_model
 
     raise fastapi.HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
+        status_code=status.HTTP_404_NOT_FOUND,
         detail={
             "err_code": "GIT_MODEL_NOT_EXISTING",
             "reason": f"The git model ({git_model_id}) does not exists on the capella model for the project",
@@ -52,7 +52,7 @@ def get_existing_primary_git_model(
         return primary_git_model
 
     raise fastapi.HTTPException(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        status_code=status.HTTP_404_NOT_FOUND,
         detail={
             "err_code": "no_git_model",
             "reason": "No git model is assigned to your project. Please ask a project lead to assign a git model.",

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
@@ -43,7 +43,7 @@ def verify_path_prefix(db: orm.Session, path: str):
                 return
 
     raise fastapi.HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
+        status_code=status.HTTP_404_NOT_FOUND,
         detail={
             "err_code": "no_git_instance_with_prefix_found",
             "reason": "There exist no git instance having the resolved path as prefix. Please check whether you correctly selected a git instance.",

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -48,7 +48,7 @@ def update_restrictions(
 ) -> models.DatabaseToolModelRestrictions:
     if body.allow_pure_variants and not model.tool.integrations.pure_variants:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": "The tool of this model has no pure::variants integration."
                 "Please enable the pure::variants integration in the settings first.",

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -48,7 +48,7 @@ def update_restrictions(
 ) -> models.DatabaseToolModelRestrictions:
     if body.allow_pure_variants and not model.tool.integrations.pure_variants:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": "The tool of this model has no pure::variants integration."
                 "Please enable the pure::variants integration in the settings first.",

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -48,7 +48,7 @@ def update_restrictions(
 ) -> models.DatabaseToolModelRestrictions:
     if body.allow_pure_variants and not model.tool.integrations.pure_variants:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
+            status_code=status.HTTP_400_BAD_REQUEST,
             detail={
                 "reason": "The tool of this model has no pure::variants integration."
                 "Please enable the pure::variants integration in the settings first.",

--- a/backend/capellacollab/projects/toolmodels/routes.py
+++ b/backend/capellacollab/projects/toolmodels/routes.py
@@ -129,7 +129,7 @@ def patch_tool_model(
     version = get_version_by_id_or_raise(db, body.version_id)
     if version.tool != model.tool:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": f"The tool having the version “{version.name}” (“{version.tool.name}”) does not match the tool of the model “{model.name}” (“{model.tool.name}”)."
             },
@@ -138,7 +138,7 @@ def patch_tool_model(
     nature = get_nature_by_id_or_raise(db, body.nature_id)
     if nature.tool != model.tool:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": f"The tool having the nature “{nature.name}” (“{nature.tool.name}”) does not match the tool of the model “{model.name}” (“{model.tool.name}”)."
             },

--- a/backend/capellacollab/projects/toolmodels/routes.py
+++ b/backend/capellacollab/projects/toolmodels/routes.py
@@ -129,7 +129,7 @@ def patch_tool_model(
     version = get_version_by_id_or_raise(db, body.version_id)
     if version.tool != model.tool:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": f"The tool having the version “{version.name}” (“{version.tool.name}”) does not match the tool of the model “{model.name}” (“{model.tool.name}”)."
             },
@@ -138,7 +138,7 @@ def patch_tool_model(
     nature = get_nature_by_id_or_raise(db, body.nature_id)
     if nature.tool != model.tool:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_409_CONFLICT,
             detail={
                 "reason": f"The tool having the nature “{nature.name}” (“{nature.tool.name}”) does not match the tool of the model “{model.name}” (“{model.tool.name}”)."
             },

--- a/backend/capellacollab/sessions/files/routes.py
+++ b/backend/capellacollab/sessions/files/routes.py
@@ -33,7 +33,7 @@ def list_files(
     except Exception:
         log.exception("Loading of files for session %s failed", session.id)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": "Loading the files of the session failed. Is the session running?"
             },

--- a/backend/capellacollab/sessions/files/routes.py
+++ b/backend/capellacollab/sessions/files/routes.py
@@ -33,7 +33,7 @@ def list_files(
     except Exception:
         log.exception("Loading of files for session %s failed", session.id)
         raise fastapi.HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={
                 "reason": "Loading the files of the session failed. Is the session running?"
             },

--- a/backend/capellacollab/settings/modelsources/git/core.py
+++ b/backend/capellacollab/settings/modelsources/git/core.py
@@ -37,7 +37,7 @@ async def ls_remote(url: str, env: cabc.Mapping[str, str]) -> list[str]:
         )
         if e.returncode == 128:
             raise fastapi.HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail={
                     "err_code": "no_git_model_credentials",
                     "reason": "There was an error accessing the model. Please ask your project lead for more information. In most cases, the credentials need to be updated.",

--- a/backend/capellacollab/settings/modelsources/git/injectables.py
+++ b/backend/capellacollab/settings/modelsources/git/injectables.py
@@ -18,7 +18,7 @@ def get_existing_git_instance(
         return git_instance
 
     raise fastapi.HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
+        status_code=status.HTTP_404_NOT_FOUND,
         detail={
             "err_code": "git_instance_not_found",
             "reason": f"The git setting ({git_instance_id}) does not exists",

--- a/backend/capellacollab/settings/modelsources/t4c/interface.py
+++ b/backend/capellacollab/settings/modelsources/t4c/interface.py
@@ -26,7 +26,7 @@ def get_t4c_status(
         )
     except requests.Timeout:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": "The connection to the license server timed out.",
                 "technical": "The license server API timed out.",
@@ -35,7 +35,7 @@ def get_t4c_status(
         )
     except requests.ConnectionError:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": "The connection to the license server failed.",
                 "technical": "We failed to connect to the license server API.",
@@ -46,7 +46,7 @@ def get_t4c_status(
     # This API endpoint returns 404 on success -> We have to handle the error here manually
     if r.status_code != 404 and not r.ok:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": "Internal server error in the license server.",
                 "technical": "The license server API returned an error.",
@@ -59,7 +59,7 @@ def get_t4c_status(
 
         if cur_status.get("message", "") == "No last status available.":
             raise fastapi.HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
+                status_code=status.HTTP_404_NOT_FOUND,
                 detail={
                     "reason": "No status is available. This can happen during and after license server restarts.",
                     "technical": "The license server API returned no status.",
@@ -71,7 +71,7 @@ def get_t4c_status(
             return sessions_models.GetSessionUsageResponse(**cur_status)
     except KeyError:
         raise fastapi.HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "reason": "No status in response from license server.",
                 "technical": "The license server response has no status.",

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -120,7 +120,7 @@ def delete_t4c_repository(
         interface.delete_repository(instance, repository.name)
     except (fastapi.HTTPException, requests.RequestException) as e:
         log.error("Repository deletion failed partially", exc_info=True)
-        response.status_code = status.HTTP_207_MULTI_STATUS
+        response.status_code = status.HTTP_202_ACCEPTED
 
         if isinstance(e, fastapi.HTTPException):
             reason: tuple[str, ...] = (

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -120,7 +120,7 @@ def delete_t4c_repository(
         interface.delete_repository(instance, repository.name)
     except (fastapi.HTTPException, requests.RequestException) as e:
         log.error("Repository deletion failed partially", exc_info=True)
-        response.status_code = status.HTTP_202_ACCEPTED
+        response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
 
         if isinstance(e, fastapi.HTTPException):
             reason: tuple[str, ...] = (

--- a/backend/capellacollab/tools/routes.py
+++ b/backend/capellacollab/tools/routes.py
@@ -99,7 +99,7 @@ def delete_tool(
         raise fastapi.HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
-                "reason": "The tool 'Capella' can not be deleted.",
+                "reason": "The tool 'Capella' cannot be deleted.",
             },
         )
 

--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -91,7 +91,7 @@ def test_create_pipeline_of_capellamodel_git_model_does_not_exist(
         },
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert {"err_code": "GIT_MODEL_NOT_EXISTING"}.items() <= response.json()[
         "detail"
     ].items()

--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -164,7 +164,7 @@ def test_pipeline_creation_fails_if_t4c_server_not_available(
         },
     )
 
-    assert response.status_code == 503
+    assert response.status_code == 422
     assert (
         response.json()["detail"]["err_code"]
         == "PIPELINE_OPERATION_FAILED_T4C_SERVER_UNREACHABLE"

--- a/backend/tests/projects/toolmodels/test_diagrams.py
+++ b/backend/tests/projects/toolmodels/test_diagrams.py
@@ -128,7 +128,7 @@ def test_get_diagrams_fails_without_git_instance(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/diagrams",
     )
 
-    assert response.status_code == 422
+    assert response.status_code == 400
     assert response.json()["detail"]["err_code"] == "GIT_INSTANCE_UNSUPPORTED"
 
 

--- a/backend/tests/projects/toolmodels/test_diagrams.py
+++ b/backend/tests/projects/toolmodels/test_diagrams.py
@@ -128,7 +128,7 @@ def test_get_diagrams_fails_without_git_instance(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/diagrams",
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert response.json()["detail"]["err_code"] == "GIT_INSTANCE_UNSUPPORTED"
 
 
@@ -151,7 +151,7 @@ def test_get_diagrams_fails_without_api_endpoint(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/diagrams",
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert (
         response.json()["detail"]["err_code"]
         == "GIT_INSTANCE_NO_API_ENDPOINT_DEFINED"
@@ -181,7 +181,7 @@ def test_get_diagrams_no_diagram_cache_job_found(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/diagrams",
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 400
     assert response.json()["detail"]["err_code"] == "FAILED_JOB_FOUND"
 
 

--- a/backend/tests/projects/toolmodels/test_model_badge.py
+++ b/backend/tests/projects/toolmodels/test_model_badge.py
@@ -126,7 +126,7 @@ def test_model_has_no_git_instance(
     response = client.get(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/badges/complexity",
     )
-    assert response.status_code == 500
+    assert response.status_code == 409
     assert response.json()["detail"]["err_code"] == "NO_MATCHING_GIT_INSTANCE"
 
 
@@ -144,7 +144,7 @@ def test_get_model_badge_fails_with_unsupported_git_instance(
     response = client.get(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/badges/complexity",
     )
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert response.json()["detail"]["err_code"] == "GIT_INSTANCE_UNSUPPORTED"
 
 
@@ -166,7 +166,7 @@ def test_get_model_badge_fails_without_api_endpoint(
     response = client.get(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/badges/complexity",
     )
-    assert response.status_code == 500
+    assert response.status_code == 422
     assert (
         response.json()["detail"]["err_code"]
         == "GIT_INSTANCE_NO_API_ENDPOINT_DEFINED"

--- a/backend/tests/projects/toolmodels/test_model_badge.py
+++ b/backend/tests/projects/toolmodels/test_model_badge.py
@@ -126,7 +126,7 @@ def test_model_has_no_git_instance(
     response = client.get(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/badges/complexity",
     )
-    assert response.status_code == 409
+    assert response.status_code == 404
     assert response.json()["detail"]["err_code"] == "NO_MATCHING_GIT_INSTANCE"
 
 
@@ -144,7 +144,7 @@ def test_get_model_badge_fails_with_unsupported_git_instance(
     response = client.get(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}/badges/complexity",
     )
-    assert response.status_code == 422
+    assert response.status_code == 400
     assert response.json()["detail"]["err_code"] == "GIT_INSTANCE_UNSUPPORTED"
 
 

--- a/backend/tests/settings/test_t4c_instances.py
+++ b/backend/tests/settings/test_t4c_instances.py
@@ -172,5 +172,5 @@ def test_get_t4c_license_usage_no_status(
         f"/api/v1/settings/modelsources/t4c/{t4c_server.id}/licenses",
     )
 
-    assert response.status_code == 502
+    assert response.status_code == 404
     assert response.json()["detail"]["err_code"] == "NO_STATUS"


### PR DESCRIPTION
Use 4xx status codes for issues that appear in our system. 
Not all "unhappy" flows are error flows. The application anticipates a lot of unhappy cases and should act accordingly.

Fixes #668.