### PR TITLE
fix: Update some old references from `docs/user` to `docs`

### DIFF
--- a/ci-templates/gitlab/image-builder.yml
+++ b/ci-templates/gitlab/image-builder.yml
@@ -123,7 +123,7 @@ docs:
         ${DOCKER_BUILD_ARGS} \
         -t ${IMAGE}:${DOCKER_TAG} \
         --build-arg BASE_IMAGE=${BASE_IMAGE} \
-        docs/user
+        docs
     - *push
 
 guacamole:

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -12,8 +12,8 @@ build:
     python: '3.11'
 
 mkdocs:
-  configuration: docs/user/mkdocs.yml
+  configuration: docs/mkdocs.yml
 
 python:
   install:
-    - requirements: docs/user/requirements.txt
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
The docs were moved to the docs directory and are not located in the user subdirectory anymore.