### PR TITLE
refactor: Use dataclasses for all SQLAlchemy database classes

### DIFF
--- a/backend/capellacollab/core/database/__init__.py
+++ b/backend/capellacollab/core/database/__init__.py
@@ -17,7 +17,7 @@ engine = sa.create_engine(
 SessionLocal = orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-class Base(orm.DeclarativeBase):
+class Base(orm.MappedAsDataclass, orm.DeclarativeBase):
     type_annotation_map = {
         dict[str, str]: postgresql.JSONB,
         dict[str, t.Any]: postgresql.JSONB,

--- a/backend/capellacollab/events/crud.py
+++ b/backend/capellacollab/events/crud.py
@@ -26,14 +26,16 @@ def create_event(
         raise ValueError(
             f"Event type must of one of the following: {allowed_types}"
         )
+
     event = models.DatabaseUserHistoryEvent(
-        user_id=user.id,
+        user=user,
         event_type=event_type,
         execution_time=datetime.datetime.now(datetime.UTC),
-        executor_id=executor.id if executor else None,
-        project_id=project.id if project else None,
+        executor=executor,
+        project=project,
         reason=reason,
     )
+
     db.add(event)
     db.commit()
 

--- a/backend/capellacollab/health/routes.py
+++ b/backend/capellacollab/health/routes.py
@@ -107,7 +107,7 @@ def project_status(db: orm.Session = fastapi.Depends(database.get_db)):
 def _create_tool_model_status_tasks(
     db: orm.Session,
     logger: logging.LoggerAdapter,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
 ) -> models.ToolModelStatusTasks:
     return models.ToolModelStatusTasks(
         primary_git_repository_status=asyncio.create_task(

--- a/backend/capellacollab/notices/models.py
+++ b/backend/capellacollab/notices/models.py
@@ -34,7 +34,9 @@ class NoticeResponse(CreateNoticeRequest):
 class DatabaseNotice(database.Base):
     __tablename__ = "notices"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True, index=True)
+    id: orm.Mapped[int] = orm.mapped_column(
+        init=False, primary_key=True, index=True
+    )
     title: orm.Mapped[str]
     message: orm.Mapped[str]
     level: orm.Mapped[NoticeLevel]

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -14,7 +14,7 @@ from capellacollab.core import database
 from capellacollab.projects.users import models as project_users_models
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
     from capellacollab.projects.users.models import ProjectUserAssociation
 
 
@@ -105,20 +105,25 @@ class DatabaseProject(database.Base):
     __tablename__ = "projects"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        unique=True, primary_key=True, index=True
+        init=False, unique=True, primary_key=True, index=True
     )
 
     name: orm.Mapped[str] = orm.mapped_column(unique=True, index=True)
     slug: orm.Mapped[str] = orm.mapped_column(unique=True, index=True)
-    description: orm.Mapped[str | None]
-    visibility: orm.Mapped[Visibility]
-    type: orm.Mapped[ProjectType]
+
+    description: orm.Mapped[str | None] = orm.mapped_column(default=None)
+    visibility: orm.Mapped[Visibility] = orm.mapped_column(
+        default=Visibility.PRIVATE
+    )
+    type: orm.Mapped[ProjectType] = orm.mapped_column(
+        default=ProjectType.GENERAL
+    )
 
     users: orm.Mapped[list[ProjectUserAssociation]] = orm.relationship(
-        back_populates="project"
+        default_factory=list, back_populates="project"
     )
-    models: orm.Mapped[list[DatabaseCapellaModel]] = orm.relationship(
-        back_populates="project"
+    models: orm.Mapped[list[DatabaseToolModel]] = orm.relationship(
+        default_factory=list, back_populates="project"
     )
 
     is_archived: orm.Mapped[bool] = orm.mapped_column(default=False)

--- a/backend/capellacollab/projects/routes.py
+++ b/backend/capellacollab/projects/routes.py
@@ -73,7 +73,6 @@ def get_projects(
             )(association.project.slug, username, db)
         ]
 
-    log.debug("Fetching the following projects: %s", projects)
     return projects
 
 

--- a/backend/capellacollab/projects/toolmodels/backups/crud.py
+++ b/backend/capellacollab/projects/toolmodels/backups/crud.py
@@ -28,7 +28,7 @@ def get_pipeline_by_id(
 
 
 def get_pipelines_for_tool_model(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodels_models.DatabaseToolModel
 ) -> abc.Sequence[models.DatabaseBackup]:
     return (
         db.execute(
@@ -42,7 +42,7 @@ def get_pipelines_for_tool_model(
 
 
 def get_first_pipeline_for_tool_model(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodels_models.DatabaseToolModel
 ) -> models.DatabaseBackup | None:
     return (
         db.execute(

--- a/backend/capellacollab/projects/toolmodels/backups/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/backups/injectables.py
@@ -16,7 +16,7 @@ from . import crud, models
 
 def get_existing_pipeline(
     pipeline_id: int,
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/projects/toolmodels/backups/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/models.py
@@ -16,7 +16,7 @@ from capellacollab.projects.toolmodels.modelsources.t4c import (
 )
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
     from capellacollab.projects.toolmodels.modelsources.git.models import (
         DatabaseGitModel,
     )
@@ -51,7 +51,7 @@ class Backup(pydantic.BaseModel):
 class DatabaseBackup(database.Base):
     __tablename__ = "backups"
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True
+        init=False, primary_key=True, index=True, autoincrement=True
     )
 
     created_by: orm.Mapped[str]
@@ -64,17 +64,19 @@ class DatabaseBackup(database.Base):
     run_nightly: orm.Mapped[bool]
 
     git_model_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("git_models.id")
+        sa.ForeignKey("git_models.id"), init=False
     )
     git_model: orm.Mapped["DatabaseGitModel"] = orm.relationship()
 
     t4c_model_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("t4c_models.id")
+        sa.ForeignKey("t4c_models.id"), init=False
     )
     t4c_model: orm.Mapped["DatabaseT4CModel"] = orm.relationship()
 
-    model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped["DatabaseCapellaModel"] = orm.relationship()
+    model_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("models.id"), init=False
+    )
+    model: orm.Mapped["DatabaseToolModel"] = orm.relationship()
 
     runs: orm.Mapped[
         list["runs_models.DatabasePipelineRun"]
@@ -82,4 +84,5 @@ class DatabaseBackup(database.Base):
         "DatabasePipelineRun",
         back_populates="pipeline",
         cascade="all, delete-orphan",
+        default_factory=list,
     )

--- a/backend/capellacollab/projects/toolmodels/backups/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/routes.py
@@ -44,7 +44,7 @@ log = logging.getLogger(__name__)
 
 @router.get("", response_model=list[models.Backup])
 def get_pipelines(
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
@@ -67,7 +67,7 @@ def get_pipeline(
 @router.post("", response_model=models.Backup)
 def create_backup(
     body: models.CreateBackup,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/projects/toolmodels/backups/runs/models.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/models.py
@@ -28,31 +28,36 @@ class PipelineRunStatus(enum.Enum):
 class DatabasePipelineRun(Base):
     __tablename__ = "pipeline_run"
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True
+        init=False, primary_key=True, index=True, autoincrement=True
     )
-    reference_id: orm.Mapped[str | None]
 
     status: orm.Mapped[PipelineRunStatus]
 
     pipeline_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("backups.id")
+        sa.ForeignKey("backups.id"), init=False
     )
     pipeline: orm.Mapped[pipeline_models.DatabaseBackup] = orm.relationship(
         pipeline_models.DatabaseBackup
     )
 
     triggerer_id: orm.Mapped[str] = orm.mapped_column(
-        sa.ForeignKey("users.id")
+        sa.ForeignKey("users.id"), init=False
     )
     triggerer: orm.Mapped[users_models.DatabaseUser] = orm.relationship(
         users_models.DatabaseUser
     )
 
     trigger_time: orm.Mapped[datetime.datetime]
-    end_time: orm.Mapped[datetime.datetime | None]
-    logs_last_fetched_timestamp: orm.Mapped[datetime.datetime | None]
 
     environment: orm.Mapped[dict[str, str]]
+
+    reference_id: orm.Mapped[str | None] = orm.mapped_column(default=None)
+    end_time: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        default=None
+    )
+    logs_last_fetched_timestamp: orm.Mapped[
+        datetime.datetime | None
+    ] = orm.mapped_column(default=None)
 
 
 class PipelineRun(pydantic.BaseModel):

--- a/backend/capellacollab/projects/toolmodels/backups/validation.py
+++ b/backend/capellacollab/projects/toolmodels/backups/validation.py
@@ -10,7 +10,7 @@ from .runs import models as runs_models
 
 
 def check_last_pipeline_run_status(
-    db: orm.Session, model: toolmodel_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodel_models.DatabaseToolModel
 ) -> runs_models.PipelineRunStatus | None:
     if pipeline := crud.get_first_pipeline_for_tool_model(db, model):
         # Only consider first pipeline for monitoring, usually there is only one pipeline.

--- a/backend/capellacollab/projects/toolmodels/crud.py
+++ b/backend/capellacollab/projects/toolmodels/crud.py
@@ -14,17 +14,17 @@ from . import models
 from .restrictions import models as restrictions_models
 
 
-def get_models(db: orm.Session) -> abc.Sequence[models.DatabaseCapellaModel]:
-    return db.execute(sa.select(models.DatabaseCapellaModel)).scalars().all()
+def get_models(db: orm.Session) -> abc.Sequence[models.DatabaseToolModel]:
+    return db.execute(sa.select(models.DatabaseToolModel)).scalars().all()
 
 
 def get_models_by_version(
     db: orm.Session, version_id: int
-) -> abc.Sequence[models.DatabaseCapellaModel]:
+) -> abc.Sequence[models.DatabaseToolModel]:
     return (
         db.execute(
-            sa.select(models.DatabaseCapellaModel).where(
-                models.DatabaseCapellaModel.version_id == version_id
+            sa.select(models.DatabaseToolModel).where(
+                models.DatabaseToolModel.version_id == version_id
             )
         )
         .scalars()
@@ -34,11 +34,11 @@ def get_models_by_version(
 
 def get_models_by_nature(
     db: orm.Session, nature_id: int
-) -> abc.Sequence[models.DatabaseCapellaModel]:
+) -> abc.Sequence[models.DatabaseToolModel]:
     return (
         db.execute(
-            sa.select(models.DatabaseCapellaModel).where(
-                models.DatabaseCapellaModel.nature_id == nature_id
+            sa.select(models.DatabaseToolModel).where(
+                models.DatabaseToolModel.nature_id == nature_id
             )
         )
         .scalars()
@@ -48,11 +48,11 @@ def get_models_by_nature(
 
 def get_models_by_tool(
     db: orm.Session, tool_id: int
-) -> abc.Sequence[models.DatabaseCapellaModel]:
+) -> abc.Sequence[models.DatabaseToolModel]:
     return (
         db.execute(
-            sa.select(models.DatabaseCapellaModel).where(
-                models.DatabaseCapellaModel.tool_id == tool_id
+            sa.select(models.DatabaseToolModel).where(
+                models.DatabaseToolModel.tool_id == tool_id
             )
         )
         .scalars()
@@ -62,16 +62,16 @@ def get_models_by_tool(
 
 def get_model_by_slugs(
     db: orm.Session, project_slug: str, model_slug: str
-) -> models.DatabaseCapellaModel | None:
+) -> models.DatabaseToolModel | None:
     return db.execute(
-        sa.select(models.DatabaseCapellaModel)
-        .options(orm.joinedload(models.DatabaseCapellaModel.project))
+        sa.select(models.DatabaseToolModel)
+        .options(orm.joinedload(models.DatabaseToolModel.project))
         .where(
-            models.DatabaseCapellaModel.project.has(
+            models.DatabaseToolModel.project.has(
                 projects_model.DatabaseProject.slug == project_slug
             )
         )
-        .where(models.DatabaseCapellaModel.slug == model_slug)
+        .where(models.DatabaseToolModel.slug == model_slug)
     ).scalar_one_or_none()
 
 
@@ -84,10 +84,8 @@ def create_model(
     nature: tools_models.DatabaseNature | None = None,
     configuration: dict[str, str] | None = None,
     display_order: int | None = None,
-) -> models.DatabaseCapellaModel:
-    restrictions = restrictions_models.DatabaseToolModelRestrictions()
-
-    model = models.DatabaseCapellaModel(
+) -> models.DatabaseToolModel:
+    model = models.DatabaseToolModel(
         name=post_model.name,
         slug=slugify.slugify(post_model.name),
         description=post_model.description if post_model.description else "",
@@ -95,9 +93,12 @@ def create_model(
         tool=tool,
         version=version,
         nature=nature,
-        restrictions=restrictions,
         configuration=configuration,
         display_order=display_order,
+    )
+
+    restrictions = restrictions_models.DatabaseToolModelRestrictions(
+        model=model
     )
     db.add(restrictions)
     db.add(model)
@@ -107,9 +108,9 @@ def create_model(
 
 def set_tool_for_model(
     db: orm.Session,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     tool: tools_models.DatabaseTool,
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model.tool = tool
     db.commit()
     return model
@@ -117,10 +118,10 @@ def set_tool_for_model(
 
 def set_tool_details_for_model(
     db: orm.Session,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     version: tools_models.DatabaseVersion,
     nature: tools_models.DatabaseNature,
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model.version = version
     model.nature = nature
     db.commit()
@@ -129,14 +130,14 @@ def set_tool_details_for_model(
 
 def update_model(
     db: orm.Session,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     description: str | None,
     name: str | None,
-    version: tools_models.DatabaseVersion,
-    nature: tools_models.DatabaseNature,
+    version: tools_models.DatabaseVersion | None,
+    nature: tools_models.DatabaseNature | None,
     project: projects_model.DatabaseProject,
     display_order: int | None,
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model.version = version
     model.nature = nature
     model.project = project
@@ -151,6 +152,6 @@ def update_model(
     return model
 
 
-def delete_model(db: orm.Session, model: models.DatabaseCapellaModel):
+def delete_model(db: orm.Session, model: models.DatabaseToolModel):
     db.delete(model)
     db.commit()

--- a/backend/capellacollab/projects/toolmodels/diagrams/validation.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/validation.py
@@ -12,7 +12,7 @@ import capellacollab.projects.toolmodels.modelsources.git.validation as git_vali
 
 async def check_diagram_cache_health(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     logger: logging.LoggerAdapter,
 ) -> git_models.ModelArtifactStatus:
     return await git_validation.check_pipeline_health(

--- a/backend/capellacollab/projects/toolmodels/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/injectables.py
@@ -18,7 +18,7 @@ def get_existing_capella_model(
         projects_injectables.get_existing_project
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> models.DatabaseCapellaModel:
+) -> models.DatabaseToolModel:
     model = crud.get_model_by_slugs(db, project.slug, model_slug)
     if not model:
         raise fastapi.HTTPException(

--- a/backend/capellacollab/projects/toolmodels/modelbadge/validation.py
+++ b/backend/capellacollab/projects/toolmodels/modelbadge/validation.py
@@ -12,7 +12,7 @@ import capellacollab.projects.toolmodels.modelsources.git.validation as git_vali
 
 async def check_model_badge_health(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     logger: logging.LoggerAdapter,
 ) -> git_models.ModelArtifactStatus:
     return await git_validation.check_pipeline_health(

--- a/backend/capellacollab/projects/toolmodels/models.py
+++ b/backend/capellacollab/projects/toolmodels/models.py
@@ -62,12 +62,12 @@ class ToolDetails(pydantic.BaseModel):
     nature_id: int
 
 
-class DatabaseCapellaModel(database.Base):
+class DatabaseToolModel(database.Base):
     __tablename__ = "models"
     __table_args__ = (sa.UniqueConstraint("project_id", "slug"),)
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, unique=True
+        init=False, primary_key=True, index=True, unique=True
     )
 
     name: orm.Mapped[str] = orm.mapped_column(index=True)
@@ -78,36 +78,47 @@ class DatabaseCapellaModel(database.Base):
     configuration: orm.Mapped[dict[str, str] | None]
 
     project_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("projects.id")
+        sa.ForeignKey("projects.id"), init=False
     )
     project: orm.Mapped[DatabaseProject] = orm.relationship(
         back_populates="models"
     )
 
-    tool_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("tools.id"))
+    tool_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("tools.id"), init=False
+    )
     tool: orm.Mapped[DatabaseTool] = orm.relationship()
 
     version_id: orm.Mapped[int | None] = orm.mapped_column(
-        sa.ForeignKey("versions.id")
+        sa.ForeignKey("versions.id"), init=False
     )
-    version: orm.Mapped[DatabaseVersion] = orm.relationship()
+    version: orm.Mapped[DatabaseVersion | None] = orm.relationship(
+        default=None
+    )
 
     nature_id: orm.Mapped[int | None] = orm.mapped_column(
-        sa.ForeignKey("types.id")
+        sa.ForeignKey("types.id"), init=False
     )
-    nature: orm.Mapped[DatabaseNature] = orm.relationship()
+    nature: orm.Mapped[DatabaseNature | None] = orm.relationship(default=None)
 
-    editing_mode: orm.Mapped[EditingMode | None]
+    editing_mode: orm.Mapped[EditingMode | None] = orm.mapped_column(
+        default=None
+    )
 
     t4c_models: orm.Mapped[list[DatabaseT4CModel]] = orm.relationship(
-        back_populates="model"
+        default_factory=list, back_populates="model"
     )
     git_models: orm.Mapped[list[DatabaseGitModel]] = orm.relationship(
-        back_populates="model"
+        default_factory=list, back_populates="model"
     )
 
-    restrictions: orm.Mapped[DatabaseToolModelRestrictions] = orm.relationship(
-        back_populates="model", uselist=False, cascade="delete"
+    restrictions: orm.Mapped[
+        DatabaseToolModelRestrictions | None
+    ] = orm.relationship(
+        back_populates="model",
+        uselist=False,
+        cascade="delete",
+        default=None,
     )
 
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/crud.py
@@ -30,13 +30,13 @@ def get_primary_git_model_of_capellamodel(
 
 def add_git_model_to_capellamodel(
     db: orm.Session,
-    capella_model: toolsmodels_models.DatabaseCapellaModel,
+    capella_model: toolsmodels_models.DatabaseToolModel,
     post_git_model: models.PostGitModel,
 ) -> models.DatabaseGitModel:
     primary = not get_primary_git_model_of_capellamodel(db, capella_model.id)
 
     git_model = models.DatabaseGitModel.from_post_git_model(
-        capella_model.id, primary, post_git_model
+        capella_model, primary, post_git_model
     )
 
     db.add(git_model)

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/injectables.py
@@ -20,7 +20,7 @@ from .handler import factory, handler
 
 def get_existing_git_model(
     git_model_id: int,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
@@ -39,7 +39,7 @@ def get_existing_git_model(
 
 
 def get_existing_primary_git_model(
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/models.py
@@ -12,7 +12,7 @@ from sqlalchemy import orm
 from capellacollab.core import database
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
 
 
 class PostGitModel(pydantic.BaseModel):
@@ -43,7 +43,7 @@ class DatabaseGitModel(database.Base):
     __tablename__ = "git_models"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True
+        init=False, primary_key=True, index=True, autoincrement=True
     )
     name: orm.Mapped[str]
     path: orm.Mapped[str]
@@ -51,8 +51,10 @@ class DatabaseGitModel(database.Base):
     revision: orm.Mapped[str]
     primary: orm.Mapped[bool]
 
-    model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped["DatabaseCapellaModel"] = orm.relationship(
+    model_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("models.id"), init=False
+    )
+    model: orm.Mapped["DatabaseToolModel"] = orm.relationship(
         back_populates="git_models"
     )
 
@@ -61,12 +63,12 @@ class DatabaseGitModel(database.Base):
 
     @classmethod
     def from_post_git_model(
-        cls, model_id: int, primary: bool, new_model: PostGitModel
+        cls, model: "DatabaseToolModel", primary: bool, new_model: PostGitModel
     ):
         return cls(
             name="",
             primary=primary,
-            model_id=model_id,
+            model=model,
             **new_model.model_dump(),
         )
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
@@ -66,7 +66,7 @@ def validate_path(
 
 @router.get("", response_model=list[models.GitModel])
 def get_git_models(
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
 ) -> list[models.DatabaseGitModel]:
@@ -151,7 +151,7 @@ async def get_revisions_with_model_credentials(
 )
 def create_git_model(
     post_git_model: models.PostGitModel,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/validation.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/validation.py
@@ -15,7 +15,7 @@ from .handler import factory
 
 async def check_primary_git_repository(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     log: logging.LoggerAdapter,
 ) -> models.GitModelStatus:
     primary_repo = crud.get_primary_git_model_of_capellamodel(db, model.id)
@@ -43,7 +43,7 @@ async def check_primary_git_repository(
 
 async def check_pipeline_health(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     job_name: str,
     logger: logging.LoggerAdapter,
 ) -> models.ModelArtifactStatus:

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/crud.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/crud.py
@@ -29,7 +29,7 @@ def get_t4c_models(db: orm.Session) -> abc.Sequence[models.DatabaseT4CModel]:
 
 
 def get_t4c_models_for_tool_model(
-    db: orm.Session, model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, model: toolmodels_models.DatabaseToolModel
 ) -> abc.Sequence[models.DatabaseT4CModel]:
     return (
         db.execute(
@@ -44,7 +44,7 @@ def get_t4c_models_for_tool_model(
 
 def create_t4c_model(
     db: orm.Session,
-    model: toolmodels_models.DatabaseCapellaModel,
+    model: toolmodels_models.DatabaseToolModel,
     repository: repositories_models.DatabaseT4CRepository,
     name: str,
 ) -> models.DatabaseT4CModel:

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/injectables.py
@@ -16,7 +16,7 @@ from . import crud, models
 
 def get_existing_t4c_model(
     t4c_model_id: int,
-    capella_model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    capella_model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/models.py
@@ -15,7 +15,7 @@ from capellacollab.settings.modelsources.t4c.repositories import (
 )
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
     from capellacollab.settings.modelsources.t4c.repositories.models import (
         DatabaseT4CRepository,
     )
@@ -28,19 +28,21 @@ class DatabaseT4CModel(database.Base):
     )
 
     id: orm.Mapped[int] = orm.mapped_column(
-        unique=True, primary_key=True, index=True
+        init=False, unique=True, primary_key=True, index=True
     )
     name: orm.Mapped[str] = orm.mapped_column(index=True)
 
     repository_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("t4c_repositories.id")
+        sa.ForeignKey("t4c_repositories.id"), init=False
     )
     repository: orm.Mapped[DatabaseT4CRepository] = orm.relationship(
         back_populates="models"
     )
 
-    model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped[DatabaseCapellaModel] = orm.relationship(
+    model_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("models.id"), init=False
+    )
+    model: orm.Mapped[DatabaseToolModel] = orm.relationship(
         back_populates="t4c_models"
     )
 

--- a/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/t4c/routes.py
@@ -41,7 +41,7 @@ router = fastapi.APIRouter(
     response_model=list[models.T4CModel],
 )
 def list_t4c_models(
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
@@ -74,7 +74,7 @@ def get_t4c_model(
 )
 def create_t4c_model(
     body: models.SubmitT4CModel,
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),

--- a/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
@@ -10,8 +10,10 @@ from . import models
 
 
 def get_model_restrictions(
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
-) -> models.DatabaseToolModelRestrictions:
-    return model.restrictions
+) -> models.DatabaseToolModelRestrictions | None:
+    restrictions = model.restrictions
+    assert restrictions  # restrictions are only None for a short time during creation
+    return restrictions

--- a/backend/capellacollab/projects/toolmodels/restrictions/models.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/models.py
@@ -12,7 +12,7 @@ from sqlalchemy import orm
 from capellacollab.core import database
 
 if t.TYPE_CHECKING:
-    from capellacollab.projects.toolmodels.models import DatabaseCapellaModel
+    from capellacollab.projects.toolmodels.models import DatabaseToolModel
 
 
 class ToolModelRestrictions(pydantic.BaseModel):
@@ -28,11 +28,13 @@ class DatabaseToolModelRestrictions(database.Base):
     __tablename__ = "model_restrictions"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, unique=True
+        init=False, primary_key=True, index=True, unique=True
     )
 
-    model_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("models.id"))
-    model: orm.Mapped[DatabaseCapellaModel] = orm.relationship(
+    model_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("models.id"), init=False
+    )
+    model: orm.Mapped[DatabaseToolModel] = orm.relationship(
         back_populates="restrictions"
     )
 

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -41,12 +41,16 @@ def update_restrictions(
     restrictions: models.DatabaseToolModelRestrictions = fastapi.Depends(
         injectables.get_model_restrictions
     ),
-    model: toolmodels_models.DatabaseCapellaModel = fastapi.Depends(
+    model: toolmodels_models.DatabaseToolModel = fastapi.Depends(
         toolmodels_injectables.get_existing_capella_model
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseToolModelRestrictions:
-    if body.allow_pure_variants and not model.tool.integrations.pure_variants:
+    if (
+        body.allow_pure_variants
+        and model.tool.integrations
+        and not model.tool.integrations.pure_variants
+    ):
         raise fastapi.HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={

--- a/backend/capellacollab/projects/toolmodels/validation.py
+++ b/backend/capellacollab/projects/toolmodels/validation.py
@@ -5,7 +5,7 @@ from . import models
 
 
 def calculate_model_warnings(
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
 ) -> list[str]:
     warnings = []
     if not model.nature:

--- a/backend/capellacollab/projects/toolmodels/workspace.py
+++ b/backend/capellacollab/projects/toolmodels/workspace.py
@@ -10,7 +10,7 @@ from . import models
 def create_shared_workspace(
     name: str,
     project: projects_models.DatabaseProject,
-    model: models.DatabaseCapellaModel,
+    model: models.DatabaseToolModel,
     size: str,
 ):
     operators.get_operator().create_persistent_volume(

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -53,14 +53,14 @@ class ProjectUserAssociation(database.Base):
     __tablename__ = "project_user_association"
 
     user_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("users.id"), primary_key=True
+        sa.ForeignKey("users.id"), primary_key=True, init=False
     )
     user: orm.Mapped["DatabaseUser"] = orm.relationship(
         back_populates="projects"
     )
 
     project_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("projects.id"), primary_key=True
+        sa.ForeignKey("projects.id"), primary_key=True, init=False
     )
     project: orm.Mapped["DatabaseProject"] = orm.relationship(
         back_populates="users"

--- a/backend/capellacollab/sessions/hooks/jupyter.py
+++ b/backend/capellacollab/sessions/hooks/jupyter.py
@@ -136,7 +136,7 @@ class JupyterIntegration(interface.HookRegistration):
 
     def _is_project_member(
         self,
-        model: toolmodels_models.DatabaseCapellaModel,
+        model: toolmodels_models.DatabaseToolModel,
         username: str,
         db: orm.Session,
     ) -> bool:
@@ -147,7 +147,7 @@ class JupyterIntegration(interface.HookRegistration):
 
     def _has_project_write_access(
         self,
-        model: toolmodels_models.DatabaseCapellaModel,
+        model: toolmodels_models.DatabaseToolModel,
         username: str,
         db: orm.Session,
     ) -> bool:

--- a/backend/capellacollab/sessions/hooks/pure_variants.py
+++ b/backend/capellacollab/sessions/hooks/pure_variants.py
@@ -82,7 +82,7 @@ class PureVariantsIntegration(interface.HookRegistration):
 
     def _model_allows_pure_variants(
         self,
-        model: toolmodels_models.DatabaseCapellaModel,
+        model: toolmodels_models.DatabaseToolModel,
     ):
         return model.restrictions and model.restrictions.allow_pure_variants
 

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -94,35 +94,46 @@ class GuacamoleAuthentication(pydantic.BaseModel):
 class DatabaseSession(database.Base):
     __tablename__ = "sessions"
 
+    # Since the sessions are not persistent, we use a UUID as the primary key
     id: orm.Mapped[str] = orm.mapped_column(primary_key=True, index=True)
 
     ports: orm.Mapped[list[int]] = orm.mapped_column(sa.ARRAY(sa.Integer))
     created_at: orm.Mapped[datetime.datetime]
 
-    rdp_password: orm.Mapped[str | None]
-    guacamole_username: orm.Mapped[str | None]
-    guacamole_password: orm.Mapped[str | None]
-    guacamole_connection_id: orm.Mapped[str | None]
-
     host: orm.Mapped[str]
     type: orm.Mapped[WorkspaceType]
 
     owner_name: orm.Mapped[str] = orm.mapped_column(
-        sa.ForeignKey("users.name")
+        sa.ForeignKey("users.name"), init=False
     )
     owner: orm.Mapped[DatabaseUser] = orm.relationship()
 
-    tool_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("tools.id"))
+    tool_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("tools.id"), init=False
+    )
     tool: orm.Mapped[DatabaseTool] = orm.relationship()
 
     version_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("versions.id")
+        sa.ForeignKey("versions.id"), init=False
     )
     version: orm.Mapped[DatabaseVersion] = orm.relationship()
 
     project_id: orm.Mapped[str | None] = orm.mapped_column(
-        sa.ForeignKey("projects.id")
+        sa.ForeignKey("projects.id"), init=False
     )
-    project: orm.Mapped[projects_models.DatabaseProject] = orm.relationship()
+    project: orm.Mapped[
+        projects_models.DatabaseProject | None
+    ] = orm.relationship()
 
     environment: orm.Mapped[dict[str, str] | None]
+
+    rdp_password: orm.Mapped[str | None] = orm.mapped_column(default=None)
+    guacamole_username: orm.Mapped[str | None] = orm.mapped_column(
+        default=None
+    )
+    guacamole_password: orm.Mapped[str | None] = orm.mapped_column(
+        default=None
+    )
+    guacamole_connection_id: orm.Mapped[str | None] = orm.mapped_column(
+        default=None
+    )

--- a/backend/capellacollab/settings/configuration/models.py
+++ b/backend/capellacollab/settings/configuration/models.py
@@ -14,7 +14,7 @@ class DatabaseConfiguration(database.Base):
     __tablename__ = "configuration"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        unique=True, primary_key=True, index=True
+        init=False, unique=True, primary_key=True, index=True
     )
 
     name: orm.Mapped[str] = orm.mapped_column(unique=True, index=True)

--- a/backend/capellacollab/settings/integrations/purevariants/models.py
+++ b/backend/capellacollab/settings/integrations/purevariants/models.py
@@ -28,7 +28,9 @@ def validate_license_url(value: str | None):
 class DatabasePureVariantsLicenses(database.Base):
     __tablename__ = "pure_variants"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True, index=True)
+    id: orm.Mapped[int] = orm.mapped_column(
+        init=False, primary_key=True, index=True
+    )
     license_server_url: orm.Mapped[str | None]
     license_key_filename: orm.Mapped[str | None]
 

--- a/backend/capellacollab/settings/modelsources/git/models.py
+++ b/backend/capellacollab/settings/modelsources/git/models.py
@@ -34,7 +34,7 @@ class DatabaseGitInstance(database.Base):
     __tablename__ = "git_instances"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True
+        init=False, primary_key=True, index=True, autoincrement=True
     )
 
     name: orm.Mapped[str]

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -46,38 +46,41 @@ class DatabaseT4CInstance(database.Base):
     __tablename__ = "t4c_instances"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True
+        init=False, primary_key=True, index=True, autoincrement=True
     )
 
     name: orm.Mapped[str] = orm.mapped_column(unique=True)
 
     license: orm.Mapped[str]
     host: orm.Mapped[str]
-    port: orm.Mapped[int] = orm.mapped_column(
-        sa.CheckConstraint("port >= 0 AND port <= 65535"), default=2036
-    )
-    cdo_port: orm.Mapped[int] = orm.mapped_column(
-        sa.CheckConstraint("cdo_port >= 0 AND cdo_port <= 65535"),
-        default=12036,
-    )
-    http_port: orm.Mapped[int | None] = orm.mapped_column(
-        sa.CheckConstraint("http_port >= 0 AND http_port <= 65535"),
-    )
+
     usage_api: orm.Mapped[str]
     rest_api: orm.Mapped[str]
     username: orm.Mapped[str]
     password: orm.Mapped[str]
 
-    protocol: orm.Mapped[Protocol] = orm.mapped_column(default=Protocol.tcp)
-
     version_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("versions.id")
+        sa.ForeignKey("versions.id"), init=False
     )
     version: orm.Mapped[DatabaseVersion] = orm.relationship()
 
     repositories: orm.Mapped[list[DatabaseT4CRepository]] = orm.relationship(
-        back_populates="instance", cascade="all, delete"
+        default_factory=list, back_populates="instance", cascade="all, delete"
     )
+
+    port: orm.Mapped[int] = orm.mapped_column(
+        sa.CheckConstraint("port >= 0 AND port <= 65535"), default=2036
+    )
+
+    http_port: orm.Mapped[int | None] = orm.mapped_column(
+        sa.CheckConstraint("http_port >= 0 AND http_port <= 65535"),
+        default=None,
+    )
+    cdo_port: orm.Mapped[int] = orm.mapped_column(
+        sa.CheckConstraint("cdo_port >= 0 AND cdo_port <= 65535"),
+        default=12036,
+    )
+    protocol: orm.Mapped[Protocol] = orm.mapped_column(default=Protocol.tcp)
 
     is_archived: orm.Mapped[bool] = orm.mapped_column(default=False)
 

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
@@ -82,9 +82,9 @@ def _get_user_write_t4c_repositories(
         sa.select(models.DatabaseT4CRepository)
         .join(models.DatabaseT4CRepository.models)
         .join(t4c_models.DatabaseT4CModel.model)
-        .join(toolmodels_models.DatabaseCapellaModel.version)
+        .join(toolmodels_models.DatabaseToolModel.version)
         .where(tools_models.DatabaseVersion.name == version_name)
-        .join(toolmodels_models.DatabaseCapellaModel.project)
+        .join(toolmodels_models.DatabaseToolModel.project)
         .where(projects_models.DatabaseProject.is_archived.is_(False))
         .join(projects_models.DatabaseProject.users)
         .where(
@@ -104,9 +104,9 @@ def _get_admin_t4c_repositories(
         sa.select(models.DatabaseT4CRepository)
         .join(models.DatabaseT4CRepository.models)
         .join(t4c_models.DatabaseT4CModel.model)
-        .join(toolmodels_models.DatabaseCapellaModel.version)
+        .join(toolmodels_models.DatabaseToolModel.version)
         .where(tools_models.DatabaseVersion.name == version_name)
-        .join(toolmodels_models.DatabaseCapellaModel.project)
+        .join(toolmodels_models.DatabaseToolModel.project)
         .where(projects_models.DatabaseProject.is_archived.is_(False))
     )
 

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/models.py
@@ -27,19 +27,25 @@ class DatabaseT4CRepository(database.Base):
     __table_args__ = (sa.UniqueConstraint("instance_id", "name"),)
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True, unique=True
+        init=False,
+        primary_key=True,
+        index=True,
+        autoincrement=True,
+        unique=True,
     )
     name: orm.Mapped[str]
 
     instance_id: orm.Mapped[int] = orm.mapped_column(
-        sa.ForeignKey("t4c_instances.id")
+        sa.ForeignKey("t4c_instances.id"), init=False
     )
     instance: orm.Mapped[DatabaseT4CInstance] = orm.relationship(
         back_populates="repositories"
     )
 
     models: orm.Mapped[list[DatabaseT4CModel]] = orm.relationship(
-        back_populates="repository", cascade="all, delete"
+        back_populates="repository",
+        cascade="all, delete",
+        default_factory=list,
     )
 
 

--- a/backend/capellacollab/settings/modelsources/t4c/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/routes.py
@@ -59,7 +59,10 @@ def create_t4c_instance(
         raise exceptions.T4CInstanceWithNameAlreadyExistsError()
 
     version = toolmodels_routes.get_version_by_id_or_raise(db, body.version_id)
-    instance = models.DatabaseT4CInstance(**body.model_dump())
+    body_dump = body.model_dump()
+    del body_dump["version_id"]
+
+    instance = models.DatabaseT4CInstance(version=version, **body_dump)
     instance.version = version
     return crud.create_t4c_instance(db, instance)
 

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -38,7 +38,7 @@ def create_tool(
     db: orm.Session, tool: models.DatabaseTool
 ) -> models.DatabaseTool:
     tool.integrations = integrations_models.DatabaseToolIntegrations(
-        pure_variants=False, t4c=False, jupyter=False
+        tool=tool, pure_variants=False, t4c=False, jupyter=False
     )
     db.add(tool)
     db.commit()
@@ -151,7 +151,7 @@ def update_version(
 
 def create_version(
     db: orm.Session,
-    tool_id: int,
+    tool: models.DatabaseTool,
     name: str,
     is_recommended: bool = False,
     is_deprecated: bool = False,
@@ -160,7 +160,7 @@ def create_version(
         name=name,
         is_recommended=is_recommended,
         is_deprecated=is_deprecated,
-        tool_id=tool_id,
+        tool=tool,
     )
     db.add(version)
     db.commit()
@@ -223,9 +223,9 @@ def get_natures_by_tool_id(
 
 
 def create_nature(
-    db: orm.Session, tool_id: int, name: str
+    db: orm.Session, tool: models.DatabaseTool, name: str
 ) -> models.DatabaseNature:
-    nature = models.DatabaseNature(name=name, tool_id=tool_id)
+    nature = models.DatabaseNature(name=name, tool=tool)
     db.add(nature)
     db.commit()
     return nature

--- a/backend/capellacollab/tools/integrations/models.py
+++ b/backend/capellacollab/tools/integrations/models.py
@@ -32,9 +32,11 @@ class PatchToolIntegrations(pydantic.BaseModel):
 class DatabaseToolIntegrations(database.Base):
     __tablename__ = "tool_integrations"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    id: orm.Mapped[int] = orm.mapped_column(init=False, primary_key=True)
 
-    tool_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("tools.id"))
+    tool_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("tools.id"), init=False
+    )
     tool: orm.Mapped[DatabaseTool] = orm.relationship(
         back_populates="integrations"
     )

--- a/backend/capellacollab/tools/integrations/routes.py
+++ b/backend/capellacollab/tools/integrations/routes.py
@@ -31,4 +31,5 @@ def update_integrations(
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseToolIntegrations:
+    assert tool.integrations
     return crud.update_integrations(db, tool.integrations, body)

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -20,22 +20,30 @@ if t.TYPE_CHECKING:
 class DatabaseTool(database.Base):
     __tablename__ = "tools"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    id: orm.Mapped[int] = orm.mapped_column(init=False, primary_key=True)
 
     name: orm.Mapped[str]
     docker_image_template: orm.Mapped[str]
-    docker_image_backup_template: orm.Mapped[str | None]
-    readonly_docker_image_template: orm.Mapped[str | None]
+    docker_image_backup_template: orm.Mapped[str | None] = orm.mapped_column(
+        default=None
+    )
+    readonly_docker_image_template: orm.Mapped[str | None] = orm.mapped_column(
+        default=None
+    )
+
+    integrations: orm.Mapped[
+        DatabaseToolIntegrations | None
+    ] = orm.relationship(
+        default=None,
+        back_populates="tool",
+        uselist=False,
+    )
 
     versions: orm.Mapped[list[DatabaseVersion]] = orm.relationship(
-        back_populates="tool"
+        default_factory=list, back_populates="tool"
     )
     natures: orm.Mapped[list[DatabaseNature]] = orm.relationship(
-        back_populates="tool"
-    )
-
-    integrations: orm.Mapped[DatabaseToolIntegrations] = orm.relationship(
-        back_populates="tool", uselist=False
+        default_factory=list, back_populates="tool"
     )
 
 
@@ -43,14 +51,15 @@ class DatabaseVersion(database.Base):
     __tablename__ = "versions"
     __table_args__ = (sa.UniqueConstraint("tool_id", "name"),)
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    id: orm.Mapped[int] = orm.mapped_column(init=False, primary_key=True)
 
     name: orm.Mapped[str]
     is_recommended: orm.Mapped[bool]
     is_deprecated: orm.Mapped[bool]
 
     tool_id: orm.Mapped[int | None] = orm.mapped_column(
-        sa.ForeignKey("tools.id")
+        sa.ForeignKey("tools.id"),
+        init=False,
     )
     tool: orm.Mapped[DatabaseTool] = orm.relationship(
         back_populates="versions"
@@ -61,11 +70,11 @@ class DatabaseNature(database.Base):
     __tablename__ = "types"
     __table_args__ = (sa.UniqueConstraint("tool_id", "name"),)
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True)
+    id: orm.Mapped[int] = orm.mapped_column(init=False, primary_key=True)
     name: orm.Mapped[str]
 
     tool_id: orm.Mapped[int | None] = orm.mapped_column(
-        sa.ForeignKey("tools.id")
+        sa.ForeignKey("tools.id"), init=False
     )
     tool: orm.Mapped[DatabaseTool] = orm.relationship(back_populates="natures")
 

--- a/backend/capellacollab/tools/routes.py
+++ b/backend/capellacollab/tools/routes.py
@@ -130,7 +130,7 @@ def create_tool_version(
     tool: models.DatabaseTool = fastapi.Depends(injectables.get_existing_tool),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseVersion:
-    return crud.create_version(db, tool.id, body.name)
+    return crud.create_version(db, tool, body.name)
 
 
 @router.patch(
@@ -194,11 +194,11 @@ def get_tool_natures(
     ],
 )
 def create_tool_nature(
-    tool_id: int,
     body: models.CreateToolNature,
+    tool: models.DatabaseTool = fastapi.Depends(injectables.get_existing_tool),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseNature:
-    return crud.create_nature(db, tool_id, body.name)
+    return crud.create_nature(db, tool, body.name)
 
 
 @router.delete(

--- a/backend/capellacollab/users/models.py
+++ b/backend/capellacollab/users/models.py
@@ -59,23 +59,34 @@ class PostUser(pydantic.BaseModel):
 class DatabaseUser(database.Base):
     __tablename__ = "users"
 
-    id: orm.Mapped[int] = orm.mapped_column(primary_key=True, index=True)
+    id: orm.Mapped[int] = orm.mapped_column(
+        init=False, primary_key=True, index=True
+    )
 
     name: orm.Mapped[str] = orm.mapped_column(unique=True, index=True)
     role: orm.Mapped[Role]
-    created: orm.Mapped[datetime.datetime | None]
-    last_login: orm.Mapped[datetime.datetime | None]
+    created: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        default=datetime.datetime.now(datetime.UTC)
+    )
 
     projects: orm.Mapped[list[ProjectUserAssociation]] = orm.relationship(
-        back_populates="user"
+        default_factory=list, back_populates="user"
     )
     sessions: orm.Mapped[list[DatabaseSession]] = orm.relationship(
-        back_populates="owner"
+        default_factory=list, back_populates="owner"
     )
     events: orm.Mapped[list[DatabaseUserHistoryEvent]] = orm.relationship(
-        back_populates="user", foreign_keys="DatabaseUserHistoryEvent.user_id"
+        default_factory=list,
+        back_populates="user",
+        foreign_keys="DatabaseUserHistoryEvent.user_id",
     )
 
     tokens: orm.Mapped[list[DatabaseUserToken]] = orm.relationship(
-        back_populates="user", cascade="all, delete-orphan"
+        default_factory=list,
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+    last_login: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
+        default=None
     )

--- a/backend/capellacollab/users/tokens/crud.py
+++ b/backend/capellacollab/users/tokens/crud.py
@@ -9,23 +9,24 @@ import sqlalchemy as sa
 from sqlalchemy import orm
 
 from capellacollab.core import credentials
+from capellacollab.users import models as users_models
 
 from . import models
 
 
 def create_token(
     db: orm.Session,
-    user_id: int,
+    user: users_models.DatabaseUser,
     description: str,
     expiration_date: datetime.date | None,
-    source: str | None,
+    source: str,
 ) -> tuple[models.DatabaseUserToken, str]:
     password = "collabmanager_" + credentials.generate_password(32)
     ph = argon2.PasswordHasher()
     if not expiration_date:
         expiration_date = datetime.date.today() + datetime.timedelta(days=30)
     db_token = models.DatabaseUserToken(
-        user_id=user_id,
+        user=user,
         hash=ph.hash(password),
         expiration_date=expiration_date,
         description=description,

--- a/backend/capellacollab/users/tokens/models.py
+++ b/backend/capellacollab/users/tokens/models.py
@@ -38,9 +38,11 @@ class DatabaseUserToken(database.Base):
     __tablename__ = "basic_auth_token"
 
     id: orm.Mapped[int] = orm.mapped_column(
-        primary_key=True, index=True, autoincrement=True
+        init=False, primary_key=True, index=True, autoincrement=True
     )
-    user_id: orm.Mapped[int] = orm.mapped_column(sa.ForeignKey("users.id"))
+    user_id: orm.Mapped[int] = orm.mapped_column(
+        sa.ForeignKey("users.id"), init=False
+    )
     user: orm.Mapped["DatabaseUser"] = orm.relationship(
         back_populates="tokens", foreign_keys=[user_id]
     )

--- a/backend/capellacollab/users/tokens/routes.py
+++ b/backend/capellacollab/users/tokens/routes.py
@@ -34,7 +34,7 @@ def create_token_for_user(
 ) -> models.UserTokenWithPassword:
     token, password = crud.create_token(
         db,
-        user.id,
+        user,
         post_token.description,
         post_token.expiration_date,
         post_token.source,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -132,7 +132,8 @@ module = [
   "alembic.*",
   "jwt.*",
   "argon2.*",
-  "websocket.*"
+  "websocket.*",
+  "testcontainers.*",
 ]
 ignore_missing_imports = true
 

--- a/backend/tests/projects/toolmodels/conftest.py
+++ b/backend/tests/projects/toolmodels/conftest.py
@@ -45,7 +45,7 @@ def fixture_capella_model(
     db: orm.Session,
     project: project_models.DatabaseProject,
     capella_tool_version: tools_models.DatabaseVersion,
-) -> toolmodels_models.DatabaseCapellaModel:
+) -> toolmodels_models.DatabaseToolModel:
     model = toolmodels_models.PostCapellaModel(
         name="test", description="test", tool_id=capella_tool_version.tool.id
     )
@@ -91,7 +91,7 @@ def fixture_git_instance(
 
 @pytest.fixture(name="git_model")
 def fixture_git_models(
-    db: orm.Session, capella_model: toolmodels_models.DatabaseCapellaModel
+    db: orm.Session, capella_model: toolmodels_models.DatabaseToolModel
 ) -> project_git_models.DatabaseGitModel:
     git_model = project_git_models.PostGitModel(
         path="https://example.com/test/project",
@@ -277,7 +277,7 @@ def fixture_t4c_repository(
 @pytest.fixture(name="t4c_model")
 def fixture_t4c_model(
     db: orm.Session,
-    capella_model: toolmodels_models.DatabaseCapellaModel,
+    capella_model: toolmodels_models.DatabaseToolModel,
     t4c_repository: settings_t4c_repositories_models.DatabaseT4CRepository,
 ) -> models_t4c_models.DatabaseT4CModel:
     return models_t4c_crud.create_t4c_model(

--- a/backend/tests/projects/toolmodels/test_toolmodel_routes.py
+++ b/backend/tests/projects/toolmodels/test_toolmodel_routes.py
@@ -43,7 +43,7 @@ def fixture_override_dependency():
 
 
 def test_rename_toolmodel_successful(
-    capella_model: toolmodels_models.DatabaseCapellaModel,
+    capella_model: toolmodels_models.DatabaseToolModel,
     project: projects_models.DatabaseProject,
     client: testclient.TestClient,
     executor_name: str,
@@ -89,7 +89,7 @@ def test_rename_toolmodel_where_name_already_exists(
 
 
 def test_update_toolmodel_order_successful(
-    capella_model: toolmodels_models.DatabaseCapellaModel,
+    capella_model: toolmodels_models.DatabaseToolModel,
     project: projects_models.DatabaseProject,
     client: testclient.TestClient,
     executor_name: str,

--- a/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
+++ b/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
@@ -73,7 +73,7 @@ def test_start_session(monkeypatch: pytest.MonkeyPatch):
     assert service_counter == 1
     assert disruption_budget_counter == 1
 
-    assert session["id"] == "testname"
+    assert session.id == "testname"
 
 
 def test_kill_session(monkeypatch: pytest.MonkeyPatch):

--- a/backend/tests/settings/conftest.py
+++ b/backend/tests/settings/conftest.py
@@ -15,7 +15,7 @@ from capellacollab.users import models as users_models
 @pytest.fixture(name="test_tool_version")
 def fixture_test_tool_version(db: orm.Session) -> tools_models.DatabaseVersion:
     tool = tools_crud.create_tool_with_name(db, "Test")
-    return tools_crud.create_version(db, tool.id, "test")
+    return tools_crud.create_version(db, tool, "test")
 
 
 @pytest.fixture(name="admin_user")


### PR DESCRIPTION
With dataclasses, a `__init__` function is created for all database classes. This adds autocomplete and code recommendations and type checkers like mypy can check the passed types.

Since the `__hash__` method was removed during this change, the intersection
method to get common projects doesn't work anymore. I changed it to a proper
database join, which is faster.

In addition, many type annotations were added. Some mypy and pylint errors
and warnings were fixed in the tests.


Resolves #1326 