### PR TITLE
build: Bump `fastapi-pagination` to version v0.12.19

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "python-slugify[unidecode]",
   "jsonschema",
   "starlette-prometheus",
-  "fastapi-pagination>=0.12.5,<=0.12.17",
+  "fastapi-pagination>=0.12.19",
   "aiohttp",
   "argon2-cffi",
   "typer",


### PR DESCRIPTION
Due a bug in fastapi-pagination, we had to downgrade the used dependency version. See also https://github.com/DSD-DBS/capella-collab-manager/pull/1406

Thanks to the amazing fastapi-pagination, they fixed the bug in now time.

This commit bumps the version again.