### PR TITLE
Migrate to pydantic v2

### DIFF
--- a/backend/capellacollab/core/authentication/provider/azure/routes.py
+++ b/backend/capellacollab/core/authentication/provider/azure/routes.py
@@ -58,7 +58,7 @@ async def api_get_token(
     auth_data = global_session_data[body.state]
     del global_session_data[body.state]
     token = ad_session().acquire_token_by_auth_code_flow(
-        auth_data, body.dict(), scopes=[]
+        auth_data, body.model_dump(), scopes=[]
     )
     access_token = token["id_token"]
 

--- a/backend/capellacollab/core/authentication/provider/models.py
+++ b/backend/capellacollab/core/authentication/provider/models.py
@@ -12,8 +12,8 @@ class JSONWebKey(pydantic.BaseModel):
     n: str
     e: str
     kid: str
-    x5t: str | None
-    x5c: list[str] | None
+    x5t: str | None = None
+    x5c: list[str] | None = None
 
 
 class JSONWebKeySet(pydantic.BaseModel):

--- a/backend/capellacollab/core/database/__init__.py
+++ b/backend/capellacollab/core/database/__init__.py
@@ -31,7 +31,7 @@ def get_db() -> orm.Session:
 def patch_database_with_pydantic_object(
     database_object: Base, pydantic_object: pydantic.BaseModel
 ):
-    for key, value in pydantic_object.dict().items():
+    for key, value in pydantic_object.model_dump().items():
         if value is not None:
             setattr(database_object, key, value)
 

--- a/backend/capellacollab/core/metadata.py
+++ b/backend/capellacollab/core/metadata.py
@@ -8,10 +8,9 @@ import capellacollab
 
 
 class Metadata(pydantic.BaseModel):
-    version: str
+    model_config = pydantic.ConfigDict(from_attributes=True)
 
-    class Config:
-        orm_mode = True
+    version: str
 
 
 router = fastapi.APIRouter()

--- a/backend/capellacollab/core/models.py
+++ b/backend/capellacollab/core/models.py
@@ -4,7 +4,6 @@
 import typing as t
 
 import pydantic
-from pydantic import generics
 
 T = t.TypeVar("T")
 
@@ -21,5 +20,5 @@ class ResponseModel(pydantic.BaseModel):
     errors: list[Message] | None = None
 
 
-class PayloadResponseModel(ResponseModel, generics.GenericModel, t.Generic[T]):
+class PayloadResponseModel(ResponseModel, t.Generic[T]):
     payload: T

--- a/backend/capellacollab/core/pydantic.py
+++ b/backend/capellacollab/core/pydantic.py
@@ -4,5 +4,9 @@
 import datetime
 
 
-def datetime_serializer(dt: datetime.datetime) -> datetime.datetime:
-    return dt.replace(tzinfo=datetime.UTC)
+def datetime_serializer(
+    dt: datetime.datetime | None,
+) -> datetime.datetime | None:
+    if dt:
+        return dt.replace(tzinfo=datetime.UTC)
+    return None

--- a/backend/capellacollab/health/models.py
+++ b/backend/capellacollab/health/models.py
@@ -23,7 +23,7 @@ class ToolmodelStatus(pydantic.BaseModel):
 
     warnings: list[str]
     primary_git_repository_status: git_models.GitModelStatus
-    pipeline_status: pipeline_run_models.PipelineRunStatus | None
+    pipeline_status: pipeline_run_models.PipelineRunStatus | None = None
     model_badge_status: git_models.ModelArtifactStatus
     diagram_cache_status: git_models.ModelArtifactStatus
 

--- a/backend/capellacollab/health/models.py
+++ b/backend/capellacollab/health/models.py
@@ -19,12 +19,14 @@ class StatusResponse(pydantic.BaseModel):
 
 class ToolmodelStatus(pydantic.BaseModel):
     project_slug: str
-    model_slug: str
+    toolmodel_slug: str = pydantic.Field(alias="model_slug")
 
     warnings: list[str]
     primary_git_repository_status: git_models.GitModelStatus
     pipeline_status: pipeline_run_models.PipelineRunStatus | None = None
-    model_badge_status: git_models.ModelArtifactStatus
+    toolmodel_badge_status: git_models.ModelArtifactStatus = pydantic.Field(
+        alias="model_badge_status"
+    )
     diagram_cache_status: git_models.ModelArtifactStatus
 
 

--- a/backend/capellacollab/health/models.py
+++ b/backend/capellacollab/health/models.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import typing as t
+
 import pydantic
 
 from capellacollab.projects.toolmodels.backups.runs import (
@@ -33,3 +36,9 @@ class ToolmodelStatus(pydantic.BaseModel):
 class ProjectStatus(pydantic.BaseModel):
     project_slug: str
     warnings: list[str]
+
+
+class ToolModelStatusTasks(t.TypedDict):
+    primary_git_repository_status: asyncio.Task[git_models.GitModelStatus]
+    model_badge_status: asyncio.Task[git_models.ModelArtifactStatus]
+    diagram_cache_status: asyncio.Task[git_models.ModelArtifactStatus]

--- a/backend/capellacollab/notices/crud.py
+++ b/backend/capellacollab/notices/crud.py
@@ -27,7 +27,7 @@ def get_notice_by_id(
 def create_notice(
     db: orm.Session, body: models.CreateNoticeRequest
 ) -> models.DatabaseNotice:
-    notice = models.DatabaseNotice(**body.dict())
+    notice = models.DatabaseNotice(**body.model_dump())
     db.add(notice)
     db.commit()
     return notice

--- a/backend/capellacollab/notices/models.py
+++ b/backend/capellacollab/notices/models.py
@@ -20,12 +20,11 @@ class NoticeLevel(enum.Enum):
 
 
 class CreateNoticeRequest(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     level: NoticeLevel
     title: str
     message: str
-
-    class Config:
-        orm_mode = True
 
 
 class NoticeResponse(CreateNoticeRequest):

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -30,6 +30,8 @@ class Visibility(enum.Enum):
 
 
 class Project(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     name: str
     slug: str
     description: str | None
@@ -74,9 +76,6 @@ class Project(pydantic.BaseModel):
                 ]
             ),
         )
-
-    class Config:
-        orm_mode = True
 
 
 class PatchProject(pydantic.BaseModel):

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -38,44 +38,46 @@ class Project(pydantic.BaseModel):
     visibility: Visibility
     users: UserMetadata
 
-    @pydantic.validator("users", pre=True)
+    @pydantic.field_validator("users", mode="before")
     @classmethod
-    def transform_users(
-        cls,
-        users: UserMetadata
-        | list[project_users_models.ProjectUserAssociation],
-    ):
-        if isinstance(users, (UserMetadata, dict)):
-            return users
+    def transform_users(cls, data: t.Any):
+        if isinstance(data, UserMetadata):
+            return data
 
-        return UserMetadata(
-            leads=len(
-                [
-                    user
-                    for user in users
-                    if user.role
-                    == project_users_models.ProjectUserRole.MANAGER
-                ]
-            ),
-            contributors=len(
-                [
-                    user
-                    for user in users
-                    if user.role == project_users_models.ProjectUserRole.USER
-                    and user.permission
-                    == project_users_models.ProjectUserPermission.WRITE
-                ]
-            ),
-            subscribers=len(
-                [
-                    user
-                    for user in users
-                    if user.role == project_users_models.ProjectUserRole.USER
-                    and user.permission
-                    == project_users_models.ProjectUserPermission.READ
-                ]
-            ),
-        )
+        if isinstance(data, list):
+            # Assumption: If it is a list, all entries are of type ProjectUserAssociation
+            return UserMetadata(
+                leads=len(
+                    [
+                        user
+                        for user in data
+                        if user.role
+                        == project_users_models.ProjectUserRole.MANAGER
+                    ]
+                ),
+                contributors=len(
+                    [
+                        user
+                        for user in data
+                        if user.role
+                        == project_users_models.ProjectUserRole.USER
+                        and user.permission
+                        == project_users_models.ProjectUserPermission.WRITE
+                    ]
+                ),
+                subscribers=len(
+                    [
+                        user
+                        for user in data
+                        if user.role
+                        == project_users_models.ProjectUserRole.USER
+                        and user.permission
+                        == project_users_models.ProjectUserPermission.READ
+                    ]
+                ),
+            )
+
+        return data
 
 
 class PatchProject(pydantic.BaseModel):

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -34,7 +34,7 @@ class Project(pydantic.BaseModel):
 
     name: str
     slug: str
-    description: str | None
+    description: str | None = None
     visibility: Visibility
     users: UserMetadata
 
@@ -79,14 +79,14 @@ class Project(pydantic.BaseModel):
 
 
 class PatchProject(pydantic.BaseModel):
-    name: str | None
-    description: str | None
-    visibility: Visibility | None
+    name: str | None = None
+    description: str | None = None
+    visibility: Visibility | None = None
 
 
 class PostProjectRequest(pydantic.BaseModel):
     name: str
-    description: str | None
+    description: str | None = None
     visibility: Visibility = Visibility.PRIVATE
 
 

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -28,16 +28,17 @@ if t.TYPE_CHECKING:
 
 
 class CreateBackup(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     git_model_id: int
     t4c_model_id: int
     include_commit_history: bool
     run_nightly: bool
 
-    class Config:
-        orm_mode = True
-
 
 class Backup(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     k8s_cronjob_id: str | None
 
@@ -45,9 +46,6 @@ class Backup(pydantic.BaseModel):
     git_model: git_models.GitModel
     run_nightly: bool
     include_commit_history: bool
-
-    class Config:
-        orm_mode = True
 
 
 class DatabaseBackup(database.Base):

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -40,7 +40,7 @@ class Backup(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
     id: int
-    k8s_cronjob_id: str | None
+    k8s_cronjob_id: str | None = None
 
     t4c_model: t4c_models.SimpleT4CModel
     git_model: git_models.GitModel

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -65,7 +65,7 @@ class PipelineRun(pydantic.BaseModel):
     status: PipelineRunStatus
     environment: dict[str, str]
 
-    _validate_trigger_time = pydantic.field_validator("trigger_time")(
+    _validate_trigger_time = pydantic.field_serializer("trigger_time")(
         core_pydantic.datetime_serializer
     )
 

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -52,16 +52,6 @@ class DatabasePipelineRun(Base):
     end_time: orm.Mapped[datetime.datetime | None]
     logs_last_fetched_timestamp: orm.Mapped[datetime.datetime | None]
 
-    _validate_trigger_time = pydantic.validator(
-        "trigger_time", allow_reuse=True
-    )(core_pydantic.datetime_serializer)
-    _validate_end_time = pydantic.validator("end_time", allow_reuse=True)(
-        core_pydantic.datetime_serializer
-    )
-    _validate_logs_last_fetched_timestamp = pydantic.validator(
-        "logs_last_fetched_timestamp", allow_reuse=True
-    )(core_pydantic.datetime_serializer)
-
     environment: orm.Mapped[dict[str, str]]
 
 
@@ -74,6 +64,10 @@ class PipelineRun(pydantic.BaseModel):
     trigger_time: datetime.datetime
     status: PipelineRunStatus
     environment: dict[str, str]
+
+    _validate_trigger_time = pydantic.field_validator("trigger_time")(
+        core_pydantic.datetime_serializer
+    )
 
 
 class BackupPipelineRun(pydantic.BaseModel):

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -6,7 +6,6 @@ import enum
 
 import pydantic
 import sqlalchemy as sa
-from pydantic import BaseModel
 from sqlalchemy import orm
 
 import capellacollab.users.models as users_models
@@ -66,16 +65,16 @@ class DatabasePipelineRun(Base):
     environment: orm.Mapped[dict[str, str]]
 
 
-class PipelineRun(BaseModel):
+class PipelineRun(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
     id: int
-    reference_id: str | None
+    reference_id: str | None = None
     triggerer: users_models.User
     trigger_time: datetime.datetime
     status: PipelineRunStatus
     environment: dict[str, str]
 
 
-class BackupPipelineRun(BaseModel):
-    include_commit_history: bool | None
+class BackupPipelineRun(pydantic.BaseModel):
+    include_commit_history: bool | None = None

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -67,15 +67,14 @@ class DatabasePipelineRun(Base):
 
 
 class PipelineRun(BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     reference_id: str | None
     triggerer: users_models.User
     trigger_time: datetime.datetime
     status: PipelineRunStatus
     environment: dict[str, str]
-
-    class Config:
-        orm_mode = True
 
 
 class BackupPipelineRun(BaseModel):

--- a/backend/capellacollab/projects/toolmodels/diagrams/models.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/models.py
@@ -10,21 +10,19 @@ from capellacollab.core import pydantic as core_pydantic
 
 
 class DiagramMetadata(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     name: str
     uuid: str
     success: bool
 
-    class Config:
-        orm_mode = True
-
 
 class DiagramCacheMetadata(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     diagrams: list[DiagramMetadata]
     last_updated: datetime.datetime
 
     _validate_last_updated = pydantic.validator(
         "last_updated", allow_reuse=True
     )(core_pydantic.datetime_serializer)
-
-    class Config:
-        orm_mode = True

--- a/backend/capellacollab/projects/toolmodels/diagrams/models.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/models.py
@@ -23,6 +23,6 @@ class DiagramCacheMetadata(pydantic.BaseModel):
     diagrams: list[DiagramMetadata]
     last_updated: datetime.datetime
 
-    _validate_last_updated = pydantic.validator(
-        "last_updated", allow_reuse=True
-    )(core_pydantic.datetime_serializer)
+    _validate_last_updated = pydantic.field_serializer("last_updated")(
+        core_pydantic.datetime_serializer
+    )

--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -12,12 +12,10 @@ import sqlalchemy as sa
 from sqlalchemy import orm
 
 from capellacollab.core import database
-from capellacollab.projects.toolmodels.modelsources.git import (
-    models as git_models,
-)
-from capellacollab.projects.toolmodels.modelsources.t4c import (
-    models as t4c_models,
-)
+
+# Importing the modules here does not work as it produces a pydantic error for the CapellaModel
+from capellacollab.projects.toolmodels.modelsources.git.models import GitModel
+from capellacollab.projects.toolmodels.modelsources.t4c.models import T4CModel
 from capellacollab.tools import models as tools_models
 
 from .restrictions import models as restrictions_models
@@ -46,12 +44,12 @@ class EditingMode(enum.Enum):
 
 class PostCapellaModel(pydantic.BaseModel):
     name: str
-    description: str | None
+    description: str | None = None
     tool_id: int
 
 
 class PatchCapellaModel(pydantic.BaseModel):
-    description: str | None
+    description: str | None = None
     version_id: int
     nature_id: int
 
@@ -119,9 +117,9 @@ class CapellaModel(pydantic.BaseModel):
     name: str
     description: str
     tool: tools_models.ToolBase
-    version: tools_models.ToolVersionBase | None
-    nature: tools_models.ToolNatureBase | None
-    git_models: list[git_models.GitModel] | None
-    t4c_models: list[t4c_models.T4CModel] | None
+    version: tools_models.ToolVersionBase | None = None
+    nature: tools_models.ToolNatureBase | None = None
+    git_models: list[GitModel] | None = None
+    t4c_models: list[T4CModel] | None = None
 
-    restrictions: restrictions_models.ToolModelRestrictions | None
+    restrictions: restrictions_models.ToolModelRestrictions | None = None

--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -112,6 +112,8 @@ class DatabaseCapellaModel(database.Base):
 
 
 class CapellaModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     slug: str
     name: str
@@ -123,6 +125,3 @@ class CapellaModel(pydantic.BaseModel):
     t4c_models: list[t4c_models.T4CModel] | None
 
     restrictions: restrictions_models.ToolModelRestrictions | None
-
-    class Config:
-        orm_mode = True

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -27,26 +27,16 @@ class PatchGitModel(PostGitModel):
     primary: bool
 
 
-class GitModel(pydantic.BaseModel):
+class GitModel(PostGitModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
     id: int
     name: str
-    path: str
-    entrypoint: str
-    revision: str
     primary: bool
-    username: str
-    password: bool
 
-    @pydantic.field_validator("password", mode="before")
-    @classmethod
-    def transform_password(cls, data: t.Any) -> t.Any:
-        if isinstance(data, bool):
-            return data
-        elif isinstance(data, str):
-            return data is not None and len(data) > 0
-        return data
+    @pydantic.field_serializer("password")
+    def transform_password(self, data: str) -> bool:
+        return data is not None and len(data) > 0
 
 
 class DatabaseGitModel(database.Base):

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -75,7 +75,7 @@ class DatabaseGitModel(database.Base):
             name="",
             primary=primary,
             model_id=model_id,
-            **new_model.dict(),
+            **new_model.model_dump(),
         )
 
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -39,12 +39,14 @@ class GitModel(pydantic.BaseModel):
     username: str
     password: bool
 
-    @pydantic.validator("password", pre=True)
+    @pydantic.field_validator("password", mode="before")
     @classmethod
-    def transform_password(cls, passw: str | bool) -> bool:
-        if isinstance(passw, bool):
-            return passw
-        return passw is not None and len(passw) > 0
+    def transform_password(cls, data: t.Any) -> t.Any:
+        if isinstance(data, bool):
+            return data
+        elif isinstance(data, str):
+            return data is not None and len(data) > 0
+        return data
 
 
 class DatabaseGitModel(database.Base):

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -28,6 +28,8 @@ class PatchGitModel(PostGitModel):
 
 
 class GitModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     name: str
     path: str
@@ -43,9 +45,6 @@ class GitModel(pydantic.BaseModel):
         if isinstance(passw, bool):
             return passw
         return passw is not None and len(passw) > 0
-
-    class Config:
-        orm_mode = True
 
 
 class DatabaseGitModel(database.Base):

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
@@ -58,13 +58,16 @@ class SimpleT4CModel(pydantic.BaseModel):
     repository_name: str
     instance_name: str
 
+    @pydantic.model_validator(mode="before")
     @classmethod
-    def from_orm(cls, obj: DatabaseT4CModel) -> SimpleT4CModel:
-        return SimpleT4CModel(
-            project_name=obj.name,
-            repository_name=obj.repository.name,
-            instance_name=obj.repository.instance.name,
-        )
+    def transform_database_t4c_model(cls, data: t.Any) -> t.Any:
+        if isinstance(data, DatabaseT4CModel):
+            return SimpleT4CModel(
+                project_name=data.name,
+                repository_name=data.repository.name,
+                instance_name=data.repository.instance.name,
+            )
+        return data
 
 
 class T4CModel(pydantic.BaseModel):

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
@@ -52,12 +52,11 @@ class SubmitT4CModel(pydantic.BaseModel):
 
 
 class SimpleT4CModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     project_name: str
     repository_name: str
     instance_name: str
-
-    class Config:
-        orm_mode = True
 
     @classmethod
     def from_orm(cls, obj: DatabaseT4CModel) -> SimpleT4CModel:
@@ -69,16 +68,14 @@ class SimpleT4CModel(pydantic.BaseModel):
 
 
 class T4CModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     name: str
     repository: repositories_models.T4CRepository
 
-    class Config:
-        orm_mode = True
-
 
 class T4CRepositoryWithModels(repositories_models.T4CRepository):
-    models: list[T4CModel]
+    model_config = pydantic.ConfigDict(from_attributes=True)
 
-    class Config:
-        orm_mode = True
+    models: list[T4CModel]

--- a/backend/capellacollab/projects/toolmodels/restrictions/models.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/models.py
@@ -16,13 +16,12 @@ if t.TYPE_CHECKING:
 
 
 class ToolModelRestrictions(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     # If true, access to the specific resource is granted for a model.
     # If false, the access is not allowed.
 
     allow_pure_variants: bool
-
-    class Config:
-        orm_mode = True
 
 
 class DatabaseToolModelRestrictions(database.Base):

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -29,12 +29,11 @@ class ProjectUserPermission(enum.Enum):
 
 
 class ProjectUser(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     role: ProjectUserRole
     permission: ProjectUserPermission
     user: users_models.User
-
-    class Config:
-        orm_mode = True
 
 
 class PostProjectUser(pydantic.BaseModel):

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -44,8 +44,8 @@ class PostProjectUser(pydantic.BaseModel):
 
 
 class PatchProjectUser(pydantic.BaseModel):
-    role: ProjectUserRole | None
-    permission: ProjectUserPermission | None
+    role: ProjectUserRole | None = None
+    permission: ProjectUserPermission | None = None
     reason: str
 
 

--- a/backend/capellacollab/projects/users/routes.py
+++ b/backend/capellacollab/projects/users/routes.py
@@ -109,12 +109,14 @@ def get_users_for_project(
         projects_injectables.get_existing_project
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> list[models.ProjectUserAssociation]:
-    return pydantic.parse_obj_as(list[models.ProjectUser], project.users) + [
+) -> list[models.ProjectUser]:
+    return pydantic.TypeAdapter(list[models.ProjectUser]).validate_python(
+        project.users
+    ) + [
         models.ProjectUser(
             role=models.ProjectUserRole.ADMIN,
             permission=models.ProjectUserPermission.WRITE,
-            user=user,
+            user=users_models.User.model_validate(user),
         )
         for user in users_crud.get_admin_users(db)
     ]

--- a/backend/capellacollab/sessions/files/models.py
+++ b/backend/capellacollab/sessions/files/models.py
@@ -19,4 +19,4 @@ class FileTree(pydantic.BaseModel):
     path: str
     name: str
     type: FileType
-    children: list[FileTree] | None
+    children: list[FileTree] | None = None

--- a/backend/capellacollab/sessions/files/models.py
+++ b/backend/capellacollab/sessions/files/models.py
@@ -14,10 +14,9 @@ class FileType(enum.Enum):
 
 
 class FileTree(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     path: str
     name: str
     type: FileType
     children: list[FileTree] | None
-
-    class Config:
-        orm_mode = True

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -55,7 +55,7 @@ class OwnSessionResponse(GetSessionsResponse):
 
 
 class PostReadonlySessionEntry(pydantic.BaseModel):
-    model_slug: str
+    toolmodel_slug: str = pydantic.Field(alias="model_slug")
     git_model_id: int
     revision: str
     deep_clone: bool

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -30,6 +30,8 @@ class WorkspaceType(enum.Enum):
 
 
 class GetSessionsResponse(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: str
     type: WorkspaceType
     created_at: datetime.datetime
@@ -46,9 +48,6 @@ class GetSessionsResponse(pydantic.BaseModel):
         core_pydantic.datetime_serializer
     )
 
-    class Config:
-        orm_mode = True
-
 
 class OwnSessionResponse(GetSessionsResponse):
     t4c_password: str | None
@@ -63,34 +62,30 @@ class PostReadonlySessionEntry(pydantic.BaseModel):
 
 
 class PostReadonlySessionRequest(pydantic.BaseModel):
-    models: list[PostReadonlySessionEntry]
+    model_config = pydantic.ConfigDict(from_attributes=True)
 
-    class Config:
-        orm_mode = True
+    models: list[PostReadonlySessionEntry]
 
 
 class PostPersistentSessionRequest(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     tool_id: int
     version_id: int
 
-    class Config:
-        orm_mode = True
-
 
 class GetSessionUsageResponse(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     free: int
     total: int
 
-    class Config:
-        orm_mode = True
-
 
 class GuacamoleAuthentication(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     token: str
     url: str
-
-    class Config:
-        orm_mode = True
 
 
 class DatabaseSession(database.Base):

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -44,7 +44,7 @@ class GetSessionsResponse(pydantic.BaseModel):
     project: projects_models.Project | None = None
     version: tools_models.ToolVersionWithTool | None = None
 
-    _validate_created_at = pydantic.field_validator("created_at")(
+    _validate_created_at = pydantic.field_serializer("created_at")(
         core_pydantic.datetime_serializer
     )
 

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -37,12 +37,12 @@ class GetSessionsResponse(pydantic.BaseModel):
     created_at: datetime.datetime
     owner: users_models.BaseUser
     state: str
-    guacamole_username: str | None
-    guacamole_connection_id: str | None
-    warnings: list[core_models.Message] | None
+    guacamole_username: str | None = None
+    guacamole_connection_id: str | None = None
+    warnings: list[core_models.Message] | None = None
     last_seen: str
-    project: projects_models.Project | None
-    version: tools_models.ToolVersionWithTool | None
+    project: projects_models.Project | None = None
+    version: tools_models.ToolVersionWithTool | None = None
 
     _validate_created_at = pydantic.validator("created_at", allow_reuse=True)(
         core_pydantic.datetime_serializer
@@ -50,8 +50,8 @@ class GetSessionsResponse(pydantic.BaseModel):
 
 
 class OwnSessionResponse(GetSessionsResponse):
-    t4c_password: str | None
-    jupyter_uri: str | None
+    t4c_password: str | None = None
+    jupyter_uri: str | None = None
 
 
 class PostReadonlySessionEntry(pydantic.BaseModel):

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -44,7 +44,7 @@ class GetSessionsResponse(pydantic.BaseModel):
     project: projects_models.Project | None = None
     version: tools_models.ToolVersionWithTool | None = None
 
-    _validate_created_at = pydantic.validator("created_at", allow_reuse=True)(
+    _validate_created_at = pydantic.field_validator("created_at")(
         core_pydantic.datetime_serializer
     )
 

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -156,7 +156,7 @@ def request_readonly_session(
         (
             entry,
             toolmodels_injectables.get_existing_capella_model(
-                entry.model_slug, project, db
+                entry.toolmodel_slug, project, db
             ),
         )
         for entry in body.models

--- a/backend/capellacollab/settings/integrations/purevariants/models.py
+++ b/backend/capellacollab/settings/integrations/purevariants/models.py
@@ -36,8 +36,8 @@ class DatabasePureVariantsLicenses(database.Base):
 class PureVariantsLicenses(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
-    license_server_url: str | None
-    license_key_filename: str | None
+    license_server_url: str | None = None
+    license_key_filename: str | None = None
 
     _validate_value = pydantic.validator(
         "license_server_url", allow_reuse=True

--- a/backend/capellacollab/settings/integrations/purevariants/models.py
+++ b/backend/capellacollab/settings/integrations/purevariants/models.py
@@ -34,12 +34,11 @@ class DatabasePureVariantsLicenses(database.Base):
 
 
 class PureVariantsLicenses(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     license_server_url: str | None
     license_key_filename: str | None
 
     _validate_value = pydantic.validator(
         "license_server_url", allow_reuse=True
     )(validate_license_url)
-
-    class Config:
-        orm_mode = True

--- a/backend/capellacollab/settings/integrations/purevariants/models.py
+++ b/backend/capellacollab/settings/integrations/purevariants/models.py
@@ -39,6 +39,6 @@ class PureVariantsLicenses(pydantic.BaseModel):
     license_server_url: str | None = None
     license_key_filename: str | None = None
 
-    _validate_value = pydantic.validator(
-        "license_server_url", allow_reuse=True
-    )(validate_license_url)
+    _validate_value = pydantic.field_validator("license_server_url")(
+        validate_license_url
+    )

--- a/backend/capellacollab/settings/modelsources/git/models.py
+++ b/backend/capellacollab/settings/modelsources/git/models.py
@@ -23,7 +23,7 @@ class PostGitInstance(pydantic.BaseModel):
     type: GitType
     name: str
     url: str
-    api_url: str | None
+    api_url: str | None = None
 
 
 class GitInstance(PostGitInstance):
@@ -46,7 +46,7 @@ class DatabaseGitInstance(database.Base):
 class GetRevisionsResponseModel(pydantic.BaseModel):
     branches: list[str]
     tags: list[str]
-    default: str | None
+    default: str | None = None
 
 
 class GitCredentials(pydantic.BaseModel):

--- a/backend/capellacollab/settings/modelsources/git/models.py
+++ b/backend/capellacollab/settings/modelsources/git/models.py
@@ -18,13 +18,12 @@ class GitType(enum.Enum):
 
 
 class PostGitInstance(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     type: GitType
     name: str
     url: str
     api_url: str | None
-
-    class Config:
-        orm_mode = True
 
 
 class GitInstance(PostGitInstance):

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -100,22 +100,12 @@ class T4CInstanceBase(pydantic.BaseModel):
     username: str
     protocol: Protocol
 
-    # validators
-    _validate_rest_api_url = pydantic.validator("rest_api", allow_reuse=True)(
+    _validate_rest_api_url = pydantic.field_validator("rest_api")(
         validate_rest_api_url
     )
-
-    _validate_port = pydantic.validator("port", allow_reuse=True)(
-        port_validator
-    )
-
-    _validate_cdo_port = pydantic.validator("cdo_port", allow_reuse=True)(
-        port_validator
-    )
-
-    _validate_http_port = pydantic.validator("http_port", allow_reuse=True)(
-        port_validator
-    )
+    _validate_port = pydantic.field_validator("port")(port_validator)
+    _validate_cdo_port = pydantic.field_validator("cdo_port")(port_validator)
+    _validate_http_port = pydantic.field_validator("http_port")(port_validator)
 
 
 class PatchT4CInstance(pydantic.BaseModel):
@@ -134,22 +124,12 @@ class PatchT4CInstance(pydantic.BaseModel):
     protocol: Protocol | None = None
     version_id: int | None = None
 
-    # validators
-    _validate_rest_api_url = pydantic.validator("rest_api", allow_reuse=True)(
+    _validate_rest_api_url = pydantic.field_validator("rest_api")(
         validate_rest_api_url
     )
-
-    _validate_port = pydantic.validator("port", allow_reuse=True)(
-        port_validator
-    )
-
-    _validate_cdo_port = pydantic.validator("cdo_port", allow_reuse=True)(
-        port_validator
-    )
-
-    _validate_http_port = pydantic.validator("http_port", allow_reuse=True)(
-        port_validator
-    )
+    _validate_port = pydantic.field_validator("port")(port_validator)
+    _validate_cdo_port = pydantic.field_validator("cdo_port")(port_validator)
+    _validate_http_port = pydantic.field_validator("http_port")(port_validator)
 
 
 class T4CInstanceComplete(T4CInstanceBase):

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -94,7 +94,7 @@ class T4CInstanceBase(pydantic.BaseModel):
     host: str
     port: int
     cdo_port: int
-    http_port: int | None
+    http_port: int | None = None
     usage_api: str
     rest_api: str
     username: str
@@ -121,18 +121,18 @@ class T4CInstanceBase(pydantic.BaseModel):
 class PatchT4CInstance(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
-    name: str | None
-    license: str | None
-    host: str | None
-    port: int | None
-    cdo_port: int | None
-    http_port: int | None
-    usage_api: str | None
-    rest_api: str | None
-    username: str | None
-    password: str | None
-    protocol: Protocol | None
-    version_id: int | None
+    name: str | None = None
+    license: str | None = None
+    host: str | None = None
+    port: int | None = None
+    cdo_port: int | None = None
+    http_port: int | None = None
+    usage_api: str | None = None
+    rest_api: str | None = None
+    username: str | None = None
+    password: str | None = None
+    protocol: Protocol | None = None
+    version_id: int | None = None
 
     # validators
     _validate_rest_api_url = pydantic.validator("rest_api", allow_reuse=True)(

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -88,6 +88,8 @@ def port_validator(value: int | None) -> int | None:
 
 
 class T4CInstanceBase(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     license: str
     host: str
     port: int
@@ -115,11 +117,10 @@ class T4CInstanceBase(pydantic.BaseModel):
         port_validator
     )
 
-    class Config:
-        orm_mode = True
-
 
 class PatchT4CInstance(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     name: str | None
     license: str | None
     host: str | None
@@ -149,9 +150,6 @@ class PatchT4CInstance(pydantic.BaseModel):
     _validate_http_port = pydantic.validator("http_port", allow_reuse=True)(
         port_validator
     )
-
-    class Config:
-        orm_mode = True
 
 
 class T4CInstanceComplete(T4CInstanceBase):

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -56,16 +56,14 @@ class T4CRepositoryStatus(str, enum.Enum):
 
 
 class T4CRepository(CreateT4CRepository):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     instance: t4c_models.T4CInstance
     status: T4CRepositoryStatus | None
 
-    class Config:
-        orm_mode = True
-
 
 class T4CInstanceWithRepositories(t4c_models.T4CInstance):
-    repositories: list[T4CRepository]
+    model_config = pydantic.ConfigDict(from_attributes=True)
 
-    class Config:
-        orm_mode = True
+    repositories: list[T4CRepository]

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -60,7 +60,7 @@ class T4CRepository(CreateT4CRepository):
 
     id: int
     instance: t4c_models.T4CInstance
-    status: T4CRepositoryStatus | None
+    status: T4CRepositoryStatus | None = None
 
 
 class T4CInstanceWithRepositories(t4c_models.T4CInstance):

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -35,7 +35,7 @@ def list_t4c_repositories(
         settings_t4c_injectables.get_existing_instance
     ),
 ) -> T4CRepositoriesResponseModel:
-    repositories = models.T4CInstanceWithRepositories.from_orm(
+    repositories = models.T4CInstanceWithRepositories.model_validate(
         instance
     ).repositories
 
@@ -83,7 +83,7 @@ def create_t4c_repository(
             },
         )
 
-    repo = models.T4CRepository.from_orm(
+    repo = models.T4CRepository.model_validate(
         crud.create_t4c_repository(
             db=db, repo_name=body.name, instance=instance
         )
@@ -237,7 +237,7 @@ def sync_db_with_server_repositories(
 
     server_not_db_repo_names = server_repos_names - db_repos_names
     for repo_name in server_not_db_repo_names:
-        repo = models.T4CRepository.from_orm(
+        repo = models.T4CRepository.model_validate(
             crud.create_t4c_repository(
                 db=db, repo_name=repo_name, instance=instance
             )

--- a/backend/capellacollab/settings/modelsources/t4c/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/routes.py
@@ -56,7 +56,7 @@ def create_t4c_instance(
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseT4CInstance:
     version = toolmodels_routes.get_version_by_id_or_raise(db, body.version_id)
-    instance = models.DatabaseT4CInstance(**body.dict())
+    instance = models.DatabaseT4CInstance(**body.model_dump())
     instance.version = version
     return crud.create_t4c_instance(db, instance)
 

--- a/backend/capellacollab/tools/integrations/models.py
+++ b/backend/capellacollab/tools/integrations/models.py
@@ -24,9 +24,9 @@ class ToolIntegrations(pydantic.BaseModel):
 
 
 class PatchToolIntegrations(pydantic.BaseModel):
-    t4c: bool | None
-    pure_variants: bool | None
-    jupyter: bool | None
+    t4c: bool | None = None
+    pure_variants: bool | None = None
+    jupyter: bool | None = None
 
 
 class DatabaseToolIntegrations(database.Base):

--- a/backend/capellacollab/tools/integrations/models.py
+++ b/backend/capellacollab/tools/integrations/models.py
@@ -16,12 +16,11 @@ if t.TYPE_CHECKING:
 
 
 class ToolIntegrations(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     t4c: bool
     pure_variants: bool
     jupyter: bool
-
-    class Config:
-        orm_mode = True
 
 
 class PatchToolIntegrations(pydantic.BaseModel):

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -81,17 +81,15 @@ class ToolBase(pydantic.BaseModel):
 class ToolDockerimage(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
-    persistent: str
-    readonly: str | None = None
-    backup: str | None = None
-
-    @classmethod
-    def from_orm(cls, obj: DatabaseTool) -> ToolDockerimage:
-        return ToolDockerimage(
-            persistent=obj.docker_image_template,
-            readonly=obj.readonly_docker_image_template,
-            backup=obj.docker_image_backup_template,
-        )
+    persistent: str = pydantic.Field(
+        ..., validation_alias="docker_image_template"
+    )
+    readonly: str | None = pydantic.Field(
+        None, validation_alias="readonly_docker_image_template"
+    )
+    backup: str | None = pydantic.Field(
+        None, validation_alias="docker_image_backup_template"
+    )
 
 
 class PatchToolDockerimage(pydantic.BaseModel):

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -82,8 +82,8 @@ class ToolDockerimage(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
     persistent: str
-    readonly: str | None
-    backup: str | None
+    readonly: str | None = None
+    backup: str | None = None
 
     @classmethod
     def from_orm(cls, obj: DatabaseTool) -> ToolDockerimage:
@@ -95,9 +95,9 @@ class ToolDockerimage(pydantic.BaseModel):
 
 
 class PatchToolDockerimage(pydantic.BaseModel):
-    persistent: str | None
-    readonly: str | None
-    backup: str | None
+    persistent: str | None = None
+    readonly: str | None = None
+    backup: str | None = None
 
 
 class CreateToolVersion(pydantic.BaseModel):
@@ -109,9 +109,9 @@ class CreateToolNature(pydantic.BaseModel):
 
 
 class UpdateToolVersion(pydantic.BaseModel):
-    name: str | None
-    is_recommended: bool | None
-    is_deprecated: bool | None
+    name: str | None = None
+    is_recommended: bool | None = None
+    is_deprecated: bool | None = None
 
 
 class ToolVersionBase(pydantic.BaseModel):

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -71,15 +71,16 @@ class DatabaseNature(database.Base):
 
 
 class ToolBase(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     name: str
     integrations: integrations_models.ToolIntegrations
 
-    class Config:
-        orm_mode = True
-
 
 class ToolDockerimage(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     persistent: str
     readonly: str | None
     backup: str | None
@@ -91,9 +92,6 @@ class ToolDockerimage(pydantic.BaseModel):
             readonly=obj.readonly_docker_image_template,
             backup=obj.docker_image_backup_template,
         )
-
-    class Config:
-        orm_mode = True
 
 
 class PatchToolDockerimage(pydantic.BaseModel):
@@ -117,13 +115,12 @@ class UpdateToolVersion(pydantic.BaseModel):
 
 
 class ToolVersionBase(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     name: str
     is_recommended: bool
     is_deprecated: bool
-
-    class Config:
-        orm_mode = True
 
 
 class ToolVersionWithTool(ToolVersionBase):
@@ -131,11 +128,10 @@ class ToolVersionWithTool(ToolVersionBase):
 
 
 class ToolNatureBase(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     id: int
     name: str
-
-    class Config:
-        orm_mode = True
 
 
 class CreateTool(pydantic.BaseModel):

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -37,11 +37,11 @@ class BaseHistoryEvent(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
     user: users_models.User
-    executor: users_models.User | None
-    project: projects_models.Project | None
+    executor: users_models.User | None = None
+    project: projects_models.Project | None = None
     execution_time: datetime.datetime
     event_type: EventType
-    reason: str | None
+    reason: str | None = None
 
     _validate_execution_time = pydantic.validator(
         "execution_time", allow_reuse=True
@@ -53,9 +53,9 @@ class HistoryEvent(BaseHistoryEvent):
 
 
 class UserHistory(users_models.User):
-    created: datetime.datetime | None
-    last_login: datetime.datetime | None
-    events: list[HistoryEvent] | None
+    created: datetime.datetime | None = None
+    last_login: datetime.datetime | None = None
+    events: list[HistoryEvent] | None = None
 
     _validate_created = pydantic.validator("created", allow_reuse=True)(
         core_pydantic.datetime_serializer

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -43,7 +43,7 @@ class BaseHistoryEvent(pydantic.BaseModel):
     event_type: EventType
     reason: str | None = None
 
-    _validate_execution_time = pydantic.field_validator("execution_time")(
+    _validate_execution_time = pydantic.field_serializer("execution_time")(
         core_pydantic.datetime_serializer
     )
 
@@ -57,10 +57,10 @@ class UserHistory(users_models.User):
     last_login: datetime.datetime | None = None
     events: list[HistoryEvent] | None = None
 
-    _validate_created = pydantic.field_validator("created")(
+    _validate_created = pydantic.field_serializer("created")(
         core_pydantic.datetime_serializer
     )
-    _validate_last_login = pydantic.field_validator("last_login")(
+    _validate_last_login = pydantic.field_serializer("last_login")(
         core_pydantic.datetime_serializer
     )
 

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -43,13 +43,13 @@ class BaseHistoryEvent(pydantic.BaseModel):
     event_type: EventType
     reason: str | None = None
 
-    _validate_execution_time = pydantic.validator(
-        "execution_time", allow_reuse=True
-    )(core_pydantic.datetime_serializer)
+    _validate_execution_time = pydantic.field_validator("execution_time")(
+        core_pydantic.datetime_serializer
+    )
 
 
 class HistoryEvent(BaseHistoryEvent):
-    id: str
+    id: int
 
 
 class UserHistory(users_models.User):
@@ -57,10 +57,10 @@ class UserHistory(users_models.User):
     last_login: datetime.datetime | None = None
     events: list[HistoryEvent] | None = None
 
-    _validate_created = pydantic.validator("created", allow_reuse=True)(
+    _validate_created = pydantic.field_validator("created")(
         core_pydantic.datetime_serializer
     )
-    _validate_last_login = pydantic.validator("last_login", allow_reuse=True)(
+    _validate_last_login = pydantic.field_validator("last_login")(
         core_pydantic.datetime_serializer
     )
 

--- a/backend/capellacollab/users/events/models.py
+++ b/backend/capellacollab/users/events/models.py
@@ -34,6 +34,8 @@ class EventType(enum.Enum):
 
 
 class BaseHistoryEvent(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     user: users_models.User
     executor: users_models.User | None
     project: projects_models.Project | None
@@ -44,9 +46,6 @@ class BaseHistoryEvent(pydantic.BaseModel):
     _validate_execution_time = pydantic.validator(
         "execution_time", allow_reuse=True
     )(core_pydantic.datetime_serializer)
-
-    class Config:
-        orm_mode = True
 
 
 class HistoryEvent(BaseHistoryEvent):

--- a/backend/capellacollab/users/models.py
+++ b/backend/capellacollab/users/models.py
@@ -24,11 +24,10 @@ class Role(enum.Enum):
 
 
 class BaseUser(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(from_attributes=True)
+
     name: str
     role: Role
-
-    class Config:
-        orm_mode = True
 
 
 class User(BaseUser):

--- a/backend/capellacollab/users/models.py
+++ b/backend/capellacollab/users/models.py
@@ -31,7 +31,7 @@ class BaseUser(pydantic.BaseModel):
 
 
 class User(BaseUser):
-    id: str
+    id: int
 
 
 class PatchUserRoleRequest(pydantic.BaseModel):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,11 +27,11 @@ dependencies = [
   "alembic==1.10.4",
   "appdirs",
   "cachetools",
-  "fastapi<0.100.0",
+  "fastapi>=0.101.0",
   "kubernetes",
   "msal",
   "psycopg2-binary",
-  "pydantic",
+  "pydantic>=2.0.0",
   "python-dateutil",
   "python-jose",
   "python-multipart",
@@ -42,8 +42,8 @@ dependencies = [
   "jsonschema",
   "openshift",
   "starlette-prometheus",
-  "fastapi-pagination",
-  "aiohttp"
+  "fastapi-pagination>=0.12.5",
+  "aiohttp",
 ]
 
 [project.urls]
@@ -63,7 +63,7 @@ dev = [
   "responses",
   "sqlalchemy[mypy]",
   "pytest-cov",
-  "aioresponses"
+  "aioresponses",
 ]
 
 [project.entry-points."capellacollab.authentication.providers"]


### PR DESCRIPTION
This PR migrates to pydantic v2. As it has to deal with the validators it also includes a small fix where the `datetime_serializer` failed due to a None value passed to it.
However, currently there are still two **warnings** open for the pydantic migrations

1. UserWarning: Field "model_slug" has conflict with protected namespace "model_"
2. UserWarning: Field "model_badge_status" has conflict with protected namespace "model_"

The reason for this is that the pydantic configuration now works via `model_...` fields and the two fields above obviously are conflicting with the protected namespace. There are three solutions to this problem:

1. Apply the suggestions: `model_config = pydantic.ConfigDict(protected_namespaces=())
`. However, I am not quite sure what would then happen if we have an actual conflict (i.e., whether we would still get an error in this case)
2. Just keep the warning as it is (don't think that this is a good idea but still wanted to put it here)
3. Rename the fields (Since it currently only affects to fields the effort of renaming them is not as big. However, especially for the `model_slug` field, I am not sure what name to choose.

@MoritzWeber0 What are your ideas on the open problem here?

Resolve: #833 #953 