### PR TITLE
refactor: Redesign session connection dialog

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connect/guacamole-dialog/guacamole-dialog.component.css
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connect/guacamole-dialog/guacamole-dialog.component.css
@@ -3,45 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-mat-card {
-  margin-top: 10px;
-  width: fit-content;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-table td {
-  border: 0;
-}
-
-table {
-  margin-left: auto;
-  margin-right: auto;
-}
-
 .title {
   font-size: 1.2em;
   font-weight: bold;
   margin-bottom: 2px;
-}
-
-.title-2 {
-  font-size: 1.3em;
-  font-weight: bold;
-  margin-bottom: 2px;
-  color: var(--primary-color);
-}
-
-.inner-mat-card {
-  width: 90%;
-}
-a {
-  text-decoration: none;
-  color: var(--primary-color);
-}
-
-.blur {
-  filter: blur(4px);
 }
 
 .border {
@@ -49,8 +14,4 @@ a {
   padding: 5px;
   border: 2px solid var(--primary-color);
   border-radius: 5px;
-}
-
-.copy {
-  cursor: copy;
 }

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connect/guacamole-dialog/guacamole-dialog.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connect/guacamole-dialog/guacamole-dialog.component.html
@@ -3,54 +3,71 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<mat-card class="inner-mat-card">
-  <div class="title">Step 1: How do I connect to the server?</div>
+<div
+  *ngIf="
+    isPersistentSession(session) && session.version?.tool?.integrations?.t4c
+  "
+>
+  <div class="m-m-card">
+    <div class="title">TeamForCapella session token</div>
+    If you'd like to connect to TeamForCapella while working with Capella,
+    <br />
+    please copy your session token and enter it when prompted in your Capella
+    session.
+    <br />
+    You can always return to this dialog by clicking on "Connect" in the "Active
+    sessions" overview. <br />
+    <div *ngIf="session?.t4c_password">
+      <span
+        class="font-mono border cursor-copy"
+        [cdkCopyToClipboard]="session!.t4c_password"
+        (click)="showClipboardMessage()"
+      >
+        <span [ngClass]="{ blur: !t4cPasswordRevealed }">{{
+          session!.t4c_password
+        }}</span></span
+      >
+
+      <button
+        *ngIf="!t4cPasswordRevealed"
+        (click)="this.t4cPasswordRevealed = true"
+        mat-mini-fab
+        matTooltip="Show session token"
+      >
+        <mat-icon> blur_off</mat-icon>
+      </button>
+      <button
+        *ngIf="t4cPasswordRevealed"
+        (click)="this.t4cPasswordRevealed = false"
+        mat-mini-fab
+        matTooltip="Hide session token"
+      >
+        <mat-icon> blur_on</mat-icon>
+      </button>
+    </div>
+    <div *ngIf="!session?.t4c_password">
+      No session token was generated for your session.
+    </div>
+  </div>
+  <hr />
+</div>
+
+<div class="m-m-card">
+  <div class="title">Connect to the session</div>
   Please click on this button to connect to the server: <br />
   <button mat-flat-button color="primary" (click)="redirectToGuacamole()">
     Connect to Session
   </button>
-</mat-card>
-<mat-card class="inner-mat-card">
-  <div class="title">Step 2: Wait for Capella</div>
-  After opening the session, Capella starts automatically. This can up to one
+</div>
+<hr />
+<div class="m-m-card">
+  <div class="title">Wait for {{ session.version?.tool?.name }}</div>
+  After opening the session, {{ session.version?.tool?.name }}
+  {{ session.version?.name }} starts automatically. This can take up to one
   minute.
-</mat-card>
-<mat-card class="inner-mat-card" *ngIf="isPersistentSession(session)">
-  <div class="title">Step 3: T4C Login</div>
-  Please enter "{{ userService.getUserName() }}" as username and use your
-  session token as password: <br />
-  <div *ngIf="session?.t4c_password">
-    <span
-      class="monospace border copy"
-      [cdkCopyToClipboard]="session!.t4c_password"
-      (click)="showClipboardMessage()"
-    >
-      <span [ngClass]="{ blur: !t4cPasswordRevealed }">{{
-        session!.t4c_password
-      }}</span></span
-    >
-
-    <button
-      *ngIf="!t4cPasswordRevealed"
-      (click)="this.t4cPasswordRevealed = true"
-      mat-mini-fab
-      matTooltip="Show session token"
-    >
-      <mat-icon> blur_off</mat-icon>
-    </button>
-    <button
-      *ngIf="t4cPasswordRevealed"
-      (click)="this.t4cPasswordRevealed = false"
-      mat-mini-fab
-      matTooltip="Hide session token"
-    >
-      <mat-icon> blur_on</mat-icon>
-    </button>
-  </div>
-  <div *ngIf="!session?.t4c_password">
-    No session token was generated for your session.
-  </div>
-</mat-card>
+</div>
 <div>
-  <button mat-button (click)="this.dialogRef.close()">Close</button>
+  <button mat-stroked-button class="w-full" (click)="this.dialogRef.close()">
+    Close
+  </button>
 </div>

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-deletion-dialog/tool-deletion-dialog.component.html
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-deletion-dialog/tool-deletion-dialog.component.html
@@ -8,7 +8,7 @@
   <div>
     <p>
       Do you really want to delete the Tool
-      <span class="monospace">{{ tool.name }}</span
+      <span class="font-mono">{{ tool.name }}</span
       >? <br />
       This will delete the tool, the linked versions and the linked types.
     </p>

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-repo-deletion-dialog/t4c-repo-deletion-dialog.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-instance-settings/t4c-repo-deletion-dialog/t4c-repo-deletion-dialog.component.html
@@ -8,7 +8,7 @@
   <div>
     <p>
       Do you really want to delete the T4C repository
-      <span class="monospace">{{ repo.name }}</span
+      <span class="font-mono">{{ repo.name }}</span
       >? <br />
       This will delete the repository in our database AND on the TeamForCapella
       server.

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -253,10 +253,6 @@ Angular Material Card Styles
   font-size: 1.5em;
 }
 
-.monospace {
-  font-family: monospace;
-}
-
 .mat-dialog {
   min-width: 800px;
 }


### PR DESCRIPTION
- Hardcoded "Capella" references were removed. Instead, the tool name and tool version name are displayed.
- TeamForCapella is now shown conditionally depending on the activated TeamForCapella integration.
- Some CSS classes were replaced with Tailwind CSS.
- The TeamForCapella connection dialog was moved above the "Connect to session" step to match the typical workflow.
- mat-cards were replaced with simple div elements.

Screenshot of new design: 
![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/b4c30e7a-1f1b-4465-98d5-0a159f79f8c5)


Resolves #413