### PR TITLE
feat: Make ingressClassName configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ helm-deploy:
 		--set target=local \
 		--set general.port=8080 \
 		--set development=$(DEVELOPMENT_MODE) \
+		--set cluster.ingressClassName=traefik \
 		--set backend.k8sSessionNamespace="$(SESSION_NAMESPACE)" \
 		--set backend.authentication.oauth.redirectURI="http://localhost:$(PORT)/oauth2/callback" \
 		--set backend.authentication.oauth.endpoints.wellKnown="http://$(RELEASE)-oauth-mock:8080/default/.well-known/openid-configuration" \

--- a/helm/templates/routing/nginx.ingress.yaml
+++ b/helm/templates/routing/nginx.ingress.yaml
@@ -13,9 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
 spec:
-  {{ if ne .Values.target "local" }}
-  ingressClassName: nginx
-  {{ end }}
+  ingressClassName: {{ .Values.cluster.ingressClassName }}
   rules:
     - host: {{ .Values.general.host }}
       http:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -199,6 +199,8 @@ cluster:
   # It is used for the backend serviceAccount
   imagePullSecret: test
 
+  ingressClassName: nginx
+
   namespaces:
     sessions:
       podSecurityContext: *podSecurityContext


### PR DESCRIPTION
Before this commit, it was set to nginx on remote deployments. This is not flexible enough.