### PR TITLE
Update pre-commit black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
         files: "^backend/"

--- a/backend/capellacollab/config/loader.py
+++ b/backend/capellacollab/config/loader.py
@@ -23,6 +23,7 @@ config_fallback_locations: list[pathlib.Path] = [
     pathlib.Path(__file__).parents[2] / "config" / "config_template.yaml",
 ]
 
+
 # https://gist.github.com/pypt/94d747fe5180851196eb?permalink_comment_id=4015118#gistcomment-4015118
 class UniqueKeyLoader(yaml.SafeLoader):
     def construct_mapping(self, node, deep=False):

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/github/handler.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/github/handler.py
@@ -142,7 +142,6 @@ class GithubHandler(handler.GitHandler):
     def get_last_updated_for_file_path(
         self, project_id: str, file_path: str, revision: str | None
     ) -> datetime.datetime | None:
-
         response = requests.get(
             f"{self.git_instance.api_url}/repos/{project_id}/commits?path={file_path}&sha={revision or self.git_model.revision}",
             headers=self.__get_headers(self.git_model.password)

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -7,7 +7,6 @@ from capellacollab.sessions import metrics, operators
 
 
 def test_metrics_endpoint(client: testclient.TestClient):
-
     response = client.get("/metrics")
 
     assert response.status_code == 200


### PR DESCRIPTION
Update to the latest version of `black`, and switch to the official pre-commit mirror, which runs about 2x faster.
