### PR TITLE
build(dev): Increase backend memory limits

### DIFF
--- a/helm/templates/backend/backend.deployment.yaml
+++ b/helm/templates/backend/backend.deployment.yaml
@@ -71,7 +71,7 @@ spec:
             {{ if .Values.development }}
             limits:
               cpu: "0.25"
-              memory: 150Mi
+              memory: 500Mi
             requests:
               cpu: "0.06"
               memory: 20Mi


### PR DESCRIPTION
The backend constantly got OOMKilled in the local development cluster deployment.