### PR TITLE
build: Remove `environment.prod.ts`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,10 +45,6 @@ jobs:
         if: ${{ matrix.name == 'frontend' }}
         run: |
           python frontend/fetch-version.py
-      - name: Prepare environment.prod.ts
-        if: ${{ matrix.name == 'frontend' }}
-        run: |
-          cp frontend/src/environments/environment.ts frontend/src/environments/environment.prod.ts
       - name: Login to github container registry
         uses: docker/login-action@v3
         with:

--- a/ci-templates/gitlab/image-builder.yml
+++ b/ci-templates/gitlab/image-builder.yml
@@ -4,30 +4,30 @@
 variables:
   PRIVATE_GPG_PATH: /secrets/private.gpg
   FRONTEND:
-    value: "1"
-    description: "Build the frontend image?"
+    value: '1'
+    description: 'Build the frontend image?'
   BACKEND:
-    value: "1"
-    description: "Build the backend image?"
+    value: '1'
+    description: 'Build the backend image?'
   DOCS:
-    value: "1"
-    description: "Build the docs image?"
+    value: '1'
+    description: 'Build the docs image?'
   GUACAMOLE:
-    value: "1"
-    description: "Build the guacamole image?"
+    value: '1'
+    description: 'Build the guacamole image?'
   REVISION:
-    value: "main"
-    description: "Revision of Github repository"
+    value: 'main'
+    description: 'Revision of Github repository'
   TARGET:
     value: staging
-  FRONTEND_IMAGE_NAME: "capella/collab/frontend"
-  BACKEND_IMAGE_NAME: "capella/collab/backend"
-  DOCS_IMAGE_NAME: "capella/collab/docs"
-  GUACAMOLE_IMAGE_NAME: "capella/collab/guacamole"
-  DOCKER_BUILD_ARGS: "--no-cache"
-  DOCKER_BUILDKIT: "1"
-  BASE_IMAGE: "debian:bookworm"
-  KUBECTL_APT_REMOTE: "https://apt.kubernetes.io/"
+  FRONTEND_IMAGE_NAME: 'capella/collab/frontend'
+  BACKEND_IMAGE_NAME: 'capella/collab/backend'
+  DOCS_IMAGE_NAME: 'capella/collab/docs'
+  GUACAMOLE_IMAGE_NAME: 'capella/collab/guacamole'
+  DOCKER_BUILD_ARGS: '--no-cache'
+  DOCKER_BUILDKIT: '1'
+  BASE_IMAGE: 'debian:bookworm'
+  KUBECTL_APT_REMOTE: 'https://apt.kubernetes.io/'
 
 default:
   image: $DOCKER_REGISTRY/base
@@ -58,8 +58,7 @@ default:
 
 .push: &push
   - >
-    if [ "${REVISION}" = "main" ];
-    then
+    if [ "${REVISION}" = "main" ]; then
       docker image tag ${IMAGE}:${DOCKER_TAG} ${IMAGE}:latest;
       docker push ${IMAGE}:latest;
     fi
@@ -80,7 +79,6 @@ frontend:
     - IMAGE=${DOCKER_REGISTRY}/${FRONTEND_IMAGE_NAME:?}
     - *docker
     - mv ../favicon.ico frontend/src
-    - mv ../environment.prod.ts frontend/src/environments
     - npm i undici
     - python frontend/fetch-version.py
     - >
@@ -144,4 +142,4 @@ guacamole:
         guacamole
     - *push
   variables:
-    DEBIAN_SLIM_BASE_IMAGE: "debian:bookworm-slim"
+    DEBIAN_SLIM_BASE_IMAGE: 'debian:bookworm-slim'

--- a/docs/docs/admin/ci-templates/gitlab/k8s-deploy.md
+++ b/docs/docs/admin/ci-templates/gitlab/k8s-deploy.md
@@ -64,7 +64,6 @@ The tree inside of your Gitlab repository should look like:
 ```zsh
 ├── .gitlab-ci.yml
 ├── .sops.yaml
-├── environment.prod.ts
 ├── favicon.ico
 ├── target1
 │   ├── general.values.yaml

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -69,12 +69,6 @@
                   "maximumError": "4kb"
                 }
               ],
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.prod.ts"
-                }
-              ],
               "outputHashing": "all"
             },
             "development": {


### PR DESCRIPTION
The `environment.ts` doesn't contain any user-defined variables anymore. They were all moved to the backend configuration.

Therefore, we can remove the option to customize the `environment.prod.ts`