### PR TITLE
fix: Reenable uvicorn error logger

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -68,7 +68,6 @@ async def startup():
     operators.get_operator()
 
     logging.getLogger("uvicorn.access").disabled = True
-    logging.getLogger("uvicorn.error").disabled = True
     logging.getLogger("requests_oauthlib.oauth2_session").setLevel("INFO")
     logging.getLogger("kubernetes.client.rest").setLevel("INFO")
 


### PR DESCRIPTION
The uvicorn error logger was disabled in #440 when our own logger was introduced. Unfortunately, our own logger doesn't work in all stages of the application.

For example, add a startup script which raises an exception to the on_startup list. The application startup will fail, but there is no error message.

This makes debugging hard and errors are overseen. The commit reenables the error log.