### PR TITLE
ci: Reenable deprecation ESLint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -58,7 +58,7 @@ module.exports = {
         ],
         "unused-imports/no-unused-imports": "error",
         "no-console": ["error", { allow: ["error"] }],
-        "deprecation/deprecation": "warn",
+        "deprecation/deprecation": "error",
         "@angular-eslint/use-lifecycle-interface": "error",
       },
     },

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@
 
 import { NgModule } from '@angular/core';
 import { Data, RouterModule, Routes } from '@angular/router';
+import { authGuard } from 'src/app/general/auth/auth-guard/auth-guard.service';
 import { JobRunOverviewComponent } from 'src/app/projects/models/backup-settings/job-run-overview/job-run-overview.component';
 import { PipelineRunWrapperComponent } from 'src/app/projects/models/backup-settings/pipeline-runs/wrapper/pipeline-run-wrapper/pipeline-run-wrapper.component';
 import { ViewLogsDialogComponent } from 'src/app/projects/models/backup-settings/view-logs-dialog/view-logs-dialog.component';
@@ -18,7 +19,6 @@ import { BasicAuthTokenComponent } from 'src/app/users/basic-auth-token/basic-au
 import { UsersProfileComponent } from 'src/app/users/users-profile/users-profile.component';
 import { EventsComponent } from './events/events.component';
 import { AuthComponent } from './general/auth/auth/auth.component';
-import { AuthGuardService } from './general/auth/auth-guard/auth-guard.service';
 import { AuthRedirectComponent } from './general/auth/auth-redirect/auth-redirect.component';
 import { LogoutComponent } from './general/auth/logout/logout/logout.component';
 import { LogoutRedirectComponent } from './general/auth/logout/logout-redirect/logout-redirect.component';
@@ -51,7 +51,7 @@ import { SettingsComponent } from './settings/settings.component';
 const routes: Routes = [
   {
     path: '',
-    canActivate: [AuthGuardService],
+    canActivate: [authGuard],
     children: [
       {
         path: '',

--- a/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
+++ b/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
@@ -3,37 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Injectable } from '@angular/core';
+import { inject } from '@angular/core';
 import {
   ActivatedRouteSnapshot,
-  CanActivate,
+  CanActivateFn,
   RouterStateSnapshot,
-  UrlTree,
 } from '@angular/router';
-import { Observable } from 'rxjs';
 import { AuthService } from 'src/app/services/auth/auth.service';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class AuthGuardService implements CanActivate {
-  constructor(private authService: AuthService) {}
+export const authGuard: CanActivateFn = (
+  _route: ActivatedRouteSnapshot,
+  _state: RouterStateSnapshot,
+) => {
+  const authService = inject(AuthService);
 
-  canActivate(
-    _route: ActivatedRouteSnapshot,
-    _state: RouterStateSnapshot,
-  ):
-    | Observable<boolean | UrlTree>
-    | Promise<boolean | UrlTree>
-    | boolean
-    | UrlTree {
-    if (this.authService.isLoggedIn()) {
-      return true;
-    } else {
-      // Needs window.location, since Router.url isn't updated yet
-      this.authService.cacheCurrentPath(window.location.pathname);
-      this.authService.webSSO();
-      return false;
-    }
+  if (authService.isLoggedIn()) {
+    return true;
+  } else {
+    // Needs window.location, since Router.url isn't updated yet
+    authService.cacheCurrentPath(window.location.pathname);
+    authService.webSSO();
+    return false;
   }
-}
+};


### PR DESCRIPTION
We had to disable the deprecation rule due to many deprecated modules after an Angular update. After replacing all deprecated modules step by step, we can reenable the rule again.