### PR TITLE
Support Python 3.12

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 name = "capellacollab-backend"
 readme = "README.md"
-requires-python = ">=3.11, <3.12"
+requires-python = ">=3.11, <3.13"
 license = { text = "Apache-2.0" }
 authors = [{ name = "DB Netz AG" }]
 keywords = []
@@ -19,8 +19,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python",
 ]
 dependencies = [
   "PyYAML",


### PR DESCRIPTION
Add Python 3.12 to the supported Python versions.

Updated Trove classifiers. Just Python should be enough. Python 2 is no longer a thing, right? ;)