### PR TITLE
feat: Add possibilities to archive t4c instances

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -39,6 +39,9 @@ from capellacollab.projects.toolmodels.modelsources.git.handler import (
 from capellacollab.routes import router
 from capellacollab.sessions import exceptions as sessions_exceptions
 from capellacollab.sessions import idletimeout, operators
+from capellacollab.settings.modelsources.t4c import (
+    exceptions as settings_t4c_exceptions,
+)
 from capellacollab.tools import exceptions as tools_exceptions
 from capellacollab.users import exceptions as users_exceptions
 
@@ -145,6 +148,7 @@ def register_exceptions():
     core_exceptions.register_exceptions(app)
     users_exceptions.register_exceptions(app)
     sessions_exceptions.register_exceptions(app)
+    settings_t4c_exceptions.register_exceptions(app)
 
 
 register_exceptions()

--- a/backend/capellacollab/alembic/versions/f7bf9456cfc9_add_archive_flag.py
+++ b/backend/capellacollab/alembic/versions/f7bf9456cfc9_add_archive_flag.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add archive flag
+
+Revision ID: f7bf9456cfc9
+Revises: 1a4208c18909
+Create Date: 2023-08-28 08:57:22.931913
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f7bf9456cfc9"
+down_revision = "1a4208c18909"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "t4c_instances", sa.Column("is_archived", sa.Boolean(), nullable=True)
+    )
+
+    op.get_bind().execute(
+        sa.text("UPDATE t4c_instances SET is_archived=false")
+    )
+
+    op.alter_column(
+        "t4c_instances",
+        "is_archived",
+        existing_type=sa.BOOLEAN(),
+        nullable=False,
+    )

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
@@ -79,7 +79,7 @@ def create_t4c_model(
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ):
-    instance = settings_t4c_injecatbles.get_existing_instance(
+    instance = settings_t4c_injecatbles.get_existing_unarchived_instance(
         body.t4c_instance_id, db
     )
     repository = (

--- a/backend/capellacollab/settings/modelsources/t4c/exceptions.py
+++ b/backend/capellacollab/settings/modelsources/t4c/exceptions.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import fastapi
+from fastapi import exception_handlers, status
+
+
+class T4CInstanceIsArchivedError(Exception):
+    def __init__(self, t4c_instance_id: int):
+        self.t4c_instance_id = t4c_instance_id
+
+
+async def t4c_instance_is_archived_exception_handler(
+    request: fastapi.Request, exc: T4CInstanceIsArchivedError
+) -> fastapi.Response:
+    return await exception_handlers.http_exception_handler(
+        request,
+        fastapi.HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "reason": f"The T4C instance identified by {exc.t4c_instance_id} is archived, thus prohibiting the execution of the requested operation."
+            },
+        ),
+    )
+
+
+def register_exceptions(app: fastapi.FastAPI):
+    app.add_exception_handler(
+        T4CInstanceIsArchivedError, t4c_instance_is_archived_exception_handler
+    )

--- a/backend/capellacollab/settings/modelsources/t4c/injectables.py
+++ b/backend/capellacollab/settings/modelsources/t4c/injectables.py
@@ -7,7 +7,7 @@ from sqlalchemy import orm
 
 from capellacollab.core import database
 
-from . import crud, models
+from . import crud, exceptions, models
 
 
 def get_existing_instance(
@@ -22,3 +22,13 @@ def get_existing_instance(
             "reason": f"The t4c instance with the id {t4c_instance_id} does not exist.",
         },
     )
+
+
+def get_existing_unarchived_instance(
+    t4c_instance_id: int, db: orm.Session = fastapi.Depends(database.get_db)
+):
+    t4c_instance = get_existing_instance(t4c_instance_id, db)
+    if t4c_instance.is_archived:
+        raise exceptions.T4CInstanceIsArchivedError(t4c_instance.id)
+
+    return t4c_instance

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -79,6 +79,8 @@ class DatabaseT4CInstance(database.Base):
         back_populates="instance", cascade="all, delete"
     )
 
