### PR TITLE
refactor: Replace `target` with `development` in `values.yaml`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -117,7 +117,7 @@ jobs:
           --set cluster.imagePullSecret="github" \
           --set promtail.storageClassName="standard" \
           --set mocks.oauth=True \
-          --set target=local \
+          --set development=True \
           --set general.port=8080 \
           --set backend.authentication.oauth.endpoints.wellKnown="http://test-oauth-mock:8080/default/.well-known/openid-configuration" \
           ./helm

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ helm-deploy:
 		--set docker.registry.internal=k3d-$(CLUSTER_REGISTRY_NAME):$(REGISTRY_PORT) \
 		--set docker.images.guacamole.guacamole=k3d-$(CLUSTER_REGISTRY_NAME):$(REGISTRY_PORT)/capella/collab/guacamole \
 		--set mocks.oauth=True \
-		--set target=local \
 		--set general.port=8080 \
 		--set development=$(DEVELOPMENT_MODE) \
 		--set cluster.ingressClassName=traefik \

--- a/helm/templates/backend/backend.deployment.yaml
+++ b/helm/templates/backend/backend.deployment.yaml
@@ -68,7 +68,7 @@ spec:
               path: /healthcheck
               port: http
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.25"
               memory: 150Mi
@@ -105,7 +105,7 @@ spec:
               containerPort: 3101
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/backend/postgres.deployment.yaml
+++ b/helm/templates/backend/postgres.deployment.yaml
@@ -20,7 +20,7 @@ spec:
       labels:
         id: {{ .Release.Name }}-deployment-backend-postgres
     spec:
-      {{ if ne .Values.target "local" }}
+      {{ if not .Values.development }}
       volumes:
         - name: {{ .Release.Name }}-data
           persistentVolumeClaim:
@@ -54,7 +54,7 @@ spec:
             initialDelaySeconds: 45
             timeoutSeconds: 2
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.25"
               memory: 150Mi
@@ -69,7 +69,7 @@ spec:
               memory: "1Gi"
               cpu: "1"
             {{ end }}
-          {{ if ne .Values.target "local" }}
+          {{ if not .Values.development }}
           volumeMounts:
             - name: {{ .Release.Name }}-data
               mountPath: /var/lib/postgresql/data

--- a/helm/templates/backend/postgres.volume.yaml
+++ b/helm/templates/backend/postgres.volume.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{ if .Values.database.backend.deploy }}
-{{ if ne .Values.target "local" }}
+{{ if not .Values.development }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/templates/docs/docs.deployment.yaml
+++ b/helm/templates/docs/docs.deployment.yaml
@@ -30,7 +30,7 @@ spec:
               path: /
               port: http
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.2"
               memory: 20Mi

--- a/helm/templates/frontend/frontend.deployment.yaml
+++ b/helm/templates/frontend/frontend.deployment.yaml
@@ -48,7 +48,7 @@ spec:
               path: /
               port: http
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.25"
               memory: 150Mi
@@ -82,7 +82,7 @@ spec:
               containerPort: 3101
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/grafana/grafana.deployment.yaml
+++ b/helm/templates/grafana/grafana.deployment.yaml
@@ -31,7 +31,7 @@ spec:
           ports:
             - containerPort: 3000
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.5"
               memory: 500Mi

--- a/helm/templates/grafana/nginx.deployment.yaml
+++ b/helm/templates/grafana/nginx.deployment.yaml
@@ -35,7 +35,7 @@ spec:
               containerPort: 3118
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/guacamole/guacamole.deployment.yaml
+++ b/helm/templates/guacamole/guacamole.deployment.yaml
@@ -88,7 +88,7 @@ spec:
               mountPath: /home/guacamole/tomcat/logs
             {{ end }}
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             requests:
               cpu: "0.1"
               memory: 20Mi
@@ -117,7 +117,7 @@ spec:
               containerPort: 3101
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/guacamole/guacd.deployment.yaml
+++ b/helm/templates/guacamole/guacd.deployment.yaml
@@ -55,7 +55,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 20
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.2"
               memory: 100Mi
@@ -89,7 +89,7 @@ spec:
               containerPort: 3101
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/guacamole/postgres.deployment.yaml
+++ b/helm/templates/guacamole/postgres.deployment.yaml
@@ -63,7 +63,7 @@ spec:
             initialDelaySeconds: 45
             timeoutSeconds: 2
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.15"
               memory: 100Mi

--- a/helm/templates/prometheus/nginx.deployment.yaml
+++ b/helm/templates/prometheus/nginx.deployment.yaml
@@ -34,7 +34,7 @@ spec:
               containerPort: 9118
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -35,7 +35,7 @@ spec:
           ports:
             - containerPort: 9118
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/templates/promtail/promtail.nodeport.yaml
+++ b/helm/templates/promtail/promtail.nodeport.yaml
@@ -3,7 +3,7 @@
 
 # Expose Grafana Loki API on development systems for direct access
 
-{{ if eq .Values.target "local" }}
+{{ if .Values.development }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/routing/nginx.deployment.yaml
+++ b/helm/templates/routing/nginx.deployment.yaml
@@ -34,7 +34,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           resources:
-            {{ if eq .Values.target "local" }}
+            {{ if .Values.development }}
             limits:
               cpu: "0.1"
               memory: 50Mi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -168,10 +168,6 @@ guacamole:
 ### KUBERNETES RELATED CONFIGURATION ###
 ########################################
 
-# target: local | azure | other
-# Never use 'local' in production!
-target: other
-
 # Activate the development mode.
 # NEVER use this in production, it will make your application unsafe.
 # The development mode changes the following options:


### PR DESCRIPTION
Resolves #770
This commit adds support for local production deployments, see #800.