### PR TITLE
feat(k8s): Add Pod disruption budgets

### DIFF
--- a/backend/tests/sessions/k8s_operator/conftest.py
+++ b/backend/tests/sessions/k8s_operator/conftest.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import kubernetes.config
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_k8s_load_config(monkeypatch):
+    monkeypatch.setattr(kubernetes.config, "load_config", lambda **_: None)

--- a/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
+++ b/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+import datetime
+
+import pytest
+from kubernetes import client
+from kubernetes.client import exceptions
+
+from capellacollab.sessions.operators import k8s
+
+
+def test_start_session(monkeypatch: pytest.MonkeyPatch):
+    operator = k8s.KubernetesOperator()
+    monkeypatch.setattr(k8s, "loki_enabled", False)
+
+    name = "testname"
+    creation_timestamp = datetime.datetime.now()
+
+    deployment_counter = 0
+    service_counter = 0
+    disruption_budget_counter = 0
+
+    def create_namespaced_deployment(namespace, deployment):
+        nonlocal deployment_counter
+        deployment_counter += 1
+        return client.V1Deployment(
+            metadata=client.V1ObjectMeta(
+                name=name, creation_timestamp=creation_timestamp
+            )
+        )
+
+    monkeypatch.setattr(
+        operator.v1_apps,
+        "create_namespaced_deployment",
+        create_namespaced_deployment,
+    )
+
+    def create_namespaced_service(namespace, service):
+        nonlocal service_counter
+        service_counter += 1
+        return client.V1Service(metadata=client.V1ObjectMeta(name=name))
+
+    monkeypatch.setattr(
+        operator.v1_core,
+        "create_namespaced_service",
+        create_namespaced_service,
+    )
+
+    def create_namespaced_pod_disruption_budget(namespace, budget):
+        nonlocal disruption_budget_counter
+        disruption_budget_counter += 1
+
+    monkeypatch.setattr(
+        operator.v1_policy,
+        "create_namespaced_pod_disruption_budget",
+        create_namespaced_pod_disruption_budget,
+    )
+
+    session = operator.start_session(
+        image="hello-world",
+        username="testuser",
+        session_type="persistent",
+        tool_name="test tool",
+        version_name="test version",
+        environment={},
+        ports={"rdp": 3389},
+        volumes=[],
+    )
+
+    assert deployment_counter == 1
+    assert service_counter == 1
+    assert disruption_budget_counter == 1
+
+    assert session["id"] == "testname"
+
+
+def test_kill_session(monkeypatch: pytest.MonkeyPatch):
+    operator = k8s.KubernetesOperator()
+    monkeypatch.setattr(k8s, "loki_enabled", False)
+
+    monkeypatch.setattr(
+        operator.v1_apps,
+        "delete_namespaced_deployment",
+        lambda namespace, name: client.V1Status(),
+    )
+
+    monkeypatch.setattr(
+        operator.v1_core,
+        "delete_namespaced_service",
+        lambda namespace, name: client.V1Status(),
+    )
+
+    monkeypatch.setattr(
+        operator.v1_policy,
+        "delete_namespaced_pod_disruption_budget",
+        lambda namespace, name: client.V1Status(),
+    )
+
+    operator.kill_session("testname")
+
+
+def test_create_job(monkeypatch: pytest.MonkeyPatch):
+    operator = k8s.KubernetesOperator()
+    monkeypatch.setattr(
+        operator.v1_batch, "create_namespaced_job", lambda namespace, job: None
+    )
+    result = operator.create_job(
+        image="fakeimage",
+        command="fakecmd",
+        labels={"key": "value"},
+        environment={"ENVVAR": "value"},
+    )
+
+    assert result
+
+
+def test_create_cronjob(monkeypatch: pytest.MonkeyPatch):
+    operator = k8s.KubernetesOperator()
+    monkeypatch.setattr(
+        operator.v1_batch,
+        "create_namespaced_cron_job",
+        lambda namespace, job: None,
+    )
+    result = operator.create_cronjob(
+        image="fakeimage",
+        command="fakecmd",
+        environment={"ENVVAR": "value"},
+    )
+
+    assert result
+
+
+def test_delete_disruption_budget_with_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test that _delete_disruptionbudget does not raise an exception if the
+    Pod disruption budget does not exist.
+    """
+
+    operator = k8s.KubernetesOperator()
+
+    def raise_api_exception(*args, **kwargs):
+        raise exceptions.ApiException(status=404)
+
+    monkeypatch.setattr(
+        operator.v1_policy,
+        "delete_namespaced_pod_disruption_budget",
+        raise_api_exception,
+    )
+    result = operator._delete_disruptionbudget("testname")
+    assert result is None

--- a/helm/templates/backend/backend.disruptionsbudget.yml
+++ b/helm/templates/backend/backend.disruptionsbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-backend
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-backend

--- a/helm/templates/backend/backend.serviceaccount.yaml
+++ b/helm/templates/backend/backend.serviceaccount.yaml
@@ -39,6 +39,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "delete"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["create", "delete"]
 {{- if eq .Values.cluster.kind "Kubernetes" }}
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]

--- a/helm/templates/backend/postgres.disruptionbudget.yml
+++ b/helm/templates/backend/postgres.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-backend-postgres
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-backend-postgres

--- a/helm/templates/docs/docs.discruptionbudget.yml
+++ b/helm/templates/docs/docs.discruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-docs
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-docs

--- a/helm/templates/frontend/frontend.disruptionbudget.yml
+++ b/helm/templates/frontend/frontend.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-frontend
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-frontend

--- a/helm/templates/grafana/grafana.disruptionbudget.yml
+++ b/helm/templates/grafana/grafana.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-grafana
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-grafana-server

--- a/helm/templates/grafana/nginx.disruptionbudget.yml
+++ b/helm/templates/grafana/nginx.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-grafana-nginx
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-grafana-nginx

--- a/helm/templates/guacamole/guacamole.disruptionbudget.yml
+++ b/helm/templates/guacamole/guacamole.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-guacamole-guacamole
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-guacamole-guacamole

--- a/helm/templates/guacamole/guacd.disruptionbudget.yml
+++ b/helm/templates/guacamole/guacd.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-guacamole-guacd
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-guacamole-guacd

--- a/helm/templates/guacamole/postgres.disruptionbudget.yml
+++ b/helm/templates/guacamole/postgres.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-guacamole-postgres
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-guacamole-postgres

--- a/helm/templates/prometheus/nginx.disruptionbudget.yml
+++ b/helm/templates/prometheus/nginx.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-prometheus-nginx
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-prometheus-nginx

--- a/helm/templates/prometheus/prometheus.disruptionbudget.yml
+++ b/helm/templates/prometheus/prometheus.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-prometheus-server
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-prometheus-server

--- a/helm/templates/routing/nginx.disruptionbudget.yml
+++ b/helm/templates/routing/nginx.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-nginx
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-nginx


### PR DESCRIPTION
Kubernetes allows a lot flexibility when it comes to cluster and node updates.
Cluster updates can happen at any time and can lead to massive interruptions (Guacamole not available) and session termination with potential data loss.

Pod discruption budgets define under which circumstances the cluster operator can terminate or restart Pods.

Our new policy is now:

- For each service of the management portal, at least one Pod has to be up&running at any time.
- Session termination by the control plane is not allowed. The cluster operator has to contact the system administrator or wait until the session is terminated.

Resolves #1089