### PR TITLE
build: No longer require `-j4` in `make dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,9 @@ provision-guacamole:
 	kubectl exec -i --context k3d-$(CLUSTER_NAME) --namespace $(NAMESPACE) deployment/$(RELEASE)-guacamole-postgres -- psql -U guacamole guacamole
 	@echo "Guacamole database initialized sucessfully.";
 
-# Execute with `make -j4 dev`
-dev: dev-oauth-mock dev-frontend dev-backend dev-docs
+
+dev:
+	$(MAKE) -j4 dev-frontend dev-backend dev-oauth-mock dev-docs
 
 dev-frontend:
 	$(MAKE) -C frontend dev

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -57,7 +57,7 @@ initial setup (only required once):
 Then, run the following command to start the dev environment:
 
 ```zsh
-make -j4 dev
+make dev
 ```
 
 If everything went well, the frontend and backend should be running now:


### PR DESCRIPTION
Developers can simply run `make dev` instead of `make -j4 dev`. Since the target does only work with parallel execution endabled, the parallel execution is now the default.