### PR TITLE
build: Add threshold to codecoverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: CC0-1.0
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%


### PR DESCRIPTION
I talked with @MoritzWeber0 about it that sometimes you only want to refactor and the coverage drops and failes so it might make sense to introduce a threshold.
Unfortunately the codecov action does not implement that at the moment which is why a yml for codecov then is needed where the coverage is quite deeply nested (also see [this](https://github.com/codecov/codecov-action/issues/554) codecov action issue)

Maybe we need to talk about the hight of the threshold