### PR TITLE
fix: Prevent Angular CLI prompts from interrupting app launch

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+export NG_FORCE_TTY=false
+
 dev:
 	ng serve --open
 


### PR DESCRIPTION
Angular CLI could prompt the user for input about autocomplete or analytics in the middle of the make process, causing a failure to properly launch the app. Adding an environmental variable to suppress TTY avoids this.