### PR TITLE
feat: Add network policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ helm-deploy:
 		--set general.port=8080 \
 		--set development=$(DEVELOPMENT_MODE) \
 		--set cluster.ingressClassName=traefik \
+		--set cluster.ingressNamespace=kube-system \
 		--set backend.k8sSessionNamespace="$(SESSION_NAMESPACE)" \
 		--set backend.authentication.oauth.redirectURI="http://localhost:$(PORT)/oauth2/callback" \
 		--set backend.authentication.oauth.endpoints.wellKnown="http://$(RELEASE)-oauth-mock:8080/default/.well-known/openid-configuration" \

--- a/helm/templates/promtail/promtail.networkpolicy.yaml
+++ b/helm/templates/promtail/promtail.networkpolicy.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{ if .Values.loki.enabled }}
-{{ if eq .Values.cluster.kind "OpenShift" }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -20,5 +19,4 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.backend.k8sSessionNamespace }}
   policyTypes:
     - Ingress
-{{ end }}
 {{ end }}

--- a/helm/templates/routing/manager.networkpolicy.yaml
+++ b/helm/templates/routing/manager.networkpolicy.yaml
@@ -1,29 +1,27 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $.Release.Name }}-allow-from-{{ .Release.Namespace }}-namespace
-  namespace: {{ .Values.backend.k8sSessionNamespace }}
-spec:
-  podSelector: {}
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  policyTypes:
-    - Ingress
 {{- if .Values.cluster.ingressNamespace }}
----
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny
-  namespace: {{ .Values.backend.k8sSessionNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector: {}
+  policyTypes:
+    - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-same-namespace
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - podSelector: {}
   policyTypes:
     - Ingress
 ---
@@ -31,7 +29,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-from-ingress-namespace
-  namespace: {{ .Values.backend.k8sSessionNamespace }}
+  namespace: {{ .Release.Namespace }}
 spec:
   podSelector: {}
   ingress:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,6 +182,8 @@ mocks:
 cluster:
   kind: Kubernetes # Kubernetes | OpenShift
 
+  ingressNamespace:
+
   podSecurityContext: &podSecurityContext
     runAsUser: 1004370000
     runAsGroup: 1004370000


### PR DESCRIPTION
This PR introduces network policies for our sessions and the main namespace. The session network policies should forbid any incoming traffic except coming from the main namespace or the ingress (required for jupyter to work). Here, we could also include a more fine grained limitation of the ingress case by only allowing this from jupyter sessions. The main namespace should forbid any incoming traffic from the outside, except from the ingress (otherwise the collab manager would not be accessible). Furthermore, we have to allow traffic between pods in this namespace.

This PR requires to add the `ingressNamespace` property to the `values.yaml` (only required for non openshift cluster in the current state)