### PR TITLE
feat: Replace `$http_host` in nginx.conf, add support for proxies

### DIFF
--- a/backend/capellacollab/config/config_schema.yaml
+++ b/backend/capellacollab/config/config_schema.yaml
@@ -114,6 +114,8 @@ properties:
         type: ["number", "string"]
       scheme:
         type: string
+      wildcardHost:
+        type: boolean
       metadata:
         type: object
         properties:

--- a/backend/capellacollab/sessions/hooks/jupyter.py
+++ b/backend/capellacollab/sessions/hooks/jupyter.py
@@ -34,12 +34,19 @@ class JupyterConfigEnvironment(t.TypedDict):
     CSP_ORIGIN_HOST: str
 
 
+class GeneralConfigEnvironment(t.TypedDict):
+    scheme: str
+    host: str
+    port: str
+    wildcardHost: t.NotRequired[bool | None]
+
+
 class JupyterIntegration(interface.HookRegistration):
     def __init__(self):
         self._jupyter_public_uri: urllib_parse.ParseResult = (
             urllib_parse.urlparse(config["extensions"]["jupyter"]["publicURI"])
         )
-        self._general_conf = config["general"]
+        self._general_conf: GeneralConfigEnvironment = config["general"]
 
     def configuration_hook(
         self,
@@ -74,11 +81,13 @@ class JupyterIntegration(interface.HookRegistration):
         user: users_models.DatabaseUser,
         **kwargs,
     ):
+        assert self._jupyter_public_uri.hostname
         operator.create_public_route(
             session_id=session_id,
             host=self._jupyter_public_uri.hostname,
             path=self._determine_base_url(user.name),
             port=8888,
+            wildcard_host=self._general_conf.get("wildcardHost", False),
         )
 
     def pre_session_termination_hook(

--- a/backend/config/config_template.yaml
+++ b/backend/config/config_template.yaml
@@ -35,6 +35,7 @@ general:
   host: localhost
   port: 4200
   scheme: http
+  wildcardHost: False
 
   metadata:
     privacyPolicyURL: https://example.com/privacy

--- a/backend/tests/sessions/test_sessions_routes.py
+++ b/backend/tests/sessions/test_sessions_routes.py
@@ -122,7 +122,12 @@ class MockOperator:
         }
 
     def create_public_route(
-        self, session_id: str, host: str, path: str, port: int
+        self,
+        session_id: str,
+        host: str,
+        path: str,
+        port: int,
+        wildcard_host: bool | None = False,
     ):
         pass
 

--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -29,6 +29,7 @@ general:
   host: "{{ .Values.general.host }}"
   port: "{{ .Values.general.port }}"
   scheme: "{{ .Values.general.scheme }}"
+  wildcardHost: {{ .Values.general.wildcardHost }}
 
   metadata:
     {{- toYaml .Values.general.metadata | nindent 4 }}

--- a/helm/config/nginx.conf
+++ b/helm/config/nginx.conf
@@ -25,8 +25,8 @@ http {
         location /api/v1/ {
             client_max_body_size 30m;
             proxy_pass http://{{ .Release.Name }}-backend:80;
-            proxy_redirect http://{{ .Release.Name }}-backend {{ .Values.general.scheme }}://$http_host;
-            proxy_redirect http://{{ .Release.Name }}-backend:80 {{ .Values.general.scheme }}://$http_host;
+            proxy_redirect http://{{ .Release.Name }}-backend {{ .Values.general.scheme }}://{{ .Values.general.host }}:{{ .Values.general.port }};
+            proxy_redirect http://{{ .Release.Name }}-backend:80 {{ .Values.general.scheme }}://{{ .Values.general.host }}:{{ .Values.general.port }};
         }
     }
 }

--- a/helm/templates/routing/nginx.ingress.yaml
+++ b/helm/templates/routing/nginx.ingress.yaml
@@ -15,8 +15,7 @@ metadata:
 spec:
   ingressClassName: {{ .Values.cluster.ingressClassName }}
   rules:
-    - host: {{ .Values.general.host }}
-      http:
+    - http:
         paths:
           - path: /
             pathType: Prefix
@@ -69,4 +68,7 @@ spec:
                 port:
                   number: 8080
           {{ end }}
+      {{ if not .Values.general.wildcardHost }}
+      host: {{ .Values.general.host }}
+      {{ end }}
 {{ end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,6 +50,11 @@ general:
   port: 80
   scheme: http
 
+  # The application will serve on all hostnames (wildcardHost set to True).
+  # The default behavior is to only serve on the configured host (wildcardHost set to False).
+  # This option has no effect when using OpenShift.
+  wildcardHost: False
+
   metadata:
     privacyPolicyURL: https://example.com/privacy
     imprintURL: https://example.com/imprint


### PR DESCRIPTION
When using a reverse proxy in front of the application, `$http_host` might point to an network internal address. The `proxy_redirect` response points to the internal address then, which leads to redirects to internal addresses (failing requests).

This is another improvement for the cluster setup on VMs (no managed clusters). Together with other merged PRs, this resolves #800.