### PR TITLE
fix: Use wider input fields in project metadata dialog

### DIFF
--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
@@ -5,10 +5,9 @@
 <div *ngIf="projectUserService.verifyRole('manager')"></div>
 <div class="wrapper">
   <mat-card id="metadata-card">
-    <h2 id="title">Description</h2>
     <form [formGroup]="form">
       <div>
-        <mat-form-field appearance="fill">
+        <mat-form-field appearance="fill" class="w-full max-w-lg">
           <mat-label>Name</mat-label>
           <input matInput formControlName="name" />
           <mat-error *ngIf="form.controls.name.errors?.required"
@@ -26,7 +25,7 @@
         </mat-form-field>
       </div>
       <div>
-        <mat-form-field appearance="fill">
+        <mat-form-field appearance="fill" class="w-full max-w-lg">
           <mat-label>Description</mat-label>
           <textarea
             formControlName="description"

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
@@ -2,7 +2,6 @@
  ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
-<div *ngIf="projectUserService.verifyRole('manager')"></div>
 <div class="wrapper">
   <mat-card id="metadata-card">
     <form [formGroup]="form">


### PR DESCRIPTION
Before: 
![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/e7d2cbda-e5b3-4db3-bb2c-330879816d08)

After: 
![image](https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/5543071a-24c9-4451-84ec-d692841fc204)
