### PR TITLE
chore: Remove debug message for job scheduling

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -43,9 +43,6 @@ async def schedule_refresh_and_trigger_pipeline_jobs(interval=5):
 
 
 def _schedule_pending_jobs():
-    log.debug(
-        "Scheduling jobs for pipelines in kubernetes cluster",
-    )
     with database.SessionLocal() as db:
         for pending_run in crud.get_pipelines_runs_by_status(
             db, models.PipelineRunStatus.PENDING


### PR DESCRIPTION
The debug messages has spammed the log, which is esp. annoying while developing as it constantly prints new messages into the pdb terminal.