### PR TITLE
feat: Improve diagram cache margins on mobile phones

### DIFF
--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.html
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.html
@@ -117,4 +117,8 @@
   >
     No diagrams for the given filter found. Please remove your search query.
   </div>
+  <div class="w-full md:hidden sticky bottom-0 bg-white">
+    <mat-divider id="bottom-divider"></mat-divider>
+    <button class="w-full" mat-button mat-dialog-close>Close</button>
+  </div>
 </div>

--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.ts
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.ts
@@ -130,8 +130,16 @@ export class ModelDiagramDialogComponent {
     const loadingDiagram = this.diagrams[diagram.uuid];
     if (!loadingDiagram.loading) {
       this.dialog.open(ModelDiagramPreviewDialogComponent, {
-        height: '80vh',
-        width: '80vw',
+        maxWidth: '100vw',
+        panelClass: [
+          'md:w-[85vw]',
+          'md:h-[85vw]',
+          'md:max-h-[85vh]',
+          'max-h-full',
+          'w-full',
+          'h-full',
+          '!max-w-full',
+        ],
         data: {
           diagram: diagram,
           content: loadingDiagram.content,

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -62,8 +62,15 @@ export class ModelOverviewComponent implements OnInit {
 
   openDiagramsDialog(model: Model): void {
     this.dialog.open(ModelDiagramDialogComponent, {
-      height: '80vh',
-      width: '80vw',
+      maxWidth: '100vw',
+      panelClass: [
+        'md:w-[85vw]',
+        'md:h-[85vw]',
+        'md:max-h-[85vh]',
+        'max-h-full',
+        'w-full',
+        'h-full',
+      ],
       data: { modelSlug: model.slug, projectSlug: this.projectSlug },
     });
   }


### PR DESCRIPTION
The diagram overview and diagram viewer makes now full use of the available space on mobile phones.
As the previous way to close the diagram by just pressing next to it it not available anymore (there are no margins),
there is a new sticky close button on mobile phones.

The UI on devices with wider screens (>=1024px) doesn't change.

Thanks to @vik378 for proposing this improvement. 

A screenshot of the new UI (grey area is outside of the device screen):

![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/829e19e5-5099-456c-bfe8-68dd72ed13bf)
