### PR TITLE
feat: Remember last requested sessions locally

### DIFF
--- a/backend/capellacollab/tools/routes.py
+++ b/backend/capellacollab/tools/routes.py
@@ -143,6 +143,18 @@ def create_tool_version(
     return crud.create_version(db, tool, body)
 
 
+@router.get(
+    "/{tool_id}/versions/{version_id}",
+    response_model=models.ToolVersionBase,
+)
+def get_tool_version(
+    version: models.DatabaseVersion = fastapi.Depends(
+        injectables.get_existing_tool_version
+    ),
+) -> models.DatabaseVersion:
+    return version
+
+
 @router.put(
     "/{tool_id}/versions/{version_id}",
     response_model=models.ToolVersionBase,
@@ -225,6 +237,18 @@ def create_tool_nature(
     if crud.get_nature_by_name(db, tool, body.name):
         raise core_exceptions.ResourceAlreadyExistsError("tool nature", "name")
     return crud.create_nature(db, tool, body.name)
+
+
+@router.get(
+    "/{tool_id}/natures/{nature_id}",
+    response_model=models.ToolNatureBase,
+)
+def get_tool_nature(
+    nature: models.DatabaseNature = fastapi.Depends(
+        injectables.get_existing_tool_nature
+    ),
+) -> models.DatabaseNature:
+    return nature
 
 
 @router.put(

--- a/backend/tests/tools/test_tools_natures_routes.py
+++ b/backend/tests/tools/test_tools_natures_routes.py
@@ -25,6 +25,38 @@ def test_create_tool_nature(
     assert response.json()["name"] == "test2"
 
 
+@pytest.mark.usefixtures("admin", "tool_nature")
+def test_get_tools_natures(
+    client: testclient.TestClient,
+    tool: tools_models.DatabaseTool,
+):
+    """Test get all tool natures"""
+    response = client.get(
+        f"/api/v1/tools/{tool.id}/natures",
+    )
+
+    assert response.is_success
+    assert len(response.json()) == 1
+    assert "id" in response.json()[0]
+    assert response.json()[0]["name"] == "test"
+
+
+@pytest.mark.usefixtures("admin")
+def test_get_tools_nature(
+    client: testclient.TestClient,
+    tool: tools_models.DatabaseTool,
+    tool_nature: tools_models.DatabaseNature,
+):
+    """Test get a tool nature"""
+    response = client.get(
+        f"/api/v1/tools/{tool.id}/natures/{tool_nature.id}",
+    )
+
+    assert "id" in response.json()
+    assert response.is_success
+    assert response.json()["name"] == "test"
+
+
 @pytest.mark.usefixtures("admin")
 def test_update_tools_nature(
     client: testclient.TestClient,
@@ -35,13 +67,13 @@ def test_update_tools_nature(
     response = client.put(
         f"/api/v1/tools/{tool.id}/natures/{tool_nature.id}",
         json={
-            "name": "test",
+            "name": "test_new",
         },
     )
 
     assert "id" in response.json()
     assert response.is_success
-    assert response.json()["name"] == "test"
+    assert response.json()["name"] == "test_new"
 
 
 @pytest.mark.usefixtures("admin")

--- a/backend/tests/tools/test_tools_version_routes.py
+++ b/backend/tests/tools/test_tools_version_routes.py
@@ -33,6 +33,36 @@ def test_create_tool_version(
 
 
 @pytest.mark.usefixtures("admin")
+def test_get_tools_version(
+    client: testclient.TestClient,
+    tool: tools_models.DatabaseTool,
+    tool_version: tools_models.DatabaseVersion,
+):
+    """Test get a tool version"""
+    response = client.get(
+        f"/api/v1/tools/{tool.id}/versions/{tool_version.id}",
+    )
+
+    assert response.is_success
+    assert "id" in response.json()
+
+
+@pytest.mark.usefixtures("admin", "tool_version")
+def test_get_tools_versions(
+    client: testclient.TestClient,
+    tool: tools_models.DatabaseTool,
+):
+    """Test get all tool versions"""
+    response = client.get(
+        f"/api/v1/tools/{tool.id}/versions",
+    )
+
+    assert response.is_success
+    assert len(response.json()) == 1
+    assert "id" in response.json()[0]
+
+
+@pytest.mark.usefixtures("admin")
 def test_update_tools_version(
     client: testclient.TestClient,
     tool: tools_models.DatabaseTool,

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -11,6 +11,7 @@ import { importProvidersFrom } from '@angular/core';
 import { applicationConfig } from '@storybook/angular';
 import { ToastrModule } from 'ngx-toastr';
 import { RouterModule } from '@angular/router';
+import { CookieModule } from 'ngx-cookie';
 
 setCompodocJson(docJson);
 
@@ -26,8 +27,8 @@ const preview: Preview = {
   decorators: [
     applicationConfig({
       providers: [
-        importProvidersFrom(HttpClientModule),
         importProvidersFrom(
+          HttpClientModule,
           ToastrModule.forRoot({
             positionClass: 'toast-bottom-left',
             timeOut: 10000,
@@ -38,8 +39,9 @@ const preview: Preview = {
             resetTimeoutOnDuplicate: true,
             includeTitleDuplicates: true,
           }),
+          CookieModule.withOptions(),
+          RouterModule.forRoot([]),
         ),
-        importProvidersFrom(RouterModule.forRoot([])),
       ],
     }),
   ],

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -52,6 +52,7 @@ import {
   HighlightPipeTransform,
   ModelDiagramCodeBlockComponent,
 } from 'src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component';
+import { CreateSessionHistoryComponent } from 'src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component';
 import { CreateToolComponent } from 'src/app/settings/core/tools-settings/create-tool/create-tool.component';
 import { BasicAuthTokenComponent } from 'src/app/users/basic-auth-token/basic-auth-token.component';
 import { AppRoutingModule } from './app-routing.module';
@@ -256,6 +257,7 @@ import { UsersProfileComponent } from './users/users-profile/users-profile.compo
     BrowserModule,
     ClipboardModule,
     CommonModule,
+    CreateSessionHistoryComponent,
     CookieModule.withOptions(),
     DragDropModule,
     FormsModule,
@@ -290,11 +292,11 @@ import { UsersProfileComponent } from './users/users-profile/users-profile.compo
     MatToolbarModule,
     MatTooltipModule,
     MatTreeModule,
-    NgxSkeletonLoaderModule.forRoot(),
     ModelComplexityBadgeComponent,
     OverlayModule,
     ProjectMetadataComponent,
     ReactiveFormsModule,
+    NgxSkeletonLoaderModule.forRoot(),
     ToastrModule.forRoot({
       positionClass: 'toast-bottom-left',
       timeOut: 10000,

--- a/frontend/src/app/projects/models/init-model/init-model.component.ts
+++ b/frontend/src/app/projects/models/init-model/init-model.component.ts
@@ -70,7 +70,7 @@ export class InitModelComponent implements OnInit {
         map((model: Model) => model.tool),
         switchMap((tool: Tool) =>
           combineLatest([
-            this.toolService.getVersionsForTool(tool.id),
+            this.toolService.getVersionsForTool(tool.id, false),
             this.toolService.getNaturesForTool(tool.id),
           ]),
         ),

--- a/frontend/src/app/projects/models/model-description/model-description.component.ts
+++ b/frontend/src/app/projects/models/model-description/model-description.component.ts
@@ -75,7 +75,7 @@ export class ModelDescriptionComponent implements OnInit {
         switchMap((model) => {
           return combineLatest([
             this.toolService.getNaturesForTool(model.tool.id),
-            this.toolService.getVersionsForTool(model.tool.id),
+            this.toolService.getVersionsForTool(model.tool.id, false),
           ]);
         }),
       )

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.ts
@@ -101,12 +101,14 @@ export class CreateReadonlySessionComponent implements OnInit {
     this.toolSelectionForm.controls.version.patchValue(null);
     this.toolVersions = undefined;
 
-    this.toolService.getVersionsForTool(tool.id).subscribe((toolVersions) => {
-      const toolVersionIds = this.models?.map((m) => m.version?.id);
-      this.toolVersions = toolVersions.filter((v) =>
-        toolVersionIds?.includes(v.id),
-      );
-    });
+    this.toolService
+      .getVersionsForTool(tool.id, false)
+      .subscribe((toolVersions) => {
+        const toolVersionIds = this.models?.map((m) => m.version?.id);
+        this.toolVersions = toolVersions.filter((v) =>
+          toolVersionIds?.includes(v.id),
+        );
+      });
   }
 
   asyncReadonlyValidator(): AsyncValidatorFn {

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.html
@@ -26,7 +26,7 @@
           >
             <mat-option
               *ngFor="let tool of toolService.tools"
-              value="{{ tool.id }}"
+              [value]="tool.id"
             >
               {{ tool.name }}
             </mat-option>
@@ -89,5 +89,9 @@
         </button>
       </div>
     </form>
+  </div>
+
+  <div class="mt-2">
+    <app-create-session-history></app-create-session-history>
   </div>
 </div>

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
@@ -33,7 +33,7 @@ export class CreatePersistentSessionComponent implements OnInit {
   requestInProgress = false;
 
   public toolSelectionForm = new FormGroup({
-    toolId: new FormControl(null, Validators.required),
+    toolId: new FormControl<number | null>(null, Validators.required),
     versionId: new FormControl<number | null>(
       { value: null, disabled: true },
       Validators.required,
@@ -106,7 +106,7 @@ export class CreatePersistentSessionComponent implements OnInit {
   getVersionsForTool(toolId: number): void {
     this.versions = [];
     this.toolService
-      .getVersionsForTool(toolId)
+      .getVersionsForTool(toolId, false)
       .subscribe((res: ToolVersion[]) => {
         this.versions = res;
         if (res.length) {

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component.html
@@ -1,0 +1,54 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+<div
+  class="mt-3 max-h-0 overflow-hidden transition-all duration-700"
+  [ngClass]="{
+    'max-h-[600px]':
+      sessionsLoaded === sessionsToBeLoaded && sessionsToBeLoaded > 0
+  }"
+>
+  <div class="flex flex-col gap-2">
+    @if (sortedResolvedHistory.length !== 0) {
+      <div class="text-sm">
+        Or quick-request one of the last requested sessions:
+      </div>
+    }
+    @for (session of sortedResolvedHistory; track $index) {
+      <button
+        class="flex w-full flex-row items-center justify-between gap-5 rounded border bg-slate-100 p-2"
+        (click)="requestSession(session)"
+      >
+        <div class="w-full flex-col items-center">
+          <div class="flex w-full flex-row items-center justify-between gap-2">
+            <div class="basis-1/4">
+              <span class="font-bold">Tool</span>
+              <div>{{ session.tool.name }}</div>
+            </div>
+            <div class="basis-1/4">
+              <span class="font-bold">Version</span>
+              <div>{{ session.version.name }}</div>
+            </div>
+            <div class="basis-1/2">
+              <span class="font-bold">Connection Method</span>
+              <div>{{ session.connectionMethod.name }}</div>
+            </div>
+          </div>
+
+          <div class="text-sm italic">
+            Last time requested on
+            {{ session.lastTimeRequested | date: "EE, dd MMM y HH:mm:ss" }}
+          </div>
+        </div>
+        <div class="flex justify-center">
+          @if (session.loading) {
+            <mat-spinner [diameter]="24"></mat-spinner>
+          } @else {
+            <mat-icon>start</mat-icon>
+          }
+        </div>
+      </button>
+    }
+  </div>
+</div>

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component.ts
@@ -1,0 +1,151 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subscription, filter, take } from 'rxjs';
+import { SessionService } from 'src/app/sessions/service/session.service';
+import {
+  SessionHistoryService,
+  SessionRequestHistory,
+} from 'src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/session-history.service';
+import {
+  ConnectionMethod,
+  Tool,
+  ToolService,
+  ToolVersion,
+} from 'src/app/settings/core/tools-settings/tool.service';
+
+@Component({
+  selector: 'app-create-session-history',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatProgressSpinnerModule],
+  templateUrl: './create-session-history.component.html',
+  styles: ``,
+})
+export class CreateSessionHistoryComponent implements OnInit, OnDestroy {
+  resolvedHistory: ResolvedSessionRequestHistory[] = [];
+  sessionsToBeLoaded = this.sessionHistoryService.MAX_SESSIONS_IN_HISTORY;
+  sessionsLoaded = 0;
+
+  activeSubscriptions: Subscription[] = [];
+
+  get sortedResolvedHistory() {
+    return this.resolvedHistory.sort(
+      (a, b) => b.lastTimeRequested.getTime() - a.lastTimeRequested.getTime(),
+    );
+  }
+
+  constructor(
+    private toolService: ToolService,
+    private sessionHistoryService: SessionHistoryService,
+    private sessionService: SessionService,
+  ) {}
+
+  ngOnInit() {
+    this.sessionHistoryService.loadSessionRequestHistory();
+    this.loadLastSessions();
+  }
+
+  pushValidResolvedSessionToHistory(
+    tool: Tool,
+    version: ToolVersion,
+    session: SessionRequestHistory,
+  ) {
+    const connectionMethod = this.toolService.getConnectionIdForTool(
+      tool,
+      session.connectionMethodId,
+    );
+    if (connectionMethod === undefined) return;
+
+    this.resolvedHistory.push({
+      tool: tool,
+      version: version,
+      connectionMethod: connectionMethod,
+      lastTimeRequested: session.lastRequested,
+      loading: false,
+    });
+  }
+
+  loadLastSessions() {
+    this.toolService._tools.pipe(filter(Boolean), take(1)).subscribe(() => {
+      this.sessionHistoryService.sessionHistory
+        .pipe(filter(Boolean))
+        .subscribe((sessions) => {
+          this.resolvedHistory = [];
+          this.sessionsToBeLoaded = sessions.length;
+          this.sessionsLoaded = 0;
+
+          this.unsubscribeAll();
+
+          for (const session of sessions) {
+            this.activeSubscriptions.push(
+              this.toolService
+                .getVersionForTool(session.toolId, session.versionId, true)
+                .subscribe({
+                  next: (version) => {
+                    this.sessionsLoaded++;
+
+                    const tool = this.toolService.getCachedToolById(
+                      session.toolId,
+                    );
+                    if (tool === undefined) return;
+
+                    this.pushValidResolvedSessionToHistory(
+                      tool,
+                      version,
+                      session,
+                    );
+                  },
+                  error: () => {
+                    this.sessionsLoaded++;
+                  },
+                }),
+            );
+          }
+        });
+    });
+  }
+
+  requestSession(session: ResolvedSessionRequestHistory) {
+    session.loading = true;
+    this.sessionService
+      .createSession(
+        session.tool.id,
+        session.version.id,
+        session.connectionMethod.id,
+        'persistent',
+        [],
+      )
+      .subscribe({
+        next: () => {
+          session.loading = false;
+        },
+        error: () => {
+          session.loading = false;
+        },
+      });
+  }
+
+  unsubscribeAll() {
+    for (const subscription of this.activeSubscriptions) {
+      subscription.unsubscribe();
+    }
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAll();
+  }
+}
+
+export type ResolvedSessionRequestHistory = {
+  tool: Tool;
+  version: ToolVersion;
+  connectionMethod: ConnectionMethod;
+  loading: boolean;
+  lastTimeRequested: Date;
+};

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.docs.mdx
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.docs.mdx
@@ -1,0 +1,28 @@
+{/*
+    SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+    SPDX-License-Identifier: Apache-2.0
+*/}
+
+import * as CreateSessionHistoryComponent from './create-session-history.stories.ts'
+import { Meta, Title, Story, Canvas, Unstyled } from '@storybook/blocks'
+
+<Meta of={CreateSessionHistoryComponent} />
+
+<Title />
+
+The following example shows two requested session in the history.
+The user has clicked on the first session to request it and the request is currently in progress (spinning).
+
+<Unstyled>
+    <div style={{width: "426px"}}>
+        <Story of={CreateSessionHistoryComponent.ResolvedSessionHistory}/>
+    </div>
+</Unstyled>
+
+On smaller mobile devices, the history is squeezed:
+
+<Unstyled>
+    <div style={{width: "300px"}}>
+        <Story of={CreateSessionHistoryComponent.ResolvedSessionHistory}/>
+    </div>
+</Unstyled>

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.stories.ts
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import {
+  ConnectionMethod,
+  Tool,
+  ToolVersion,
+} from 'src/app/settings/core/tools-settings/tool.service';
+import { CreateSessionHistoryComponent } from './create-session-history.component';
+
+const meta: Meta<CreateSessionHistoryComponent> = {
+  title: 'Session Component / Session History',
+  component: CreateSessionHistoryComponent,
+};
+
+export default meta;
+type Story = StoryObj<CreateSessionHistoryComponent>;
+
+const tool: Tool = {
+  id: 1,
+  name: 'Tool 1',
+  integrations: { t4c: true, pure_variants: true, jupyter: false },
+  config: { connection: { methods: [] } },
+};
+
+const version: ToolVersion = {
+  id: 1,
+  name: 'Version 1',
+  config: { is_recommended: false, is_deprecated: false },
+};
+
+const connectionMethod: ConnectionMethod = {
+  id: '1',
+  name: 'Method 1',
+  type: 'http',
+};
+
+export const ResolvedSessionHistory: Story = {
+  args: {
+    resolvedHistory: [
+      {
+        tool: tool,
+        version: version,
+        lastTimeRequested: new Date(),
+        loading: true,
+        connectionMethod: connectionMethod,
+      },
+      {
+        tool: { ...tool, name: 'Example tool' },
+        version: { ...version, name: 'Example version' },
+        lastTimeRequested: new Date('2024-01-01'),
+        loading: false,
+        connectionMethod: {
+          ...connectionMethod,
+          name: 'Example connection method',
+        },
+      },
+    ],
+    sessionsLoaded: 2,
+    sessionsToBeLoaded: 2,
+  },
+};

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/session-history.service.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/session-history.service.ts
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { LocalStorageService } from 'src/app/general/auth/local-storage/local-storage.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SessionHistoryService {
+  LOCAL_STORAGE_SESSION_HISTORY_KEY = 'sessionRequestHistory';
+  MAX_SESSIONS_IN_HISTORY = 3;
+
+  constructor(private localStorageService: LocalStorageService) {}
+
+  sessionHistory = new BehaviorSubject<SessionRequestHistory[] | undefined>(
+    undefined,
+  );
+
+  getSessionRequestHistory(): SessionRequestHistory[] {
+    let localStorageHistory: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    try {
+      localStorageHistory = JSON.parse(
+        this.localStorageService.getValue(
+          this.LOCAL_STORAGE_SESSION_HISTORY_KEY,
+        ),
+      );
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+
+    if (!(localStorageHistory instanceof Array)) {
+      return [];
+    }
+
+    const validSessionHistoryEntries: SessionRequestHistory[] = [];
+    for (const entry of localStorageHistory) {
+      if (this.isSessionRequestHistoryType(entry)) {
+        entry.lastRequested = new Date(entry.lastRequested);
+        validSessionHistoryEntries.push(entry);
+      }
+    }
+
+    return validSessionHistoryEntries;
+  }
+
+  loadSessionRequestHistory() {
+    this.sessionHistory.next(this.getSessionRequestHistory());
+  }
+
+  private isSessionRequestHistoryType(
+    item: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  ): item is SessionRequestHistory {
+    return (
+      typeof item === 'object' &&
+      typeof item.toolId === 'number' &&
+      typeof item.versionId === 'number' &&
+      typeof item.connectionMethodId === 'string' &&
+      typeof item.lastRequested === 'string'
+    );
+  }
+
+  addSessionRequestToHistory(history: SessionRequestHistory) {
+    let currentHistory = this.getSessionRequestHistory();
+    currentHistory = currentHistory
+      .filter(
+        (entry) =>
+          entry.toolId !== history.toolId ||
+          entry.versionId !== history.versionId ||
+          entry.connectionMethodId !== history.connectionMethodId,
+      )
+      .sort((a, b) => a.lastRequested.getTime() - b.lastRequested.getTime());
+
+    currentHistory.push(history);
+
+    if (currentHistory.length > this.MAX_SESSIONS_IN_HISTORY) {
+      currentHistory.shift();
+    }
+
+    this.sessionHistory.next(currentHistory);
+    this.localStorageService.setValue(
+      this.LOCAL_STORAGE_SESSION_HISTORY_KEY,
+      JSON.stringify(currentHistory),
+    );
+  }
+}
+
+export type SessionRequestHistory = {
+  toolId: number;
+  versionId: number;
+  connectionMethodId: string;
+  lastRequested: Date;
+};

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-version/tool-version.component.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-version/tool-version.component.ts
@@ -38,7 +38,7 @@ export class ToolVersionComponent implements AfterViewInit {
 
     if (this._tool !== undefined) {
       this.toolService
-        .getVersionsForTool(this._tool.id)
+        .getVersionsForTool(this._tool.id, false)
         .subscribe((versions: ToolVersion[]) => {
           this.toolVersions = versions;
         });

--- a/frontend/src/app/settings/core/tools-settings/tool.service.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool.service.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { SKIP_ERROR_HANDLING } from 'src/app/general/error-handling/error-handling.interceptor';
 import { environment } from 'src/environments/environment';
 
 export type ConnectionMethod = {
@@ -124,8 +125,26 @@ export class ToolService {
     return this.http.delete<void>(`${this.baseURL}/${tool_id}`);
   }
 
-  getVersionsForTool(toolId: number): Observable<ToolVersion[]> {
-    return this.http.get<ToolVersion[]>(`${this.baseURL}/${toolId}/versions`);
+  getVersionsForTool(
+    toolId: number,
+    skipErrorHandling: boolean,
+  ): Observable<ToolVersion[]> {
+    return this.http.get<ToolVersion[]>(`${this.baseURL}/${toolId}/versions`, {
+      context: new HttpContext().set(SKIP_ERROR_HANDLING, skipErrorHandling),
+    });
+  }
+
+  getVersionForTool(
+    toolId: number,
+    versionId: number,
+    skipErrorHandling: boolean,
+  ): Observable<ToolVersion> {
+    return this.http.get<ToolVersion>(
+      `${this.baseURL}/${toolId}/versions/${versionId}`,
+      {
+        context: new HttpContext().set(SKIP_ERROR_HANDLING, skipErrorHandling),
+      },
+    );
   }
 
   getDefaultVersion(): Observable<ToolVersion> {
@@ -208,5 +227,19 @@ export class ToolService {
       `${this.baseURL}/${toolId}/integrations`,
       toolIntegrations,
     );
+  }
+
+  getConnectionIdForTool(
+    tool: Tool,
+    connectionMethodId: string,
+  ): ConnectionMethod | undefined {
+    return tool?.config.connection.methods.find(
+      (cm) => cm.id === connectionMethodId,
+    );
+  }
+
+  getCachedToolById(toolId: number): Tool | undefined {
+    if (this._tools.value === undefined) return undefined;
+    return this._tools.value.find((t) => t.id === toolId);
   }
 }

--- a/frontend/src/app/settings/core/tools-settings/tools-settings.component.ts
+++ b/frontend/src/app/settings/core/tools-settings/tools-settings.component.ts
@@ -26,7 +26,7 @@ export class ToolsSettingsComponent {
       for (const tool of this.toolService.tools!.map((tool) => tool.id)) {
         combineLatest([
           this.toolService.getNaturesForTool(tool),
-          this.toolService.getVersionsForTool(tool),
+          this.toolService.getVersionsForTool(tool, false),
         ]).subscribe({
           next: (result: [ToolNature[], ToolVersion[]]) => {
             this.tools[tool] = {

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -105,7 +105,7 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
       });
 
     this.toolService
-      .getVersionsForTool(1)
+      .getVersionsForTool(1, false)
       .pipe(filter(Boolean))
       .subscribe((capellaVersions) => (this.capellaVersions = capellaVersions));
   }


### PR DESCRIPTION
The last three requested sessions are cached locally and can be used to quick-request those sessions again.
The session history is lazy-loaded, so it doesn't slow down loading of the page.