### PR TITLE
fix(frontend): Remove trailing `/` from backend API requests

### DIFF
--- a/frontend/src/app/projects/models/service/model.service.ts
+++ b/frontend/src/app/projects/models/service/model.service.ts
@@ -26,7 +26,7 @@ import { environment } from 'src/environments/environment';
   providedIn: 'root',
 })
 export class ModelService {
-  base_url = environment.backend_url + '/projects/';
+  base_url = environment.backend_url + '/projects';
 
   constructor(private http: HttpClient) {}
 
@@ -37,11 +37,11 @@ export class ModelService {
   public readonly models$ = this._models.asObservable();
 
   backendURLFactory(projectSlug: string, modelSlug: string) {
-    return `${this.base_url}${projectSlug}/models/${modelSlug}`;
+    return `${this.base_url}/${projectSlug}/models/${modelSlug}`;
   }
 
   loadModels(projectSlug: string): void {
-    this.http.get<Model[]>(`${this.base_url}${projectSlug}/models`).subscribe({
+    this.http.get<Model[]>(`${this.base_url}/${projectSlug}/models`).subscribe({
       next: (models) => this._models.next(models),
       error: () => this._models.next(undefined),
     });
@@ -49,7 +49,7 @@ export class ModelService {
 
   loadModelbySlug(modelSlug: string, projectSlug: string): void {
     this.http
-      .get<Model>(`${this.base_url}${projectSlug}/models/${modelSlug}/`)
+      .get<Model>(`${this.base_url}/${projectSlug}/models/${modelSlug}`)
       .subscribe({
         next: (model) => this._model.next(model),
         error: () => this._model.next(undefined),
@@ -58,7 +58,7 @@ export class ModelService {
 
   createModel(projectSlug: string, model: NewModel): Observable<Model> {
     return this.http
-      .post<Model>(`${this.base_url}${projectSlug}/models`, model)
+      .post<Model>(`${this.base_url}/${projectSlug}/models`, model)
       .pipe(
         tap({
           next: (model) => {
@@ -77,7 +77,7 @@ export class ModelService {
     nature_id: number,
   ): Observable<Model> {
     return this.http
-      .patch<Model>(`${this.base_url}${projectSlug}/models/${modelSlug}/`, {
+      .patch<Model>(`${this.base_url}/${projectSlug}/models/${modelSlug}`, {
         version_id,
         nature_id,
       })
@@ -98,7 +98,7 @@ export class ModelService {
     patchData: PatchModel,
   ): Observable<Model> {
     return this.http.patch<Model>(
-      `${this.base_url}${projectSlug}/models/${modelSlug}/`,
+      `${this.base_url}/${projectSlug}/models/${modelSlug}`,
       patchData,
     );
   }
@@ -138,7 +138,7 @@ export class ModelService {
 
   deleteModel(projectSlug: string, modelSlug: string): Observable<void> {
     return this.http
-      .delete<void>(`${this.base_url}${projectSlug}/models/${modelSlug}`)
+      .delete<void>(`${this.base_url}/${projectSlug}/models/${modelSlug}`)
       .pipe(
         tap(() => {
           this.loadModels(projectSlug);

--- a/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
+++ b/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
@@ -31,7 +31,7 @@ export class ProjectUserService {
     this.loadProjectUsersOnProjectChange();
     this.loadProjectUserOnProjectChange();
   }
-  BACKEND_URL_PREFIX = environment.backend_url + '/projects/';
+  BACKEND_URL_PREFIX = environment.backend_url + '/projects';
 
   PERMISSIONS = { read: 'read only', write: 'read & write' };
   ROLES = { user: 'User', manager: 'Manager' };
@@ -108,7 +108,7 @@ export class ProjectUserService {
         filter(Boolean),
         switchMap((project) =>
           this.http.get<ProjectUser>(
-            this.BACKEND_URL_PREFIX + project.slug + '/users/current',
+            `${this.BACKEND_URL_PREFIX}/${project.slug}/users/current`,
           ),
         ),
       )
@@ -141,7 +141,7 @@ export class ProjectUserService {
   loadProjectUsers(projectSlug: string): void {
     this._projectUsers.next(undefined);
     this.http
-      .get<ProjectUser[]>(this.BACKEND_URL_PREFIX + projectSlug + '/users')
+      .get<ProjectUser[]>(`${this.BACKEND_URL_PREFIX}/${projectSlug}/users`)
       .pipe(
         tap((projectUsers) => {
           this._projectUsers.next(projectUsers);
@@ -158,7 +158,7 @@ export class ProjectUserService {
     reason: string,
   ): Observable<ProjectUser> {
     return this.http
-      .post<ProjectUser>(this.BACKEND_URL_PREFIX + projectSlug + '/users', {
+      .post<ProjectUser>(`${this.BACKEND_URL_PREFIX}/${projectSlug}/users`, {
         username,
         role,
         permission,
@@ -178,32 +178,35 @@ export class ProjectUserService {
     reason: string,
   ): Observable<null> {
     return this.http
-      .patch<null>(this.BACKEND_URL_PREFIX + projectSlug + '/users/' + userID, {
-        role,
-        reason,
-      })
+      .patch<null>(
+        `${this.BACKEND_URL_PREFIX}/${projectSlug}/users/${userID}`,
+        {
+          role,
+          reason,
+        },
+      )
       .pipe(tap(() => this.loadProjectUsers(projectSlug)));
   }
 
   changePermissionOfProjectUser(
-    project_slug: string,
+    projectSlug: string,
     userID: number,
     permission: ProjectUserPermission,
     reason: string,
   ): Observable<null> {
     return this.http.patch<null>(
-      this.BACKEND_URL_PREFIX + project_slug + '/users/' + userID,
+      `${this.BACKEND_URL_PREFIX}/${projectSlug}/users/${userID}`,
       { permission, reason },
     );
   }
 
   deleteUserFromProject(
-    project_slug: string,
+    projectSlug: string,
     userID: number,
     reason: string,
   ): Observable<void> {
     return this.http.delete<void>(
-      this.BACKEND_URL_PREFIX + project_slug + '/users/' + userID,
+      `${this.BACKEND_URL_PREFIX}/${projectSlug}/users/${userID}`,
       { body: reason },
     );
   }

--- a/frontend/src/app/services/load-files/load-files.service.ts
+++ b/frontend/src/app/services/load-files/load-files.service.ts
@@ -13,13 +13,13 @@ import { environment } from 'src/environments/environment';
   providedIn: 'root',
 })
 export class LoadFilesService {
-  BACKEND_URL_PREFIX = environment.backend_url + '/sessions/';
+  BACKEND_URL_PREFIX = environment.backend_url + '/sessions';
 
   constructor(private http: HttpClient) {}
 
   upload(id: string, files: FormData): Observable<HttpEvent<UploadResponse>> {
     return this.http.post<UploadResponse>(
-      this.BACKEND_URL_PREFIX + id + '/files',
+      `${this.BACKEND_URL_PREFIX}/${id}/files`,
       files,
       {
         reportProgress: true,
@@ -30,12 +30,12 @@ export class LoadFilesService {
 
   getCurrentFiles(id: string, showHiddenFiles: boolean): Observable<PathNode> {
     return this.http.get<PathNode>(
-      this.BACKEND_URL_PREFIX + id + '/files?show_hidden=' + showHiddenFiles,
+      `${this.BACKEND_URL_PREFIX}/${id}/files?show_hidden=${showHiddenFiles}`,
     );
   }
 
   download(id: string, filename: string): Observable<Blob> {
-    return this.http.get(`${this.BACKEND_URL_PREFIX}${id}/files/download`, {
+    return this.http.get(`${this.BACKEND_URL_PREFIX}/${id}/files/download`, {
       params: { filename: filename },
       responseType: 'blob',
     });

--- a/frontend/src/app/services/user/user.service.ts
+++ b/frontend/src/app/services/user/user.service.ts
@@ -18,7 +18,7 @@ import { AuthService } from '../auth/auth.service';
 export class UserService {
   user: User | undefined = undefined;
 
-  BACKEND_URL_PREFIX = environment.backend_url + '/users/';
+  BACKEND_URL_PREFIX = environment.backend_url + '/users';
 
   constructor(
     private http: HttpClient,
@@ -48,19 +48,19 @@ export class UserService {
   }
 
   getUser(user: User): Observable<User> {
-    return this.http.get<User>(this.BACKEND_URL_PREFIX + user.id);
+    return this.http.get<User>(`${this.BACKEND_URL_PREFIX}/${user.id}`);
   }
 
   getUserById(userId: number): Observable<User> {
-    return this.http.get<User>(this.BACKEND_URL_PREFIX + userId);
+    return this.http.get<User>(`${this.BACKEND_URL_PREFIX}/${userId}`);
   }
 
   getCurrentUser(): Observable<User> {
-    return this.http.get<User>(this.BACKEND_URL_PREFIX + 'current');
+    return this.http.get<User>(`${this.BACKEND_URL_PREFIX}/current`);
   }
 
   deleteUser(user: User): Observable<void> {
-    return this.http.delete<void>(this.BACKEND_URL_PREFIX + user.id);
+    return this.http.delete<void>(`${this.BACKEND_URL_PREFIX}/${user.id}`);
   }
 
   getUsers(): Observable<User[]> {
@@ -69,13 +69,13 @@ export class UserService {
 
   getOwnActiveSessions(): Observable<Array<Session>> {
     return this.http.get<Session[]>(
-      this.BACKEND_URL_PREFIX + 'current/sessions',
+      `${this.BACKEND_URL_PREFIX}/current/sessions`,
     );
   }
 
   getUserEvents(userId: number): Observable<HistoryEvent[]> {
     return this.http.get<HistoryEvent[]>(
-      this.BACKEND_URL_PREFIX + userId + '/events',
+      `${this.BACKEND_URL_PREFIX}/${userId}/events`,
     );
   }
 
@@ -84,10 +84,13 @@ export class UserService {
     role: UserRole,
     reason: string,
   ): Observable<User> {
-    return this.http.patch<User>(this.BACKEND_URL_PREFIX + user.id + '/roles', {
-      role,
-      reason,
-    });
+    return this.http.patch<User>(
+      `${this.BACKEND_URL_PREFIX}/${user.id}/roles`,
+      {
+        role,
+        reason,
+      },
+    );
   }
 
   validateUserRole(requiredRole: UserRole): boolean {
@@ -104,7 +107,7 @@ export class UserService {
 
   loadCommonProjects(userId: number): Observable<Project[]> {
     return this.http.get<Project[]>(
-      `${this.BACKEND_URL_PREFIX}${userId}/common-projects`,
+      `${this.BACKEND_URL_PREFIX}/${userId}/common-projects`,
     );
   }
 }

--- a/frontend/src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/service/t4c-repos/t4c-repo.service.ts
@@ -41,7 +41,7 @@ export class T4CRepoService {
     this.http
       .get<
         T4CServerRepository[]
-      >(`${this.t4cInstanceService.urlFactory(instanceId)}/repositories/`)
+      >(`${this.t4cInstanceService.urlFactory(instanceId)}/repositories`)
       .subscribe({
         next: (repositories) => this._repositories.next(repositories),
         error: () => this._repositories.next(undefined),
@@ -62,7 +62,7 @@ export class T4CRepoService {
   ): Observable<T4CRepository> {
     return this.http
       .post<T4CRepository>(
-        `${this.t4cInstanceService.urlFactory(instanceId)}/repositories/`,
+        `${this.t4cInstanceService.urlFactory(instanceId)}/repositories`,
         repository,
       )
       .pipe(tap(() => this.loadRepositories(instanceId)));
@@ -71,14 +71,14 @@ export class T4CRepoService {
   startRepository(instanceId: number, repositoryId: number): Observable<null> {
     this.publishRepositoriesWithChangedStatus(repositoryId, 'LOADING');
     return this.http
-      .post<null>(`${this.urlFactory(instanceId, repositoryId)}/start/`, {})
+      .post<null>(`${this.urlFactory(instanceId, repositoryId)}/start`, {})
       .pipe(tap(() => this.loadRepositories(instanceId)));
   }
 
   stopRepository(instanceId: number, repositoryId: number): Observable<null> {
     this.publishRepositoriesWithChangedStatus(repositoryId, 'LOADING');
     return this.http
-      .post<null>(`${this.urlFactory(instanceId, repositoryId)}/stop/`, {})
+      .post<null>(`${this.urlFactory(instanceId, repositoryId)}/stop`, {})
       .pipe(tap(() => this.loadRepositories(instanceId)));
   }
 
@@ -88,13 +88,13 @@ export class T4CRepoService {
   ): Observable<null> {
     this.publishRepositoriesWithChangedStatus(repositoryId, 'LOADING');
     return this.http
-      .post<null>(`${this.urlFactory(instanceId, repositoryId)}/recreate/`, {})
+      .post<null>(`${this.urlFactory(instanceId, repositoryId)}/recreate`, {})
       .pipe(tap(() => this.loadRepositories(instanceId)));
   }
 
   deleteRepository(instanceId: number, repositoryId: number): Observable<null> {
     return this.http
-      .delete<null>(`${this.urlFactory(instanceId, repositoryId)}/`)
+      .delete<null>(`${this.urlFactory(instanceId, repositoryId)}`)
       .pipe(tap(() => this.loadRepositories(instanceId)));
   }
 


### PR DESCRIPTION
A trailing slash leads to an unnecessary redirect, triggered by the backend. In addition, it's harder readable when a `/` is part of a base URL, which is then used in template literals, e.g. `${baseURL}/${resource}` is better to read than `${baseURL}${resource}`.

The redirect behaviour lead to occasional request failues and some parts of the frontend stopped working when running behind a reverse proxy with TLS edge termination.