### PR TITLE
fix: Restrict clickable area on mat-card overviews

### DIFF
--- a/frontend/src/app/projects/project-overview/project-overview.component.html
+++ b/frontend/src/app/projects/project-overview/project-overview.component.html
@@ -4,8 +4,8 @@
  -->
 
 <div class="flex flex-wrap">
-  <a routerLink="/projects/create">
-    <mat-card matRipple class="mat-card-overview new">
+  <a routerLink="/projects/create" class="m-2.5">
+    <mat-card matRipple class="mat-card-overview new m-0">
       <div class="content">
         Add new project <br />
         <div class="icon">
@@ -19,13 +19,14 @@
   ></app-mat-card-overview-skeleton-loader>
   <ng-container *ngIf="projectService.projects$ | async">
     <a
+      class="m-2.5"
       *ngFor="let project of (projectService.projects$ | async)!"
       [routerLink]="['/project', project.slug]"
     >
       <mat-card
         [ngClass]="{ 'bg-archived': project.is_archived }"
         matRipple
-        class="mat-card-overview"
+        class="mat-card-overview m-0"
       >
         <div class="header">{{ project.name }}</div>
         <div class="p-3">

--- a/frontend/src/app/settings/core/tools-settings/tools-settings.component.html
+++ b/frontend/src/app/settings/core/tools-settings/tools-settings.component.html
@@ -4,8 +4,8 @@
  -->
 
 <article class="flex flex-wrap">
-  <a [routerLink]="['create']">
-    <mat-card matRipple class="mat-card-overview new">
+  <a [routerLink]="['create']" class="m-2.5">
+    <mat-card matRipple class="mat-card-overview new m-0">
       <div class="content">
         Add a tool <br />
         <div class="icon">
@@ -18,8 +18,9 @@
   <a
     *ngFor="let tool of toolService.tools"
     [routerLink]="['..', 'tool', tool.id]"
+    class="m-2.5"
   >
-    <mat-card matRipple class="mat-card-overview">
+    <mat-card matRipple class="mat-card-overview m-0">
       <div class="header">{{ tool.name }}</div>
       <div class="content" *ngIf="tools[tool.id]">
         <mat-icon class="mat-icon-position top">history</mat-icon>

--- a/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/t4c-settings.component.html
@@ -4,8 +4,8 @@
  -->
 
 <article class="flex flex-wrap">
-  <a [routerLink]="['create']">
-    <mat-card matRipple class="mat-card-overview new">
+  <a [routerLink]="['create']" class="m-2.5">
+    <mat-card matRipple class="mat-card-overview new m-0">
       <div class="content">
         Add an instance <br />
         <div class="icon">
@@ -18,10 +18,11 @@
   <a
     *ngFor="let instance of t4cInstanceService.t4cInstances$ | async"
     [routerLink]="['instance', instance.id]"
+    class="m-2.5"
   >
     <mat-card
       matRipple
-      class="mat-card-overview"
+      class="mat-card-overview m-0"
       [ngClass]="{ 'bg-gray-300': instance.is_archived }"
     >
       <div class="header">{{ instance.name }}</div>

--- a/frontend/src/app/settings/settings.component.css
+++ b/frontend/src/app/settings/settings.component.css
@@ -2,13 +2,3 @@
  * SPDX-FileCopyrightText: Copyright DB Netz AG and the capella-collab-manager contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
-.title {
-  font-size: 2em;
-  margin: 20px;
-}
-
-#git {
-  max-width: 50%;
-  margin-top: 5px;
-}

--- a/frontend/src/app/settings/settings.component.html
+++ b/frontend/src/app/settings/settings.component.html
@@ -5,26 +5,26 @@
 
 <div class="title">Core functionality</div>
 <div class="flex flex-wrap">
-  <a [routerLink]="['/settings/core/users']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5" [routerLink]="['/settings/core/users']">
+    <mat-card class="option-card m-0" matRipple>
       <div>Manage users</div>
       <app-mat-icon size="50px">supervised_user_circle</app-mat-icon>
     </mat-card>
   </a>
