### PR TITLE
feat: Make external links available in development mode

### DIFF
--- a/frontend/src/app/general/nav-bar/nav-bar.service.ts
+++ b/frontend/src/app/general/nav-bar/nav-bar.service.ts
@@ -6,6 +6,7 @@
 import { Injectable } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
 import { UserRole } from 'src/app/services/user/user.service';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -40,21 +41,21 @@ export class NavBarService {
     },
     {
       name: 'Prometheus',
-      href: '/prometheus/graph',
+      href: environment.prometheus_url,
       target: '_blank',
       icon: 'open_in_new',
       requiredRole: 'administrator',
     },
     {
       name: 'Grafana',
-      href: '/grafana/',
+      href: environment.grafana_url,
       target: '_blank',
       icon: 'open_in_new',
       requiredRole: 'administrator',
     },
     {
       name: 'Documentation',
-      href: '/docs/',
+      href: environment.docs_url,
       target: '_blank',
       icon: 'open_in_new',
       requiredRole: 'user',

--- a/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.ts
@@ -72,8 +72,8 @@ export class ModelComplexityBadgeComponent implements OnChanges {
   openModelComplexityBadgeDocs() {
     let docsURL = '/docs';
     if ('docsURL' in environment) {
-      docsURL = environment.docsURL as string;
+      docsURL = environment.docs_url as string;
     }
-    window.open(docsURL + '/projects/models/complexity_badge/', '_blank');
+    window.open(docsURL + '/user/projects/models/complexity_badge/', '_blank');
   }
 }

--- a/frontend/src/environments/environment.dev.ts
+++ b/frontend/src/environments/environment.dev.ts
@@ -7,5 +7,7 @@ export const environment = {
   production: false,
   backend_url: 'http://localhost:8000/api/v1',
   api_docs_url: 'http://localhost:8000/api/docs',
-  docsURL: 'http://localhost:8082',
+  docs_url: 'http://localhost:8081',
+  prometheus_url: 'http://localhost:8080/prometheus/graph',
+  grafana_url: 'http://localhost:8080/grafana/',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -6,6 +6,8 @@
 export const environment = {
   production: true,
   backend_url: '/api/v1',
-  docsURL: '/docs',
+  docs_url: '/docs',
   api_docs_url: '/api/docs',
+  prometheus_url: '/prometheus/graph',
+  grafana_url: '/grafana/',
 };


### PR DESCRIPTION
Grafana, Prometheus and Documentation are not available on relative pathes in the development mode. Instead, they have to point to corresponding absolute URLs.

Documentation will point to the mkdocs serve.
Grafana & Prometheus to the local cluster deployment.

Same as https://github.com/DSD-DBS/capella-collab-manager/pull/1356, but this time with main as target branch.