### PR TITLE
fix: Add asterisc to entry point when editiing the model sources

### DIFF
--- a/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.component.ts
+++ b/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.component.ts
@@ -146,9 +146,10 @@ export class ManageGitModelComponent implements OnInit, OnDestroy {
       .subscribe((model) => {
         this.modelSlug = model.slug;
         if (model.tool.name === 'Capella') {
-          this.form.controls.entrypoint.addValidators(
-            Validators.pattern(/^$|\.aird$/)
-          );
+          this.form.controls.entrypoint.addValidators([
+            Validators.pattern(/^$|\.aird$/),
+            Validators.required,
+          ]);
         }
       });
 


### PR DESCRIPTION
Apparently the entrypoint field is not a required field in the strict sense since it has two error messages attached. Nevertheless, it confused me that it seems not to be required while at the same time throwing an error when being left empty.