### PR TITLE
Group Angular updates in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    groups:
+      angular:
+        patterns:
+        - "@angular*"
+        update-types:
+        - "minor"
+        - "patch"
   # Capella Dockerimages
   - package-ecosystem: "gitsubmodule"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
         patterns:
         - "@angular*"
         update-types:
+        - "major"
         - "minor"
         - "patch"
   # Capella Dockerimages


### PR DESCRIPTION
Instead of having a bunch of NPM updates provided by Dependabot, each one not building, group all Angular related updates, so we have one concise update for all Angular packages.

This way we do not have to do the frontend updates ourselves.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups