### PR TITLE
feat: Disable automatic service account mounting

### DIFF
--- a/helm/templates/backend/postgres.deployment.yaml
+++ b/helm/templates/backend/postgres.deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         id: {{ .Release.Name }}-deployment-backend-postgres
     spec:
+      automountServiceAccountToken: false
       {{ if not .Values.development }}
       volumes:
         - name: {{ .Release.Name }}-data

--- a/helm/templates/docs/docs.deployment.yaml
+++ b/helm/templates/docs/docs.deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         id: {{ .Release.Name }}-deployment-docs
     spec:
+      automountServiceAccountToken: false
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-docs

--- a/helm/templates/frontend/frontend.deployment.yaml
+++ b/helm/templates/frontend/frontend.deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/config-promtail: {{ include (print $.Template.BasePath "/promtail" "/promtail.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         {{ if .Values.loki.enabled }}
         - name: logs

--- a/helm/templates/grafana/nginx.deployment.yaml
+++ b/helm/templates/grafana/nginx.deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/grafana/nginx.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         - name: {{ .Release.Name }}-grafana-nginx
           configMap:

--- a/helm/templates/guacamole/guacamole.deployment.yaml
+++ b/helm/templates/guacamole/guacamole.deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/config-promtail: {{ include (print $.Template.BasePath "/promtail" "/promtail.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         {{ if .Values.loki.enabled }}
         - name: unused

--- a/helm/templates/guacamole/guacd.deployment.yaml
+++ b/helm/templates/guacamole/guacd.deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/config-promtail: {{ include (print $.Template.BasePath "/promtail" "/promtail.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         {{ if .Values.loki.enabled }}
         - name: logs

--- a/helm/templates/guacamole/postgres.deployment.yaml
+++ b/helm/templates/guacamole/postgres.deployment.yaml
@@ -24,6 +24,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/guacamole" "/postgres.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         - name: {{ .Release.Name }}-data
           persistentVolumeClaim:

--- a/helm/templates/mock/oauth.deployment.yaml
+++ b/helm/templates/mock/oauth.deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/mock/oauth.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         - name: {{ .Release.Name }}-oauth-mock
           configMap:

--- a/helm/templates/prometheus/nginx.deployment.yaml
+++ b/helm/templates/prometheus/nginx.deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/prometheus/nginx.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       volumes:
         - name: {{ .Release.Name }}-prometheus-nginx
           configMap:

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/prometheus/prometheus.configmap.yaml") . | sha256sum }}
     spec:
+      automountServiceAccountToken: false
       serviceAccountName: {{ .Release.Name }}-prometheus
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:


### PR DESCRIPTION
Service accounts aren't needed for most of the services since they don't talk to the Kubernetes API.

For increased security, this disables the automatic mounting of secrets.