### PR TITLE
fix: Correctly call `psql` in probes

### DIFF
--- a/helm/templates/guacamole/postgres.deployment.yaml
+++ b/helm/templates/guacamole/postgres.deployment.yaml
@@ -54,12 +54,12 @@ spec:
               protocol: TCP
           readinessProbe:
             exec:
-              command: ["psql", "-W", "{{ .Values.database.guacamole.internal.password }}", "-U", "guacamole", "-d", "guacamole", "-c", "SELECT 1"]
+              command: ["psql", "-w", "-U", "guacamole", "-d", "guacamole", "-c", "SELECT 1"]
             initialDelaySeconds: 15
             timeoutSeconds: 2
           livenessProbe:
             exec:
-              command: ["psql", "-W", "{{ .Values.database.guacamole.internal.password }}", "-U", "guacamole", "-d", "guacamole", "-c", "SELECT 1"]
+              command: ["psql", "-w", "-U", "guacamole", "-d", "guacamole", "-c", "SELECT 1"]
             initialDelaySeconds: 45
             timeoutSeconds: 2
           resources:


### PR DESCRIPTION
The `-W` flag in psql is used to provide a password prompt to the user. However, this lead to a problem that the probes were no longer successful due to that. Chaning this to `-w' ensures that no prompt is given and additionally,
we don't need the password here.