### PR TITLE
feat: Remove connection method specific variables

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/core.py
+++ b/backend/capellacollab/projects/toolmodels/backups/core.py
@@ -43,7 +43,7 @@ def get_environment(
     t4c_password: str,
     include_commit_history: bool = False,
 ) -> dict[str, str]:
-    env = {
+    return {
         "GIT_REPO_URL": git_model.path,
         "GIT_REPO_BRANCH": git_model.revision,
         "GIT_USERNAME": git_model.username,
@@ -57,21 +57,6 @@ def get_environment(
         "LOG_LEVEL": "INFO",
         "INCLUDE_COMMIT_HISTORY": json.dumps(include_commit_history),
     }
-
-    if http_port := t4c_model.repository.instance.http_port:
-        env |= {
-            "HTTP_LOGIN": t4c_model.repository.instance.username,
-            "HTTP_PASSWORD": t4c_model.repository.instance.password,
-            "HTTP_PORT": str(http_port),
-            "CONNECTION_TYPE": "http",
-        }
-    else:
-        env |= env | {
-            "T4C_CDO_PORT": str(t4c_model.repository.instance.cdo_port),
-            "CONNECTION_TYPE": "telnet",
-        }
-
-    return env
 
 
 def delete_pipeline(


### PR DESCRIPTION
This change is possible because we no longer need connection method-specific variables to perform our backups or export. You can find more information on this in the corresponding Docker images PR: https://github.com/DSD-DBS/capella-dockerimages/pull/254.

Requires https://github.com/DSD-DBS/capella-dockerimages/pull/254 to be deployed.