### PR TITLE
fix: Disable Docker Buildkit

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,8 +46,7 @@ ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /tmp/backend
-RUN --mount=type=cache,id=capella-collaboration-backend-dependencies,target=/root/.cache/pip,sharing=locked \
-    pip install .
+RUN pip install .
 
 RUN mkdir -p /var/log/backend && \
     chmod -R 777 /var/log/backend


### PR DESCRIPTION
Docker buildkit is not available when running
`az acr build`. To add support, we have to remove
the Docker BuildKit requirement.

Revert "perf: Use build cache for Docker build"

This reverts commit 3b23c78e0cc4a4504f53ced4b537e9ffc0d8f3ca.