### PR TITLE
chore: Bump capellambse to 0.5.36

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
           - fastapi
           - pydantic
           - sqlalchemy
-          - capellambse==0.5.35.dev4
+          - capellambse==0.5.36
   - repo: local
     hooks:
       - id: pylint

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -52,7 +52,7 @@ Homepage = "https://github.com/DSD-DBS/capella-collab-manager"
 [project.optional-dependencies]
 dev = [
   "black",
-  "capellambse==0.5.35.dev4",
+  "capellambse==0.5.36",
   "deepdiff",
   "isort",
   "mypy",


### PR DESCRIPTION
A few weeks ago, we required a pre-release version of [capellambse](https://github.com/DSD-DBS/py-capellambse) as dev dependency. Since they now already released two new versions, I just bumped the version to the most recent one to no longer depend on a pre-relase.