### PR TITLE
feat: Make resources configurable per tool

### DIFF
--- a/backend/capellacollab/alembic/versions/6c4ff61acc8e_add_resources_to_tools.py
+++ b/backend/capellacollab/alembic/versions/6c4ff61acc8e_add_resources_to_tools.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add resources to tools
+
+Revision ID: 6c4ff61acc8e
+Revises: 3ec39e345cc9
+Create Date: 2024-02-15 14:21:18.085411
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "6c4ff61acc8e"
+down_revision = "3ec39e345cc9"
+branch_labels = None
+depends_on = None
+
+
+t_tools = sa.Table(
+    "tools",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer()),
+    sa.Column("integrations", postgresql.JSONB(astext_type=sa.Text())),
+)
+
+t_tools_new = sa.Table(
+    "tools",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer()),
+    sa.Column("resources", postgresql.JSONB(astext_type=sa.Text())),
+)
+
+
+def upgrade():
+    op.add_column(
+        "tools",
+        sa.Column(
+            "resources",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+    connection = op.get_bind()
+    tools = connection.execute(sa.select(t_tools)).mappings().all()
+
+    for tool in tools:
+        if tool["integrations"]["jupyter"]:
+            resources = {
+                "cpu": {"requests": 1, "limits": 2},
+                "memory": {"requests": "500Mi", "limits": "3Gi"},
+            }
+        else:
+            resources = {
+                "cpu": {"requests": 0.4, "limits": 2},
+                "memory": {"requests": "1.6Gi", "limits": "6Gi"},
+            }
+
+        connection.execute(
+            sa.update(t_tools_new)
+            .where(t_tools_new.c.id == tool["id"])
+            .values(resources=resources)
+        )

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -201,6 +201,12 @@ def create_jupyter_tool(db: orm.Session, registry: str):
     jupyter = tools_models.CreateTool(
         name="Jupyter",
         integrations=tools_models.ToolIntegrations(jupyter=True),
+        resources=tools_models.Resources(
+            cpu=tools_models.CPUResources(requests=1, limits=2),
+            memory=tools_models.MemoryResources(
+                requests="500Mi", limits="3Gi"
+            ),
+        ),
     )
     jupyter_database = tools_crud.create_tool(db, jupyter)
 

--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -10,6 +10,7 @@ from sqlalchemy import orm
 
 import capellacollab.settings.modelsources.t4c.repositories.interface as t4c_repository_interface
 from capellacollab.core.authentication import injectables as auth_injectables
+from capellacollab.projects.toolmodels import models as toolmodels_models
 from capellacollab.projects.toolmodels.modelsources.git import (
     models as git_models,
 )
@@ -22,6 +23,17 @@ from capellacollab.users import models as users_models
 from . import crud, exceptions, models
 
 log = logging.getLogger(__name__)
+
+
+def get_pipeline_labels(
+    model: toolmodels_models.DatabaseToolModel,
+) -> dict[str, str]:
+    return {
+        "app.capellacollab/projectSlug": model.project.slug,
+        "app.capellacollab/projectID": str(model.project.id),
+        "app.capellacollab/modelSlug": model.slug,
+        "app.capellacollab/modelID": str(model.id),
+    }
 
 
 def get_environment(

--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -19,6 +19,7 @@ from capellacollab.projects.toolmodels.backups import core as backups_core
 from capellacollab.sessions import operators
 from capellacollab.tools import crud as tools_crud
 
+from .. import core as pipelines_core
 from . import crud, models
 
 log = logging.getLogger(__name__)
@@ -64,11 +65,8 @@ def _schedule_pending_jobs():
                         db, model.version_id
                     ),
                     command="backup",
-                    labels={
-                        "app.capellacollab/projectSlug": model.project.slug,
-                        "app.capellacollab/projectID": str(model.project.id),
-                        "app.capellacollab/modelSlug": model.slug,
-                        "app.capellacollab/modelID": str(model.id),
+                    labels=pipelines_core.get_pipeline_labels(model)
+                    | {
                         "app.capellacollab/pipelineID": str(
                             pending_run.pipeline.id
                         ),

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -46,11 +46,7 @@ def update_restrictions(
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ) -> models.DatabaseToolModelRestrictions:
-    if (
-        body.allow_pure_variants
-        and model.tool.integrations
-        and not model.tool.integrations.pure_variants
-    ):
+    if body.allow_pure_variants and not model.tool.integrations.pure_variants:
         raise fastapi.HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={

--- a/backend/capellacollab/projects/toolmodels/routes.py
+++ b/backend/capellacollab/projects/toolmodels/routes.py
@@ -231,8 +231,7 @@ def delete_tool_model(
         )
 
     if (
-        model.tool.integrations
-        and model.tool.integrations.jupyter
+        model.tool.integrations.jupyter
         and model.configuration
         and "workspace" in model.configuration
     ):

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -211,9 +211,9 @@ def request_readonly_session(
     session = operator.start_session(
         image=docker_image,
         username=db_user.name,
-        session_type="readonly",
-        tool_name=model.tool.name,
-        version_name=model.version.name,
+        session_type=models.WorkspaceType.READONLY,
+        tool=model.tool,
+        version=model.version,
         volumes=[
             operators_models.EmptyVolume(
                 name="workspace",
@@ -410,15 +410,14 @@ def start_persistent_jupyter_session(
     session = operator.start_session(
         image=docker_image,
         username=owner.name,
-        session_type="persistent",
-        tool_name=tool.name,
-        version_name=version.name,
+        session_type=models.WorkspaceType.PERSISTENT,
+        tool=tool,
+        version=version,
         environment=environment,
         ports={"http": 8888},
         volumes=volumes,
         prometheus_path=f"{environment.get('JUPYTER_BASE_URL')}/metrics",
         prometheus_port=8888,
-        limits="low",
     )
 
     return create_database_session(
@@ -450,9 +449,9 @@ def start_persistent_guacamole_session(
     session = operator.start_session(
         image=docker_image,
         username=user.name,
-        session_type="persistent",
-        tool_name=tool.name,
-        version_name=version.name,
+        session_type=models.WorkspaceType.PERSISTENT,
+        tool=tool,
+        version=version,
         environment=environment,
         ports={"rdp": 3389, "metrics": 9118},
         volumes=volumes,

--- a/backend/capellacollab/tools/crud.py
+++ b/backend/capellacollab/tools/crud.py
@@ -37,7 +37,9 @@ def create_tool(
     db: orm.Session, tool: models.CreateTool
 ) -> models.DatabaseTool:
     database_tool = tools_models.DatabaseTool(
-        name=tool.name, integrations=tool.integrations
+        name=tool.name,
+        integrations=tool.integrations,
+        resources=tool.resources,
     )
     db.add(database_tool)
     db.commit()

--- a/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
+++ b/backend/tests/projects/toolmodels/pipelines/test_pipelines.py
@@ -28,11 +28,8 @@ class MockOperator:
 
     def create_cronjob(
         self,
-        image: str,
-        command: str,
-        environment: dict[str, str | None],
-        schedule="* * * * *",
-        timeout=18000,
+        *args,
+        **kwargs,
     ) -> str:
         self.cronjob_counter += 1
         return self._generate_id()

--- a/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
+++ b/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
@@ -8,7 +8,9 @@ import pytest
 from kubernetes import client
 from kubernetes.client import exceptions
 
+from capellacollab.sessions import models as sessions_models
 from capellacollab.sessions.operators import k8s
+from capellacollab.tools import models as tools_models
 
 
 def test_start_session(monkeypatch: pytest.MonkeyPatch):
@@ -58,12 +60,13 @@ def test_start_session(monkeypatch: pytest.MonkeyPatch):
         create_namespaced_pod_disruption_budget,
     )
 
+    tool = tools_models.DatabaseTool(name="testtool")
     session = operator.start_session(
         image="hello-world",
         username="testuser",
-        session_type="persistent",
-        tool_name="test tool",
-        version_name="test version",
+        session_type=sessions_models.WorkspaceType.PERSISTENT,
+        tool=tool,
+        version=tools_models.DatabaseVersion(name="testversion", tool=tool),
         environment={},
         ports={"rdp": 3389},
         volumes=[],
@@ -111,6 +114,7 @@ def test_create_job(monkeypatch: pytest.MonkeyPatch):
         command="fakecmd",
         labels={"key": "value"},
         environment={"ENVVAR": "value"},
+        tool_resources=tools_models.Resources(),
     )
 
     assert result
@@ -127,6 +131,8 @@ def test_create_cronjob(monkeypatch: pytest.MonkeyPatch):
         image="fakeimage",
         command="fakecmd",
         environment={"ENVVAR": "value"},
+        labels={},
+        tool_resources=tools_models.Resources(),
     )
 
     assert result

--- a/backend/tests/sessions/test_sessions_routes.py
+++ b/backend/tests/sessions/test_sessions_routes.py
@@ -89,15 +89,14 @@ class MockOperator:
         self,
         image: str,
         username: str,
-        session_type: str,
-        tool_name: str,
-        version_name: str,
+        session_type: sessions_models.WorkspaceType,
+        tool: tools_models.DatabaseTool,
+        version: tools_models.DatabaseVersion,
         environment: dict[str, str],
         ports: dict[str, int],
         volumes: list[operators_models.Volume],
         prometheus_path="/metrics",
         prometheus_port=9118,
-        limits="high",
     ) -> k8s.Session:
         assert image
         self.sessions.append(


### PR DESCRIPTION
Instead of the hard-coded resource configuration, it can now be set per tool.

In addition, this commit adds job labels to cronjobs.

Resolves #1136.