### PR TITLE
fix: Ensure that PostgreSQL database uses 'UTC' timezone

### DIFF
--- a/backend/capellacollab/core/database/__init__.py
+++ b/backend/capellacollab/core/database/__init__.py
@@ -11,7 +11,8 @@ from sqlalchemy.dialects import postgresql
 from capellacollab.config import config
 
 engine = sa.create_engine(
-    config["database"]["url"], connect_args={"connect_timeout": 5}
+    config["database"]["url"],
+    connect_args={"connect_timeout": 5, "options": "-c timezone=utc"},
 )
 SessionLocal = orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
The application stores the datatime objects in a timezone naive format. Therefore, we store them as UTC and also expect to get UTC as response.

We expect the database to run in UTC, it should not perform any additional datetime or timezone transformation. The transformation is done in the application.

However, some databases run in different timezones. In this case, we ensure that UTC is used for our transactions.