### PR TITLE
feat: Make Prometheus persistent

### DIFF
--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -61,4 +61,5 @@ spec:
             defaultMode: 420
             name: {{ .Release.Name }}-prometheus
         - name: prometheus-storage-volume
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name -}}-prometheus

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: prometheus
           image: {{ .Values.docker.registry.external }}/prom/prometheus
           args:
-            - "--storage.tsdb.retention.time=12h"
+            - "--storage.tsdb.retention.time=1y"
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
             - "--web.external-url=http://{{ .Release.Name }}-prometheus-server/prometheus/"

--- a/helm/templates/prometheus/prometheus.volume.yaml
+++ b/helm/templates/prometheus/prometheus.volume.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    id: {{ .Release.Name }}-pvc-prometheus
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: {{ .Values.cluster.pvc.storageClassName }}


### PR DESCRIPTION
Prometheus will now store the idletime of sessions and newly introduced TeamForCapella license usage. This allows us to look back to time frames before the last restart.