### PR TITLE
Fix readonly session branch selection

### DIFF
--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -256,15 +256,15 @@ def models_as_json(
             )
         ):
             continue
-        yield git_model_as_json(git_model, entry.deep_clone)
+        yield git_model_as_json(git_model, entry.revision, entry.deep_clone)
 
 
 def git_model_as_json(
-    git_model: git_models.DatabaseGitModel, deep_clone: bool
+    git_model: git_models.DatabaseGitModel, revision: str, deep_clone: bool
 ) -> dict[str, str | int]:
     d: dict[str, str | int] = {
         "url": git_model.path,
-        "revision": git_model.revision,
+        "revision": revision,
         "depth": 0 if deep_clone else 1,
         "entrypoint": git_model.entrypoint,
         "nature": git_model.model.nature.name,

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component.ts
@@ -53,6 +53,10 @@ export class CreateReadonlyModelOptionsComponent implements OnInit {
     this.form.controls.include.valueChanges.subscribe((value) => {
       this.modelOptions.include = value || false;
     });
+    this.form.controls.revision.valueChanges.subscribe((value) => {
+      this.modelOptions.revision =
+        value || this.modelOptions.primaryGitModel.revision;
+    });
 
     this.gitService
       .getPrivateRevision(


### PR DESCRIPTION
The selected branch was not passed to the backend, and the backend did not add it to the configuration of the session container.

Fixes #1072