### PR TITLE
fix: Update of tool metadata didn't trigger on 'Enter'

### DIFF
--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-details.component.html
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-details.component.html
@@ -94,7 +94,12 @@
         </div>
         <br />
         <div *ngIf="editing" class="flex justify-between">
-          <button mat-flat-button color="warn" (click)="cancelEditing()">
+          <button
+            mat-flat-button
+            type="button"
+            color="warn"
+            (click)="cancelEditing()"
+          >
             Cancel
           </button>
           <button mat-flat-button type="submit" color="primary">Submit</button>


### PR DESCRIPTION
The fixed was could be reproduced by:
- Navigate to > Profile > Settings > Tools > (Choose any tool)
- Change name and/or docker images
- Press enter
- Refresh the page, the values are the old ones again, wasn't passed to the backend