### PR TITLE
fix: Downgrade `fastapi-pagination` dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
   "jsonschema",
   "openshift",
   "starlette-prometheus",
-  "fastapi-pagination>=0.12.5",
+  "fastapi-pagination>=0.12.5,<=0.12.17",
   "aiohttp",
   "argon2-cffi",
   "typer",


### PR DESCRIPTION
The newest version of `fastapi-pagination` breaks the pydantic resolution in our codebase. I've opened an issue in their repository.
https://github.com/uriyyo/fastapi-pagination/issues/1068

For now, I'll downgrade the dependency version.