### PR TITLE
fix: Add permission to delete Jupyter file share PVCs

### DIFF
--- a/helm/templates/backend/backend.serviceaccount.yaml
+++ b/helm/templates/backend/backend.serviceaccount.yaml
@@ -29,7 +29,7 @@ rules:
   verbs: ["get", "create", "delete"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
-  verbs: ["get", "create"]
+  verbs: ["get", "create", "delete"]
 - apiGroups: [""]
   resources: ["pods", "pods/log", "events"]
   verbs: ["get", "list"]


### PR DESCRIPTION
The deletion of Jupyter file-shares failed because of insufficient permissions in the sessions namespace.
This PR adds the "delete" verb to the "pvc" resource in the backend serviceaccount.