### PR TITLE
build: Let Git ignore dirty `capella-dockerimages` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = capella-dockerimages
 	url = ../capella-dockerimages
 	branch = main
+	ignore = dirty


### PR DESCRIPTION
Git submodules are often staged and committed accidentally. We are generally not supposed to commit dirty submodules, so we can let Git ignore them. Dirty submodules are no longer shown as modified in git status.