+    is_archived: orm.Mapped[bool] = orm.mapped_column(default=False)
+
 
 def port_validator(value: int | None) -> int | None:
     if not value:
@@ -123,6 +125,7 @@ class PatchT4CInstance(pydantic.BaseModel):
     password: str | None = None
     protocol: Protocol | None = None
     version_id: int | None = None
+    is_archived: bool | None = None
 
     _validate_rest_api_url = pydantic.field_validator("rest_api")(
         validate_rest_api_url
@@ -138,9 +141,11 @@ class T4CInstanceComplete(T4CInstanceBase):
 
 
 class CreateT4CInstance(T4CInstanceComplete):
+    is_archived: bool | None = None
     password: str
 
 
 class T4CInstance(T4CInstanceComplete):
     id: int
     version: tools_models.ToolVersionBase
+    is_archived: bool

--- a/backend/capellacollab/settings/modelsources/t4c/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/routes.py
@@ -15,7 +15,7 @@ from capellacollab.settings.modelsources.t4c.repositories import (
 )
 from capellacollab.users import models as users_models
 
-from . import crud, injectables, interface, models
+from . import crud, exceptions, injectables, interface, models
 
 router = fastapi.APIRouter(
     dependencies=[
@@ -72,6 +72,9 @@ def edit_t4c_instance(
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseT4CInstance:
+    if instance.is_archived and (body.is_archived is None or body.is_archived):
+        raise exceptions.T4CInstanceIsArchivedError(instance.id)
+
     return crud.update_t4c_instance(db, instance, body)
 
 

--- a/backend/tests/settings/conftest.py
+++ b/backend/tests/settings/conftest.py
@@ -25,8 +25,8 @@ def fixture_admin_user(
     return users_crud.create_user(db, executor_name, users_models.Role.ADMIN)
 
 
-@pytest.fixture(name="t4c_server")
-def fixture_t4c_server(
+@pytest.fixture(name="t4c_instance")
+def fixture_t4c_instance(
     db: orm.Session,
     test_tool_version: tools_models.DatabaseVersion,
 ) -> t4c_models.DatabaseT4CInstance:

--- a/backend/tests/settings/test_t4c_repositories.py
+++ b/backend/tests/settings/test_t4c_repositories.py
@@ -23,7 +23,7 @@ from capellacollab.users import models as users_models
 def test_list_t4c_repositories(
     client: testclient.TestClient,
     db: orm.Session,
-    t4c_server: t4c_models.DatabaseT4CInstance,
+    t4c_instance: t4c_models.DatabaseT4CInstance,
 ):
     responses.get(
         "http://localhost:8080/api/v1.0/repositories",
@@ -41,10 +41,10 @@ def test_list_t4c_repositories(
         },
     )
 
-    t4c_repositories_crud.create_t4c_repository(db, "test4", t4c_server)
-    t4c_repositories_crud.create_t4c_repository(db, "test5", t4c_server)
+    t4c_repositories_crud.create_t4c_repository(db, "test4", t4c_instance)
+    t4c_repositories_crud.create_t4c_repository(db, "test5", t4c_instance)
     response = client.get(
-        f"/api/v1/settings/modelsources/t4c/{t4c_server.id}/repositories",
+        f"/api/v1/settings/modelsources/t4c/{t4c_instance.id}/repositories",
     )
 
     assert response.status_code == 200

--- a/docs/user/docs/settings/model-sources/t4c.md
+++ b/docs/user/docs/settings/model-sources/t4c.md
@@ -1,0 +1,40 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+# Manage T4C instances
+
+## Define a T4C instance
+
+1.  Please navigate to `Profile` > `Settings`
+1.  Select `T4C` bewlow `Model sources`
+1.  You can see all existing instances (if any). To add a new instance, click
+    on the "Add an instance" card. You have to enter the following information:
+    <!-- prettier-ignore -->
+    1. **Name**: Any name to identify the instance
+    1. **Capella version**: Capella version that corresponds to the instance
+    1. **License configuration**: License key of your license server
+    1. **Protocol**: Protocol that should be used to communicate between
+    capella sessions and the T4C server
+    1. **Host**: Hostname of the T4C server
+    1. **Port**, **CDO Port**, and **HTTP Port** Corresponding ports of your server
+    1. **License server API**: License server API url
+    1. **REST API**: REST API URL of the T4C server
+    1. **Username**: Username with access to the REST API, required for communication
+    with the REST API
+    1. **Password**: Password corresponding to username
+
+## Archive a T4C instance
+
+1.  Please navigate to `Profile` > `Settings`
+1.  Select `T4C` bewlow `Model sources`
+1.  Click on the instance that you want to archive
+1.  Click on the `Archive` button. When everything worked you should see a
+    messages stating "Instance updated: The instance _name_ is now archived"
+
+An archived instance can no longer be selected when creating a new T4C model
+and is highlighted with a gray background and an `Archived` tag in the bottom
+right in the T4C instance overview. Existing linked T4C models and all
+repositories corresponding to the archived instance will continue to work as
+before.

--- a/docs/user/mkdocs.yml
+++ b/docs/user/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
           - pure::variants: settings/tools/pure_variants.md
       - Model sources:
           - Git: settings/model-sources/git.md
+          - T4C: settings/model-sources/t4c.md
       - Alerts:
           - Create an alert: additional/alerts/create.md
           - Delete an alert: additional/alerts/delete.md
@@ -91,5 +92,7 @@ markdown_extensions:
 
 extra:
   generator: false
+
+dev_addr: 127.0.0.1:8081
 
 copyright: Copyright &copy; 2022-2023 DB Netz AG

--- a/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
+++ b/frontend/src/app/projects/models/model-source/t4c/manage-t4c-model/manage-t4c-model.component.html
@@ -24,6 +24,10 @@
             <mat-option
               *ngFor="let instance of t4cInstanceService.t4cInstances$ | async"
               [value]="instance.id"
+              [disabled]="instance.is_archived"
+              [matTooltip]="
+                instance.is_archived ? 'This instance is archived' : ''
+              "
             >
               {{ instance.name }}
             </mat-option>

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -5,7 +5,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { BehaviorSubject, Observable, map, tap } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
 export type Protocol = 'tcp' | 'ssl' | 'ws' | 'wss';
@@ -24,6 +24,8 @@ export type BaseT4CInstance = {
   protocol: Protocol;
   is_archived: boolean;
 };
+
+export type PatchT4CInstance = Partial<BaseT4CInstance>;
 
 export type NewT4CInstance = BaseT4CInstance & {
   name: string;
@@ -59,6 +61,12 @@ export class T4CInstanceService {
   );
   public readonly t4cInstance$ = this._t4cInstance.asObservable();
 
+  public readonly unarchivedT4cInstances$ = this._t4cInstances.pipe(
+    map((t4cInstances) =>
+      t4cInstances?.filter((t4cInstance) => !t4cInstance.is_archived)
+    )
+  );
+
   loadInstances(): void {
     this.http.get<T4CInstance[]>(this.baseUrl).subscribe({
       next: (instances) => this._t4cInstances.next(instances),
@@ -84,7 +92,7 @@ export class T4CInstanceService {
 
   updateInstance(
     instanceId: number,
-    instance: BaseT4CInstance
+    instance: PatchT4CInstance
   ): Observable<T4CInstance> {
     return this.http
       .patch<T4CInstance>(this.urlFactory(instanceId), instance)

--- a/frontend/src/app/services/settings/t4c-instance.service.ts
+++ b/frontend/src/app/services/settings/t4c-instance.service.ts
@@ -22,6 +22,7 @@ export type BaseT4CInstance = {
   username: string;
   password: string;
   protocol: Protocol;
+  is_archived: boolean;
 };
 
 export type NewT4CInstance = BaseT4CInstance & {

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -176,9 +176,27 @@
           </button>
           <button mat-flat-button type="submit" color="primary">Submit</button>
         </div>
-        <div *ngIf="!editing && existing" class="flex justify-between">
-          <button mat-flat-button color="primary" (click)="enableEditing()">
-            Edit
+        <div
+          *ngIf="
+            !editing &&
+            existing &&
+            (t4cInstanceService.t4cInstance$ | async) !== undefined
+          "
+          class="flex justify-between"
+        >
+          <div *ngIf="!isArchived; else archivePlaceholder">
+            <button mat-flat-button color="primary" (click)="enableEditing()">
+              Edit
+            </button>
+          </div>
+          <ng-template #archivePlaceholder>
+            <div class="grow"></div>
+          </ng-template>
+          <button mat-flat-button color="primary" (click)="toggleArchive()">
+            <mat-icon class="mat-icon-position left">{{
+              this.isArchived ? "unarchive" : "archive"
+            }}</mat-icon>
+            {{ this.isArchived ? "Unarchive" : "Archive" }}
           </button>
         </div>
         <div *ngIf="!existing" class="text-right">

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -11,8 +11,8 @@ import { filter, map } from 'rxjs';
 import { BreadcrumbsService } from 'src/app/general/breadcrumbs/breadcrumbs.service';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
 import {
-  BaseT4CInstance,
   NewT4CInstance,
+  PatchT4CInstance,
   Protocol,
   T4CInstanceService,
 } from 'src/app/services/settings/t4c-instance.service';
@@ -33,6 +33,8 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
 
   instanceId?: number;
   capellaVersions?: ToolVersion[];
+
+  isArchived?: boolean;
 
   portValidators = [
     Validators.pattern(/^\d*$/),
@@ -91,6 +93,7 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
       .pipe(untilDestroyed(this), filter(Boolean))
       .subscribe((t4cInstance) => {
         t4cInstance.password = '***********';
+        this.isArchived = t4cInstance.is_archived;
         this.form.patchValue(t4cInstance);
         this.breadcrumbsService.updatePlaceholder({ t4cInstance });
       });
@@ -139,13 +142,31 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
   update(): void {
     if (this.form.valid && this.instanceId) {
       this.t4cInstanceService
-        .updateInstance(this.instanceId, this.form.value as BaseT4CInstance)
+        .updateInstance(this.instanceId, this.form.value as PatchT4CInstance)
         .subscribe((instance) => {
           this.editing = false;
           this.form.disable();
           this.toastService.showSuccess(
             'Instance updated',
             `The instance “${instance.name}” was updated.`
+          );
+        });
+    }
+  }
+
+  toggleArchive(): void {
+    if (this.instanceId) {
+      this.t4cInstanceService
+        .updateInstance(this.instanceId, {
+          is_archived: !this.isArchived,
+        })
+        .subscribe((instance) => {
+          this.isArchived = instance.is_archived;
+          this.toastService.showSuccess(
+            'Instance updated',
+            `The instance “${instance.name}” is now ${
+              this.isArchived ? 'archived' : 'unarchived'
+            }.`
           );
         });
     }

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
@@ -19,7 +19,11 @@
     *ngFor="let instance of t4cInstanceService.t4cInstances$ | async"
     [routerLink]="['instance', instance.id]"
   >
-    <mat-card matRipple class="mat-card-overview">
+    <mat-card
+      matRipple
+      class="mat-card-overview"
+      [ngClass]="{ 'bg-gray-300': instance.is_archived }"
+    >
       <div class="header">{{ instance.name }}</div>
       <div class="content">
         <mat-icon class="aligned">tag</mat-icon> <b> Capella version:</b>
@@ -27,6 +31,13 @@
         <br />
         <mat-icon class="aligned">link</mat-icon><b> Host:</b>
         {{ instance.protocol }}://{{ instance.host }}:{{ instance.port }}
+      </div>
+
+      <div
+        *ngIf="instance.is_archived"
+        class="fixed bottom-2 right-2 text-right text-stone-500"
+      >
+        Archived
       </div>
     </mat-card>
   </a>


### PR DESCRIPTION
This PR adds an archive flag to the t4c instances. When set the t4c instances should be grayed out in the drop down menu (i.e., no longer be selectable) and one should no longer be able to edit the instance. However, existing linked models should still work as expected.

Resolves #970 