### PR TITLE
feat: Redesign NavBar and Breadcrumbs

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -51,16 +51,16 @@ const routes: Routes = [
       {
         path: '',
         component: SessionsComponent,
-        data: { breadcrumb: 'sessions' },
+        data: { breadcrumb: 'Sessions' },
       },
       {
         path: 'session',
         component: SessionComponent,
-        data: { breadcrumb: 'session' },
+        data: { breadcrumb: 'Session Viewer' },
       },
       {
         path: 'projects',
-        data: { breadcrumb: 'projects' },
+        data: { breadcrumb: 'Projects' },
         children: [
           {
             path: '',
@@ -69,14 +69,14 @@ const routes: Routes = [
           },
           {
             path: 'create',
-            data: { breadcrumb: 'create' },
+            data: { breadcrumb: 'Create Project' },
             component: CreateProjectComponent,
           },
         ],
       },
       {
         path: 'project',
-        data: { breadcrumb: 'projects', redirect: '/projects' },
+        data: { breadcrumb: 'Projects', redirect: '/projects' },
         children: [
           {
             path: ':project',
@@ -88,16 +88,13 @@ const routes: Routes = [
             children: [
               {
                 path: '',
-                data: {
-                  breadcrumb: 'overview',
-                  redirect: (data: Data) => `/project/${data.project?.slug}`,
-                },
+                data: { breadcrumb: undefined },
                 component: ProjectDetailsComponent,
               },
               {
                 path: 'metadata',
                 data: {
-                  breadcrumb: 'metadata',
+                  breadcrumb: 'Configure Project',
                   redirect: (data: Data) =>
                     `/project/${data.project?.slug}/metadata`,
                 },
@@ -105,36 +102,31 @@ const routes: Routes = [
               },
               {
                 path: 'models',
-                data: { breadcrumb: 'models' },
                 children: [
                   {
                     path: 'create',
-                    data: { breadcrumb: 'create' },
+                    data: { breadcrumb: 'Create Model' },
                     component: CreateModelComponent,
                   },
                 ],
               },
               {
                 path: 'model',
-                data: {
-                  breadcrumb: 'models',
-                  redirect: (data: Data) => `/project/${data.project?.slug}`,
-                },
                 children: [
                   {
                     path: ':model',
-                    component: ModelWrapperComponent,
                     data: {
-                      breadcrumb: (data: Data) => data.model?.name,
+                      breadcrumb: (data: Data) => data.model?.slug,
                       redirect: (data: Data) =>
                         `/project/${data.project?.slug}`,
                     },
+                    component: ModelWrapperComponent,
 
                     children: [
                       {
                         path: 'modelsources',
                         data: {
-                          breadcrumb: 'model sources',
+                          breadcrumb: 'Model Sources',
                           redirect: (data: Data) =>
                             `/project/${data.project?.slug}/model/${data.model?.slug}/modelsources`,
                         },
@@ -142,20 +134,28 @@ const routes: Routes = [
                       },
                       {
                         path: 'metadata',
-                        data: { breadcrumb: 'metadata' },
+                        data: {
+                          breadcrumb: 'Configure Model',
+                          redirect: (data: Data) =>
+                            `/project/${data.project?.slug}/model/${data.model?.slug}/metadata`,
+                        },
                         component: ModelDescriptionComponent,
                       },
                       {
                         path: 'restrictions',
-                        data: { breadcrumb: 'restrictions' },
+                        data: {
+                          breadcrumb: 'Restrictions',
+                          redirect: (data: Data) =>
+                            `/project/${data.project?.slug}/model/${data.model?.slug}/restrictions`,
+                        },
                         component: ModelRestrictionsComponent,
                       },
                       {
                         path: 'pipeline',
                         data: {
-                          breadcrumb: 'pipelines',
+                          breadcrumb: 'Pipelines',
                           redirect: (data: Data) =>
-                            `/project/${data.project?.slug}`,
+                            `/project/${data.project?.slug}/model/${data.model?.slug}/pipeline/${data.pipeline?.id}/runs`,
                         },
                         children: [
                           {
@@ -208,14 +208,18 @@ const routes: Routes = [
                       {
                         path: 'git-model',
                         data: {
-                          breadcrumb: 'git models',
+                          breadcrumb: 'Model Sources',
                           redirect: (data: Data) =>
-                            `/project/${data.project?.slug}/model/${data.model?.slug}`,
+                            `/project/${data.project?.slug}/model/${data.model?.slug}/modelsources`,
                         },
                         children: [
                           {
                             path: 'create',
-                            data: { breadcrumb: 'create' },
+                            data: {
+                              breadcrumb: 'Create Git Model',
+                              redirect: (data: Data) =>
+                                `/project/${data.project?.slug}/model/${data.model?.slug}/git-model/create`,
+                            },
                             component: ManageGitModelComponent,
                           },
                           {
@@ -223,6 +227,10 @@ const routes: Routes = [
                             data: {
                               breadcrumb: (data: Data) =>
                                 data.gitModel?.id || '...',
+                              redirect: (data: Data) =>
+                                data.gitModel?.id
+                                  ? `/project/${data.project?.slug}/model/${data.model?.slug}/git-model/${data.gitModel?.id}`
+                                  : undefined,
                             },
                             component: ManageGitModelComponent,
                           },
@@ -231,14 +239,18 @@ const routes: Routes = [
                       {
                         path: 't4c-model',
                         data: {
-                          breadcrumb: 't4c models',
+                          breadcrumb: 'Model Sources',
                           redirect: (data: Data) =>
-                            `/project/${data.project?.slug}/model/${data.model?.slug}`,
+                            `/project/${data.project?.slug}/model/${data.model?.slug}/modelsources`,
                         },
                         children: [
                           {
                             path: 'create',
-                            data: { breadcrumb: 'create' },
+                            data: {
+                              breadcrumb: 'Create T4C Model',
+                              redirect: (data: Data) =>
+                                `/project/${data.project?.slug}/model/${data.model?.slug}/t4c-model/create`,
+                            },
                             component: ManageT4CModelComponent,
                           },
                           {
@@ -246,14 +258,15 @@ const routes: Routes = [
                             data: {
                               breadcrumb: (data: Data) =>
                                 data.t4cModel?.id || '...',
+                              redirect: (data: Data) =>
+                                data.t4cModel?.id
+                                  ? `/project/${data.project?.slug}/model/${data.model?.slug}/t4c-model/${data.t4cModel?.id}`
+                                  : undefined,
                             },
                             component: T4CModelWrapperComponent,
                             children: [
                               {
                                 path: '',
-                                data: {
-                                  breadcrumb: () => 'edit',
-                                },
                                 component: ManageT4CModelComponent,
                               },
                             ],
@@ -270,7 +283,6 @@ const routes: Routes = [
       },
       {
         path: 'sessions',
-        data: { breadcrumb: 'sessions' },
         children: [
           {
             path: '',
@@ -278,14 +290,14 @@ const routes: Routes = [
           },
           {
             path: 'overview',
-            data: { breadcrumb: 'overview' },
+            data: { breadcrumb: 'Session Overview' },
             component: SessionOverviewComponent,
           },
         ],
       },
       {
         path: 'settings',
-        data: { breadcrumb: 'settings' },
+        data: { breadcrumb: 'Settings' },
         children: [
           {
             path: '',
@@ -298,22 +310,22 @@ const routes: Routes = [
             children: [
               {
                 path: 'users',
-                data: { breadcrumb: 'users' },
+                data: { breadcrumb: 'Users' },
                 component: UserSettingsComponent,
               },
               {
                 path: 'alerts',
-                data: { breadcrumb: 'alerts' },
+                data: { breadcrumb: 'Alerts' },
                 component: AlertSettingsComponent,
               },
               {
                 path: 'pipelines',
-                data: { breadcrumb: 'pipelines' },
+                data: { breadcrumb: 'Pipelines' },
                 component: PipelinesOverviewComponent,
               },
               {
                 path: 'tools',
-                data: { breadcrumb: 'tools' },
+                data: { breadcrumb: 'Tools' },
                 children: [
                   {
                     path: '',
@@ -322,18 +334,24 @@ const routes: Routes = [
                   },
                   {
                     path: 'create',
-                    data: { breadcrumb: 'create' },
+                    data: { breadcrumb: 'Create Tool' },
                     component: ToolDetailsComponent,
                   },
                 ],
               },
               {
                 path: 'tool/:toolID',
-                data: { breadcrumb: 'tool', redirect: '/settings/core/tools' },
+                data: { breadcrumb: 'Tools', redirect: '/settings/core/tools' },
                 children: [
                   {
                     path: '',
-                    data: { breadcrumb: (data: Data) => data.tool?.name },
+                    data: {
+                      breadcrumb: (data: Data) => data.tool?.name || '...',
+                      redirect: (data: Data) =>
+                        data.tool?.id
+                          ? `/settings/core/tools/${data.tool?.id}`
+                          : undefined,
+                    },
                     component: ToolDetailsComponent,
                   },
                 ],
@@ -346,7 +364,7 @@ const routes: Routes = [
             children: [
               {
                 path: 'git',
-                data: { breadcrumb: 'git' },
+                data: { breadcrumb: 'Git Instances' },
                 children: [
                   {
                     path: '',
@@ -364,7 +382,7 @@ const routes: Routes = [
               },
               {
                 path: 't4c',
-                data: { breadcrumb: 'T4C' },
+                data: { breadcrumb: 'T4C Instances' },
                 children: [
                   {
                     path: '',
@@ -402,7 +420,7 @@ const routes: Routes = [
       },
       {
         path: 'events',
-        data: { breadcrumb: 'events' },
+        data: { breadcrumb: 'Events' },
         component: EventsComponent,
       },
     ],

--- a/frontend/src/app/general/breadcrumbs/breadcrumbs.component.html
+++ b/frontend/src/app/general/breadcrumbs/breadcrumbs.component.html
@@ -3,7 +3,8 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<ul>
+<ul class="break-all">
+  /
   <li *ngFor="let breadcrumb of breadcrumbService.breadcrumbs | async">
     <a class="rounded-lg hover:bg-zinc-300 p-1" [routerLink]="breadcrumb.url">{{
       breadcrumb.label

--- a/frontend/src/app/general/breadcrumbs/breadcrumbs.component.html
+++ b/frontend/src/app/general/breadcrumbs/breadcrumbs.component.html
@@ -5,6 +5,8 @@
 
 <ul>
   <li *ngFor="let breadcrumb of breadcrumbService.breadcrumbs | async">
-    <a [routerLink]="breadcrumb.url">{{ breadcrumb.label }}</a>
+    <a class="rounded-lg hover:bg-zinc-300 p-1" [routerLink]="breadcrumb.url">{{
+      breadcrumb.label
+    }}</a>
   </li>
 </ul>

--- a/frontend/src/app/general/header/header.component.css
+++ b/frontend/src/app/general/header/header.component.css
@@ -3,40 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#toolbar {
-  display: flex;
-  background-color: #f5f5f5;
-  justify-content: space-between;
-  align-items: center;
-  min-height: 65px;
-}
-
-#title {
-  margin-left: 20px;
-  user-select: none;
-}
-
-#maintitle {
-  font-size: 1em;
-}
-
-#subtitle {
-  font-size: 1.5em;
-}
-
-.breadcrumbs {
-  margin-left: 20px;
-}
-
-#profile {
-  margin-left: 20px;
-  margin-right: 15px;
-}
-
-.right-aligned {
-  display: flex;
-  align-items: center;
-}
 ::ng-deep.mat-menu-panel {
   overflow: hidden !important;
 }

--- a/frontend/src/app/general/header/header.component.html
+++ b/frontend/src/app/general/header/header.component.html
@@ -87,7 +87,7 @@
     </div>
   </div>
 
-  <div class="primaryText ml-5 select-none text-base">
+  <div class="primaryText ml-5 pb-2 select-none text-base">
     <app-breadcrumbs></app-breadcrumbs>
   </div>
 </div>

--- a/frontend/src/app/general/header/header.component.html
+++ b/frontend/src/app/general/header/header.component.html
@@ -3,83 +3,91 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div id="toolbar">
-  <div class="xl:hidden">
-    <button
-      mat-icon-button
-      color="primary"
-      (click)="navBarService.toggle()"
-      aria-label="Toggle navigation menu"
-    >
-      <mat-icon>menu</mat-icon>
-    </button>
-  </div>
-  <div class="primaryText" id="title">
-    <div id="maintitle">Capella Collaboration Manager</div>
-    <div id="subtitle"><app-breadcrumbs></app-breadcrumbs></div>
-  </div>
-  <div class="hidden gap-2 xl:flex">
-    <div
-      *ngFor="let item of navBarService.navBarItems"
-      [routerLink]="item.routerLink"
-    >
-      <a
-        mat-raised-button
+<div class="bg-zinc-100">
+  <div class="flex justify-between items-center min-h-[65px]">
+    <div class="xl:hidden">
+      <button
+        mat-icon-button
         color="primary"
-        *ngIf="userService.validateUserRole(item.requiredRole)"
-        [attr.href]="item.href"
-        [attr.target]="item.target"
+        (click)="navBarService.toggle()"
+        aria-label="Toggle navigation menu"
       >
-        {{ item.name }} <mat-icon *ngIf="item.icon">{{ item.icon }}</mat-icon>
-      </a>
+        <mat-icon>menu</mat-icon>
+      </button>
     </div>
-  </div>
-  <div>
-    <div class="hidden xl:flex xl:right-aligned gap-2">
-      <div>
+
+    <div class="primaryText ml-5 select-none text-2xl">
+      Capella Collaboration Manager
+    </div>
+
+    <div class="hidden gap-2 xl:flex">
+      <div
+        *ngFor="let item of navBarService.navBarItems"
+        [routerLink]="item.routerLink"
+      >
         <a
           mat-raised-button
           color="primary"
-          href="https://github.com/DSD-DBS/capella-collab-manager/issues"
-          target="_blank"
-          >Open Issue on Github <mat-icon>open_in_new</mat-icon>
+          *ngIf="userService.validateUserRole(item.requiredRole)"
+          [attr.href]="item.href"
+          [attr.target]="item.target"
+        >
+          {{ item.name }} <mat-icon *ngIf="item.icon">{{ item.icon }}</mat-icon>
         </a>
       </div>
-      <mat-menu #profileMenu="matMenu">
-        <a
-          *ngIf="userService.user?.role === 'administrator'"
-          class="profileMenuButton"
-          mat-menu-item
-          routerLink="settings"
-        >
-          Settings <mat-icon>settings</mat-icon>
-        </a>
-        <a
-          *ngIf="userService.user?.role === 'administrator'"
-          class="profileMenuButton"
-          mat-menu-item
-          routerLink="events"
-        >
-          Events <mat-icon>event_note</mat-icon>
-        </a>
-        <a
-          class="profileMenuButton"
-          mat-menu-item
-          routerLink="logout/redirect"
-          [queryParams]="{ reason: 'logout' }"
-          *ngIf="authService.isLoggedIn()"
-        >
-          Log out <mat-icon>logout</mat-icon>
-        </a>
-      </mat-menu>
-      <button
-        color="primary"
-        id="profile"
-        mat-raised-button
-        [matMenuTriggerFor]="profileMenu"
-      >
-        Profile <mat-icon>account_circle</mat-icon>
-      </button>
     </div>
+    <div>
+      <div class="hidden xl:flex xl:right-aligned gap-2">
+        <div>
+          <a
+            mat-raised-button
+            color="primary"
+            href="https://github.com/DSD-DBS/capella-collab-manager/issues"
+            target="_blank"
+            >Open Issue on Github <mat-icon>open_in_new</mat-icon>
+          </a>
+        </div>
+        <mat-menu #profileMenu="matMenu">
+          <a
+            *ngIf="userService.user?.role === 'administrator'"
+            class="profileMenuButton"
+            mat-menu-item
+            routerLink="settings"
+          >
+            Settings <mat-icon>settings</mat-icon>
+          </a>
+          <a
+            *ngIf="userService.user?.role === 'administrator'"
+            class="profileMenuButton"
+            mat-menu-item
+            routerLink="events"
+          >
+            Events <mat-icon>event_note</mat-icon>
+          </a>
+          <a
+            class="profileMenuButton"
+            mat-menu-item
+            routerLink="logout/redirect"
+            [queryParams]="{ reason: 'logout' }"
+            *ngIf="authService.isLoggedIn()"
+          >
+            Log out <mat-icon>logout</mat-icon>
+          </a>
+        </mat-menu>
+
+        <button
+          class="!ml-5 !mr-5"
+          color="primary"
+          mat-raised-button
+          [matMenuTriggerFor]="profileMenu"
+        >
+          Profile <mat-icon>account_circle</mat-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="primaryText ml-5 select-none text-base">
+    <app-breadcrumbs></app-breadcrumbs>
   </div>
 </div>

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
@@ -7,7 +7,7 @@
   <h2 id="title">Project information</h2>
   <mat-card class="!flex flex-col grow justify-between">
     <div class="flex flex-col">
-      <div *ngIf="projectService.project$ | async">
+      <div class="break-all" *ngIf="projectService.project$ | async">
         <h2 id="title">{{ (projectService.project$ | async)!.name }}</h2>
       </div>
       <div *ngIf="(projectService.project$ | async) === undefined">


### PR DESCRIPTION
This PR mainly moves the breadcrumbs into a separate row below the main NavBar and makes them smaller. This has the advantage that even long breadcrumbs (e.g., long model names) will be displayed correctly. In addition, the breadcrumbs now also have a proper hover visualisation and some broken redirects were fixed. Lastly, just a few unnecessary breadcrumbs where removed (e.g., `projects / overview` -> `Projects`) and some breadcrumb names were adjusted.

Resolves #784