### PR TITLE
build(frontend): Skip creation of `.css` and `.spec.ts` files

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -8,6 +8,13 @@
       "schematics": {
         "@schematics/angular:application": {
           "strict": true
+        },
+        "@schematics/angular:component": {
+          "skipTests": true,
+          "style": "none"
+        },
+        "@schematics/angular:service": {
+          "skipTests": true
         }
       },
       "root": "",


### PR DESCRIPTION
The project relies heavily on TailwindCSS and existing legacy components will moved their styles to TailwindCSS. For many new components, there is no need to a separate CSS file anymore, Tailwind covers most of the capabilities.

Also, we hardly use `.spec.ts` files and have only a small number of frontend tests. Therefore, they are also omitted during component or service creation.