### PR TITLE
fix: Remove button touch target to prevent scrollbars

### DIFF
--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component.html
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component.html
@@ -37,7 +37,7 @@
       mat-raised-button
       (click)="showClipboardMessage()"
     >
-      <mat-icon class="m-0">content_copy</mat-icon>
+      <mat-icon class="!m-0">content_copy</mat-icon>
     </button>
     <button
       class="mt-auto self-end text-white"

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.component.html
@@ -50,7 +50,11 @@
   minute.
 </div>
 <div>
-  <button mat-stroked-button class="w-full" (click)="this.dialogRef.close()">
+  <button
+    mat-stroked-button
+    class="m-0 w-full"
+    (click)="this.dialogRef.close()"
+  >
     Close
   </button>
 </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -276,6 +276,11 @@ Angular Material Card Styles
   background-color: black !important;
 }
 
+/* https://github.com/angular/components/issues/26176 */
+.mat-mdc-button-touch-target {
+  display: none;
+}
+
 /*
 Option cards
 */


### PR DESCRIPTION
In some dialogs components, a scrollbar has appeared due to a touch target on the button, which was larger than the actual button itself.

To prevent similar cases, I'd disable it globally.