### PR TITLE
feat: Conditional display of skip or continue during user creation in the project creation

### DIFF
--- a/frontend/src/app/projects/create-project/create-project.component.html
+++ b/frontend/src/app/projects/create-project/create-project.component.html
@@ -101,7 +101,13 @@
                 (click)="stepper.next()"
                 data-testId="button-skipAddMembers"
               >
-                Skip
+                <ng-container
+                  *ngIf="
+                    projectUserService.nonAdminProjectUsers$ | async as users
+                  "
+                >
+                  {{ !users || users.length === 0 ? "skip" : "continue" }}
+                </ng-container>
                 <mat-icon class="mat-icon-position right"
                   >arrow_forward</mat-icon
                 >

--- a/frontend/src/app/projects/create-project/create-project.component.spec.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.spec.ts
@@ -36,6 +36,7 @@ import {
   ProjectVisibility,
 } from '../service/project.service';
 import { CreateProjectComponent } from './create-project.component';
+import { ProjectUserService } from '../project-detail/project-users/service/project-user.service';
 
 const mockProjects: Project[] = [
   {
@@ -61,6 +62,17 @@ describe('CreateProjectComponent', () => {
 
   const fakeToastService: Pick<ToastService, 'showSuccess'> = {
     showSuccess(): void {},
+  };
+
+  const fakeProjectUserService = {
+    get nonAdminProjectUsers$(): Observable<any> {
+      return of(undefined);
+    },
+
+    resetProjectUserOnProjectReset(): void {},
+    resetProjectUsersOnProjectReset(): void {},
+    loadProjectUsersOnProjectChange(): void {},
+    loadProjectUserOnProjectChange(): void {},
   };
 
   const fakeProjectService = {
@@ -121,6 +133,7 @@ describe('CreateProjectComponent', () => {
       providers: [
         { provide: ProjectService, useValue: fakeProjectService },
         { provide: ToastService, useValue: fakeToastService },
+        { provide: ProjectUserService, useValue: fakeProjectUserService },
         { provide: Location, useClass: SpyLocation },
       ],
       declarations: [CreateProjectComponent],

--- a/frontend/src/app/projects/create-project/create-project.component.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.ts
@@ -11,6 +11,7 @@ import {
   CreateModelStep,
 } from 'src/app/projects/models/create-model/create-model.component';
 import { ToastService } from '../../helpers/toast/toast.service';
+import { ProjectUserService } from '../project-detail/project-users/service/project-user.service';
 import { ProjectService, ProjectVisibility } from '../service/project.service';
 
 @Component({
@@ -25,6 +26,7 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
 
   constructor(
     public projectService: ProjectService,
+    public projectUserService: ProjectUserService,
     private toastService: ToastService
   ) {}
 

--- a/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
+++ b/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
@@ -10,6 +10,7 @@ import {
   Observable,
   combineLatest,
   filter,
+  map,
   switchMap,
   tap,
 } from 'rxjs';
@@ -45,6 +46,16 @@ export class ProjectUserService {
     undefined
   );
   public readonly projectUsers$ = this._projectUsers.asObservable();
+
+  public readonly nonAdminProjectUsers$ = this._projectUsers
+    .asObservable()
+    .pipe(
+      map((projectUsers) =>
+        projectUsers?.filter(
+          (projectUser) => projectUser.role !== 'administrator'
+        )
+      )
+    );
 
   resetProjectUserOnProjectReset() {
     this.projectService.project$


### PR DESCRIPTION
This adjusts the second step of the project creation. Up to now, there was always the "skip" button shown even if a user was added. As this is quite misleading this PR changes it such that the button states "continue" if at least one user was added.

Resolves: #632 