### PR TITLE
fix: Add loading case for "Common projects"

### DIFF
--- a/backend/capellacollab/users/routes.py
+++ b/backend/capellacollab/users/routes.py
@@ -57,7 +57,8 @@ def get_user(
         raise fastapi.HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
-                "reason": "You have to have at least one project in common to get this information.",
+                "err_code": "NO_PROJECTS_IN_COMMON",
+                "reason": "You need at least one project in common to access the user profile of another user.",
             },
         )
 

--- a/frontend/src/app/users/users-profile/users-profile.component.html
+++ b/frontend/src/app/users/users-profile/users-profile.component.html
@@ -100,9 +100,9 @@
         <h3>Common Projects</h3>
         <mat-divider></mat-divider>
         <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
-          <ng-container
-            *ngIf="(commonProjects$ | async)?.length; else elseBlock"
-          >
+          @if ((commonProjects$ | async) === undefined) {
+            <span>Loading...</span>
+          } @else if ((commonProjects$ | async)?.length !== 0) {
             <div
               *ngFor="let project of commonProjects$ | async"
               class="collab-card !ml-0 cursor-pointer"
@@ -122,10 +122,9 @@
                 }
               </div>
             </div>
-          </ng-container>
-          <ng-template #elseBlock class="col-span-2"
-            ><br />You do not have any common projects.</ng-template
-          >
+          } @else {
+            You do not have any common projects.
+          }
         </div>
       </div>
     </div>


### PR DESCRIPTION
Before, the frontend has displayed "No common projects" while the client waited for the response from the server.

Instead, a simple "Loading..." is now displayed.