### PR TITLE
ci: Prohibit use of `print` function

### DIFF
--- a/backend/capellacollab/config/diff.py
+++ b/backend/capellacollab/config/diff.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# pylint: disable=bad-builtin
+
 import pathlib
 
 import deepdiff

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -205,8 +205,6 @@ def _delete_all_pipelines_for_project(
     pipelines: list[backups_models.DatabaseBackup] = []
     for model in project.models:
         pipelines.extend(backups_crud.get_pipelines_for_tool_model(db, model))
-    print(project.models)
-    print(pipelines)
     for pipeline in pipelines:
         backups_core.delete_pipeline(db, pipeline, username, True)
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/github/handler.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/github/handler.py
@@ -109,9 +109,6 @@ class GithubHandler(handler.GitHandler):
         headers = None
         if self.git_model.password:
             headers = self.__get_headers(self.git_model.password)
-        print(
-            f"{self.git_instance.api_url}/repos/{project_id}/actions/runs?branch={parse.quote(self.git_model.revision, safe='')}&per_page=20"
-        )
         response = requests.get(
             f"{self.git_instance.api_url}/repos/{project_id}/actions/runs?branch={parse.quote(self.git_model.revision, safe='')}&per_page=20",
             headers=headers,

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -976,7 +976,9 @@ class KubernetesOperator:
             import pathlib
             import sys
 
-            print("Using CLI arguments: " + str(sys.argv[1:]), file=sys.stderr)
+            print(  # pylint: disable=bad-builtin
+                "Using CLI arguments: " + str(sys.argv[1:]), file=sys.stderr
+            )
 
             def get_files(dir: pathlib.Path, show_hidden: bool):
                 file = {
@@ -1004,7 +1006,7 @@ class KubernetesOperator:
 
                 return file
 
-            print(
+            print(  # pylint: disable=bad-builtin
                 json.dumps(
                     get_files(
                         pathlib.Path(sys.argv[1]), json.loads(sys.argv[2])

--- a/backend/capellacollab/settings/modelsources/git/askpass.py
+++ b/backend/capellacollab/settings/modelsources/git/askpass.py
@@ -7,5 +7,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    print(os.environ["GIT_" + sys.argv[1].split()[0].upper()])
+    print(  # pylint: disable=bad-builtin
+        os.environ["GIT_" + sys.argv[1].split()[0].upper()]
+    )
     raise SystemExit(0)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -150,6 +150,9 @@ add-ignore = [
   "D213", # Multi-line docstring summary should start at the second line
 ]
 
+[tool.pylint]
+bad-functions = ["print"]
+
 [tool.pylint.messages_control]
 disable = [
   "broad-except",
@@ -220,6 +223,7 @@ extension-pkg-whitelist = "pydantic" # https://github.com/pydantic/pydantic/issu
 
 [tool.pylint.master]
 init-import = "yes"
+load-plugins = "pylint.extensions.bad_builtin"
 
 [tool.pylint.similarities]
 min-similarity-lines = 6


### PR DESCRIPTION
There were again a few print statements, which messed up the logs.
We should use log messages instead of print statements. If a print statement is required, disable the pylint warning.