### PR TITLE
feat: Make Guacamole database persistent in development mode

### DIFF
--- a/helm/templates/guacamole/postgres.deployment.yaml
+++ b/helm/templates/guacamole/postgres.deployment.yaml
@@ -25,11 +25,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/guacamole" "/postgres.configmap.yaml") . | sha256sum }}
     spec:
       volumes:
-        {{ if ne .Values.target "local" }}
         - name: {{ .Release.Name }}-data
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-volume-guacamole-postgres
-        {{ end }}
         - name: {{ .Release.Name }}-initsql
           configMap:
             name: {{ .Release.Name }}-guacamole-postgres
@@ -81,10 +79,8 @@ spec:
               cpu: "1"
             {{ end }}
           volumeMounts:
-            {{ if ne .Values.target "local" }}
             - name: {{ .Release.Name }}-data
               mountPath: /var/lib/postgresql/data
-            {{ end }}
             - name: {{ .Release.Name }}-initsql
               mountPath: /docker-entrypoint-initdb.d
           {{ if .Values.cluster.containers }}

--- a/helm/templates/guacamole/postgres.volume.yaml
+++ b/helm/templates/guacamole/postgres.volume.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{ if .Values.database.guacamole.deploy }}
-{{ if ne .Values.target "local" }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -18,5 +17,4 @@ spec:
     requests:
       storage: 1Gi
   storageClassName: {{ .Values.cluster.pvc.storageClassName }}
-{{ end }}
 {{ end }}


### PR DESCRIPTION
When running the environment with target: local, the Guacamole database was not persistent. The database had to be reinitialized after each restart.

This can be annoying, also in local development environments. The specific Guacamole database handling for local environment is removed in this commit.

This will improve the local stability, see #800.