-  <a [routerLink]="['/settings/core/alerts']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5" [routerLink]="['/settings/core/alerts']">
+    <mat-card class="option-card m-0" matRipple>
       <div>Announcements</div>
       <app-mat-icon size="50px">add_alert</app-mat-icon>
     </mat-card>
   </a>
-  <a [routerLink]="['/settings/core/tools']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5" [routerLink]="['/settings/core/tools']">
+    <mat-card class="option-card m-0" matRipple>
       <div>Tools</div>
       <app-mat-icon size="50px">build</app-mat-icon>
     </mat-card>
   </a>
-  <a [routerLink]="['/settings/core/pipelines']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5" [routerLink]="['/settings/core/pipelines']">
+    <mat-card class="option-card m-0" matRipple>
       <div>Monitoring</div>
       <app-mat-icon size="50px">sync</app-mat-icon>
     </mat-card>
@@ -33,8 +33,8 @@
 
 <div class="title">Model sources</div>
 <div class="flex flex-wrap">
-  <a class="flex" [routerLink]="['/settings/modelsources/git']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5 flex" [routerLink]="['/settings/modelsources/git']">
+    <mat-card class="option-card m-0" matRipple>
       <div>Git</div>
       <div class="flex justify-center">
         <img
@@ -44,8 +44,8 @@
       </div>
     </mat-card>
   </a>
-  <a [routerLink]="['/settings/modelsources/t4c']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5" [routerLink]="['/settings/modelsources/t4c']">
+    <mat-card class="option-card m-0" matRipple>
       <div>Team For Capella</div>
       <app-mat-icon size="50px">people</app-mat-icon>
     </mat-card>
@@ -54,8 +54,8 @@
 
 <div class="title">Integrations</div>
 <div class="flex flex-wrap">
-  <a [routerLink]="['/settings/integrations/pure-variants']">
-    <mat-card class="option-card" matRipple>
+  <a class="m-2.5" [routerLink]="['/settings/integrations/pure-variants']">
+    <mat-card class="option-card m-0" matRipple>
       <div>pure::variants</div>
       <app-mat-icon size="50px">people</app-mat-icon>
     </mat-card>

--- a/frontend/src/app/settings/settings.component.html
+++ b/frontend/src/app/settings/settings.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div class="title">Core functionality</div>
+<div class="m-2.5 text-2xl">Core functionality</div>
 <div class="flex flex-wrap">
   <a class="m-2.5" [routerLink]="['/settings/core/users']">
     <mat-card class="option-card m-0" matRipple>
@@ -31,7 +31,7 @@
   </a>
 </div>
 
-<div class="title">Model sources</div>
+<div class="m-2.5 text-2xl">Model sources</div>
 <div class="flex flex-wrap">
   <a class="m-2.5 flex" [routerLink]="['/settings/modelsources/git']">
     <mat-card class="option-card m-0" matRipple>
@@ -39,6 +39,7 @@
       <div class="flex justify-center">
         <img
           id="git"
+          class="mt-1 max-w-[50%]"
           src="https://git-scm.com/images/logos/downloads/Git-Logo-1788C.png"
         />
       </div>
@@ -52,7 +53,7 @@
   </a>
 </div>
 
-<div class="title">Integrations</div>
+<div class="m-2.5 text-2xl">Integrations</div>
 <div class="flex flex-wrap">
   <a class="m-2.5" [routerLink]="['/settings/integrations/pure-variants']">
     <mat-card class="option-card m-0" matRipple>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -269,8 +269,6 @@ Option cards
 .option-card {
   width: 200px;
   max-width: 85vw;
-  margin: 20px;
-  padding: 20px;
   font-size: 1.5em;
   text-align: center;
   display: flex;


### PR DESCRIPTION
The clickable area in the mat-card overviews was slightly larger than the mat-card. Reason is that that the mat-card element has a margin of 10px and is wrapped by an a-element. The margin is now "moved" to the a-element.