### PR TITLE
feat: Improve test runtime by only calling `migrate_db` once

### DIFF
--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -68,7 +68,6 @@ def test_get_all_pipelines_of_capellamodel(
 
     assert response.status_code == 200
     assert len(response.json()) == 1
-    assert response.json()[0]["id"] == 1
 
 
 @pytest.mark.usefixtures(

--- a/backend/tests/users/test_tokens.py
+++ b/backend/tests/users/test_tokens.py
@@ -76,7 +76,9 @@ def test_create_and_delete_token(
     response = client.post("/api/v1/users/current/tokens", json=POST_TOKEN)
     assert response.status_code == 200
 
-    response = client.delete("/api/v1/users/current/tokens/1")
+    token_id = response.json()["id"]
+
+    response = client.delete(f"/api/v1/users/current/tokens/{token_id}")
     assert response.status_code == 204
 
 
@@ -91,7 +93,9 @@ def test_token_lifecycle(
     response_string = response.content.decode("utf-8")
     assert len(json.loads(response_string)) == 1
 
-    response = client.delete("/api/v1/users/current/tokens/1")
+    token_id = response.json()[0]["id"]
+
+    response = client.delete(f"/api/v1/users/current/tokens/{token_id}")
     assert response.status_code == 204
 
     response = client.get("/api/v1/users/current/tokens")


### PR DESCRIPTION
This update significantly enhances test execution efficiency by invoking the `migrate_db` function just once for all tests. More precisely with the changes running all tests took around **32 seconds** while running the tests on the main branch takes around **3 minutes and 15 seconds**. This optimization is accomplished by maintaining database changes in memory, rather than persisting them with `db.commit()`. Consequently, it is essential to expire all objects in scenarios where `db.commit()` would have been typically used. This approach introduces minimal overhead, given the limited number and frequency of object interactions during testing.
Additionally, some test cases have been modified to accommodate this change. They now rely on dynamic ids returned from the backend instead of static ids. With the database no longer resetting after each test, ids now increment continuously, necessitating this adjustment (i.e., even though we rollback the database after each test, the previously assigned ids can't be reassigned).

First step towards resolving #1179 