### PR TITLE
feat: Training mode for projects

### DIFF
--- a/backend/capellacollab/alembic/versions/5ca7037ef183_project_type.py
+++ b/backend/capellacollab/alembic/versions/5ca7037ef183_project_type.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Project type
+
+Revision ID: 5ca7037ef183
+Revises: ac0e6e0f77ee
+Create Date: 2023-10-24 14:21:07.128985
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5ca7037ef183"
+down_revision = "ac0e6e0f77ee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    projecttype = sa.Enum("GENERAL", "TRAINING", name="projecttype")
+    projecttype.create(op.get_bind())
+
+    op.add_column(
+        "projects",
+        sa.Column(
+            "type", projecttype, server_default="GENERAL", nullable=False
+        ),
+    )

--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -59,6 +59,7 @@ def create_project(
     name: str,
     description: str = "",
     visibility: models.Visibility = models.Visibility.PRIVATE,
+    type: models.ProjectType = models.ProjectType.GENERAL,
 ) -> models.DatabaseProject:
     project = models.DatabaseProject(
         name=name,
@@ -66,7 +67,7 @@ def create_project(
         description=description,
         users=[],
         visibility=visibility,
-        type=models.ProjectType.GENERAL,
+        type=type,
     )
 
     db.add(project)

--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -66,6 +66,7 @@ def create_project(
         description=description,
         users=[],
         visibility=visibility,
+        type=models.ProjectType.GENERAL,
     )
 
     db.add(project)

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -41,7 +41,7 @@ class Project(pydantic.BaseModel):
     slug: str
     description: str | None = None
     visibility: Visibility
-    type: ProjectType = ProjectType.GENERAL
+    type: ProjectType
     users: UserMetadata
     is_archived: bool
 

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -29,6 +29,11 @@ class Visibility(enum.Enum):
     INTERNAL = "internal"
 
 
+class ProjectType(enum.Enum):
+    GENERAL = "general"
+    TRAINING = "training"
+
+
 class Project(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(from_attributes=True)
 
@@ -36,6 +41,7 @@ class Project(pydantic.BaseModel):
     slug: str
     description: str | None = None
     visibility: Visibility
+    type: ProjectType = ProjectType.GENERAL
     users: UserMetadata
     is_archived: bool
 
@@ -105,6 +111,7 @@ class DatabaseProject(database.Base):
     slug: orm.Mapped[str] = orm.mapped_column(unique=True, index=True)
     description: orm.Mapped[str | None]
     visibility: orm.Mapped[Visibility]
+    type: orm.Mapped[ProjectType]
 
     users: orm.Mapped[list[ProjectUserAssociation]] = orm.relationship(
         back_populates="project"

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -91,6 +91,7 @@ class PatchProject(pydantic.BaseModel):
     name: str | None = None
     description: str | None = None
     visibility: Visibility | None = None
+    type: ProjectType | None = None
     is_archived: bool | None = None
 
 

--- a/backend/tests/projects/test_projects_routes.py
+++ b/backend/tests/projects/test_projects_routes.py
@@ -37,6 +37,7 @@ def test_get_internal_default_project_as_user(
         "slug": "default",
         "description": "",
         "visibility": "internal",
+        "type": "general",
         "users": {"leads": 0, "contributors": 0, "subscribers": 0},
         "is_archived": False,
     } == response.json()
@@ -223,6 +224,7 @@ def fixture_mock_project():
     project.slug = "mock-project"
     project.description = "Mock Description"
     project.visibility = "private"
+    project.type = "general"
     project.users.leads = 0
     project.users.contributors = 0
     project.users.subscribers = 0

--- a/frontend/src/app/projects/create-project/create-project.component.spec.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.spec.ts
@@ -44,6 +44,7 @@ const mockProjects: Project[] = [
     slug: 'existing-test-project-name',
     description: 'existing-test-project-description',
     visibility: 'private',
+    type: 'general',
     users: {
       leads: 1,
       contributors: 0,
@@ -98,6 +99,7 @@ describe('CreateProjectComponent', () => {
         description: project.description!,
         slug: project.name!,
         visibility: project.visibility!,
+        type: project.type!,
         users: { leads: 1, contributors: 0, subscribers: 0 },
         is_archived: false,
       };
@@ -187,6 +189,7 @@ describe('CreateProjectComponent', () => {
       name: testProjectName,
       description: '',
       visibility: 'private',
+      type: 'general',
     });
     expect(fakeToastService.showSuccess).toHaveBeenCalledTimes(1);
   });
@@ -205,6 +208,7 @@ describe('CreateProjectComponent', () => {
       name: testProjectName,
       description: testProjectDescription,
       visibility: 'private',
+      type: 'general',
     });
     expect(fakeToastService.showSuccess).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/app/projects/create-project/create-project.component.spec.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.spec.ts
@@ -35,6 +35,7 @@ import {
   Project,
   ProjectService,
   ProjectVisibility,
+  ProjectVisibilityDescriptions,
 } from '../service/project.service';
 import { CreateProjectComponent } from './create-project.component';
 
@@ -125,10 +126,10 @@ describe('CreateProjectComponent', () => {
       };
     },
     getProjectVisibilityDescription(visibility: ProjectVisibility): string {
-      return ProjectVisibility[visibility];
+      return ProjectVisibilityDescriptions[visibility];
     },
     getAvailableVisibilities(): ProjectVisibility[] {
-      return Object.keys(ProjectVisibility) as ProjectVisibility[];
+      return Object.keys(ProjectVisibilityDescriptions) as ProjectVisibility[];
     },
   };
 

--- a/frontend/src/app/projects/create-project/create-project.component.ts
+++ b/frontend/src/app/projects/create-project/create-project.component.ts
@@ -54,6 +54,7 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
           name: this.form.value.name!,
           description: this.form.value.description!,
           visibility: this.form.value.visibility! as ProjectVisibility,
+          type: 'general',
         })
         .subscribe((project) => {
           this.toastService.showSuccess(

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.css
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.css
@@ -15,12 +15,6 @@
   max-height: 80vh;
 }
 
-.header {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-}
-
 pre {
   white-space: pre-wrap;
 }

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
@@ -4,7 +4,7 @@
  -->
 
 <div *ngIf="pipelineRunService.pipelineRun$ | async">
-  <div class="flex flex-col justify-between">
+  <div class="flex flex-row justify-between">
     <h1>
       Logs for pipeline run
       {{ (pipelineRunService.pipelineRun$ | async)?.id }}

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
@@ -4,7 +4,7 @@
  -->
 
 <div *ngIf="pipelineRunService.pipelineRun$ | async">
-  <div class="header">
+  <div class="header flex-col">
     <h1>
       Logs for pipeline run
       {{ (pipelineRunService.pipelineRun$ | async)?.id }}

--- a/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
+++ b/frontend/src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component.html
@@ -4,7 +4,7 @@
  -->
 
 <div *ngIf="pipelineRunService.pipelineRun$ | async">
-  <div class="header flex-col">
+  <div class="flex flex-col justify-between">
     <h1>
       Logs for pipeline run
       {{ (pipelineRunService.pipelineRun$ | async)?.id }}

--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.html
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 <div class="dialog">
-  <div class="header">
+  <div class="header flex-col">
     <h2>View diagrams</h2>
     <span
       >Last update:

--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.html
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-dialog.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 <div class="dialog">
-  <div class="header flex-col">
+  <div class="header">
     <h2>View diagrams</h2>
     <span
       >Last update:

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
@@ -54,6 +54,21 @@
           </mat-radio-group>
         </div>
       </fieldset>
+      <fieldset>
+        <div class="flex flex-col">
+          <h3>Project type</h3>
+          <mat-radio-group formControlName="type" class="flex flex-col">
+            <mat-radio-button
+              *ngFor="
+                let projectType of projectService.getAvailableProjectTypes()
+              "
+              [value]="projectType"
+            >
+              {{ projectService.getProjectTypeDescription(projectType) }}
+            </mat-radio-button>
+          </mat-radio-group>
+        </div>
+      </fieldset>
     </form>
     <div class="flex justify-between">
       <span

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
@@ -7,7 +7,7 @@
   <mat-card id="metadata-card">
     <h2 id="title">Description</h2>
     <form [formGroup]="form">
-      <fieldset>
+      <div>
         <mat-form-field appearance="fill">
           <mat-label>Name</mat-label>
           <input matInput formControlName="name" />
@@ -24,8 +24,8 @@
             references.</mat-hint
           >
         </mat-form-field>
-      </fieldset>
-      <fieldset>
+      </div>
+      <div>
         <mat-form-field appearance="fill">
           <mat-label>Description</mat-label>
           <textarea
@@ -38,8 +38,8 @@
             "
           ></textarea>
         </mat-form-field>
-      </fieldset>
-      <fieldset>
+      </div>
+      <div>
         <div class="flex flex-col">
           <h3>Project visibility</h3>
           <mat-radio-group formControlName="visibility" class="flex flex-col">
@@ -53,8 +53,8 @@
             </mat-radio-button>
           </mat-radio-group>
         </div>
-      </fieldset>
-      <fieldset>
+      </div>
+      <div>
         <div class="flex flex-col">
           <h3>Project type</h3>
           <mat-radio-group formControlName="type" class="flex flex-col">
@@ -68,7 +68,7 @@
             </mat-radio-button>
           </mat-radio-group>
         </div>
-      </fieldset>
+      </div>
     </form>
     <div class="flex justify-between">
       <span

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.ts
@@ -38,6 +38,7 @@ export class EditProjectMetadataComponent implements OnInit, OnChanges {
     name: new FormControl<string>('', Validators.required),
     description: new FormControl<string>(''),
     visibility: new FormControl(''),
+    type: new FormControl(''),
   });
 
   ngOnInit(): void {

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -129,7 +129,9 @@
             class="!m-1.5"
             (click)="openPipelineDialog(model)"
             *ngIf="
-              projectUserService.verifyRole('manager') && !project?.is_archived
+              projectUserService.verifyRole('manager') &&
+              !project?.is_archived &&
+              project?.type !== 'training'
             "
           >
             <mat-icon>sync</mat-icon>
@@ -152,6 +154,7 @@
             routerLink="/sessions"
             *ngIf="
               !project?.is_archived &&
+              project?.type !== 'training' &&
               model.t4c_models &&
               projectUserService.verifyPermission('write')
             "

--- a/frontend/src/app/projects/project-overview/project-overview.component.html
+++ b/frontend/src/app/projects/project-overview/project-overview.component.html
@@ -28,7 +28,12 @@
         matRipple
         class="mat-card-overview m-0"
       >
-        <div class="header">{{ project.name }}</div>
+        <div class="header flex-row">
+          <mat-icon class="mr-1" *ngIf="project.type === 'training'"
+            >school</mat-icon
+          >
+          <span class="">{{ project.name }}</span>
+        </div>
         <div class="p-3">
           <div>
             <div *ngIf="project.description; else elseBlock">

--- a/frontend/src/app/projects/service/project.service.ts
+++ b/frontend/src/app/projects/service/project.service.ts
@@ -140,6 +140,7 @@ export type PostProject = {
   name: string;
   description: string;
   visibility: ProjectVisibility;
+  type: ProjectType;
 };
 
 export type PatchProject = Partial<PostProject> & {

--- a/frontend/src/app/projects/service/project.service.ts
+++ b/frontend/src/app/projects/service/project.service.ts
@@ -114,19 +114,19 @@ export class ProjectService {
   }
 
   getProjectVisibilityDescription(visibility: ProjectVisibility): string {
-    return ProjectVisibility[visibility];
+    return ProjectVisibilityDescriptions[visibility];
   }
 
   getAvailableVisibilities(): ProjectVisibility[] {
-    return Object.keys(ProjectVisibility) as ProjectVisibility[];
+    return Object.keys(ProjectVisibilityDescriptions) as ProjectVisibility[];
   }
 
   getProjectTypeDescription(type: ProjectType): string {
-    return ProjectTypes[type];
+    return ProjectTypeDescriptions[type];
   }
 
   getAvailableProjectTypes(): ProjectType[] {
-    return Object.keys(ProjectTypes) as ProjectType[];
+    return Object.keys(ProjectTypeDescriptions) as ProjectType[];
   }
 }
 
@@ -156,12 +156,12 @@ export type Project = Required<PatchProject> & {
   users: UserMetadata;
 };
 
-export const ProjectVisibility = {
+export const ProjectVisibilityDescriptions = {
   internal: 'Internal (viewable by all logged in users)',
   private: 'Private (only viewable by project members)',
 };
 
-export const ProjectTypes = {
-  general: 'General - a project that contains multiple related models.',
-  training: 'Training - this project contains training material.',
+export const ProjectTypeDescriptions = {
+  general: 'General (a project that contains multiple related models)',
+  training: 'Training (special project containing training material)',
 };

--- a/frontend/src/app/projects/service/project.service.ts
+++ b/frontend/src/app/projects/service/project.service.ts
@@ -120,6 +120,14 @@ export class ProjectService {
   getAvailableVisibilities(): ProjectVisibility[] {
     return Object.keys(ProjectVisibility) as ProjectVisibility[];
   }
+
+  getProjectTypeDescription(type: ProjectType): string {
+    return ProjectTypes[type];
+  }
+
+  getAvailableProjectTypes(): ProjectType[] {
+    return Object.keys(ProjectTypes) as ProjectType[];
+  }
 }
 
 export type UserMetadata = {
@@ -140,6 +148,8 @@ export type PatchProject = Partial<PostProject> & {
 
 export type ProjectVisibility = 'internal' | 'private';
 
+export type ProjectType = 'general' | 'training';
+
 export type Project = Required<PatchProject> & {
   slug: string;
   users: UserMetadata;
@@ -148,4 +158,9 @@ export type Project = Required<PatchProject> & {
 export const ProjectVisibility = {
   internal: 'Internal (viewable by all logged in users)',
   private: 'Private (only viewable by project members)',
+};
+
+export const ProjectTypes = {
+  general: 'General - a project that contains multiple related models.',
+  training: 'Training - this project contains training material.',
 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -231,7 +231,6 @@ Angular Material Card Styles
   color: white;
   border-radius: 5px 5px 0 0;
   display: flex;
-  flex-direction: column;
   padding: 10px 20px;
   font-size: 1.5em;
 }


### PR DESCRIPTION
Support different types of projects. Currently _general_ and _training_. 

By default you're creating a normal project. This is what most users tend to do and I think we should not bother with training projects upon project creation directly. You can, however, modify a project and set it to _training_.

Training mode is depicted by a "study" icon before the name. Maybe we want to change the color of the header too.

![image](https://github.com/DSD-DBS/capella-collab-manager/assets/96249/c1cf2c5b-f7fe-4839-9ff5-b14db4163451)

Synchronization and persistent session buttons are not shown for models in a training project.

No additional behavior has been implemented.

Related to #1004.