### PR TITLE
feat: Add base error model, remove dupe error handlers and registration

### DIFF
--- a/backend/capellacollab/core/exceptions.py
+++ b/backend/capellacollab/core/exceptions.py
@@ -1,61 +1,54 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
-
-import fastapi
-from fastapi import exception_handlers, status
+import pydantic
+from fastapi import status
 
 
-@dataclasses.dataclass
-class ExistingDependenciesError(Exception):
-    entity_name: str
-    entity_type: str
-    dependencies: list[str]
+@pydantic.dataclasses.dataclass
+class BaseError(Exception):
+    status_code: int = pydantic.Field(
+        description="The HTTP status code of an exception, accepts any int but passed as fastapi.status.DESIRED_STATUS_CODE for code readability",
+        examples=[status.HTTP_404_NOT_FOUND],
+    )
+    title: str = pydantic.Field(
+        description="The title of the error, displayed in the frontend",
+        examples=["User not found"],
+    )
+    reason: str = pydantic.Field(
+        description="The reason for the error and any possible resolutions/next steps, displayed in the frontend",
+        examples=["The user 'username' doesn't exist."],
+    )
+    err_code: str = pydantic.Field(
+        description="The error code of the error, used for logging and debugging, not displayed in the frontend.",
+        examples=["USER_NOT_FOUND"],
+    )
 
 
-async def existing_dependencies_exception_handler(
-    request: fastapi.Request, exc: ExistingDependenciesError
-) -> fastapi.Response:
-    dependencies_str = ", ".join(exc.dependencies)
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class ExistingDependenciesError(BaseError):
+    def __init__(
+        self, entity_name: str, entity_type: str, dependencies: list[str]
+    ):
+        super().__init__(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": [
-                    f"The {exc.entity_type} '{exc.entity_name}' can not be deleted. Please remove the following dependencies first: {dependencies_str}"
-                ]
-            },
-        ),
-    )
+            title=f"{entity_name} cannot be deleted",
+            reason=(
+                f"The {entity_type} '{entity_name}' can not be deleted. "
+                f"Please remove the following dependencies first: {', '.join(dependencies)}"
+            ),
+            err_code="EXISTING_DEPENDENCIES_PREVENT_DELETE",
+        )
 
 
-@dataclasses.dataclass
-class ResourceAlreadyExistsError(Exception):
-    resource_name: str
-    identifier_name: str
-
-
-async def resource_already_exists_exception_handler(
-    request: fastapi.Request, exc: ResourceAlreadyExistsError
-):
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class ResourceAlreadyExistsError(BaseError):
+    def __init__(
+        self,
+        resource_name: str | None = None,
+        identifier_name: str | None = None,
+    ):
+        super().__init__(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "reason": f"A {exc.resource_name} with a similar {exc.identifier_name} already exists.",
-                "technical": f"{exc.identifier_name} already used",
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        ExistingDependenciesError, existing_dependencies_exception_handler  # type: ignore[arg-type]
-    )
-    app.add_exception_handler(
-        ResourceAlreadyExistsError, resource_already_exists_exception_handler  # type: ignore[arg-type]
-    )
+            title=f"{identifier_name} already used",
+            reason=f"A {resource_name} with a similar {identifier_name} already exists.",
+            err_code="RESOURCE_NAME_ALREADY_IN_USE",
+        )

--- a/backend/capellacollab/core/logging/exceptions.py
+++ b/backend/capellacollab/core/logging/exceptions.py
@@ -1,30 +1,16 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import fastapi
-from fastapi import exception_handlers, status
+from fastapi import status
+
+from capellacollab.core import exceptions as core_exceptions
 
 
-class TooManyOutStandingRequests(Exception):
-    pass
-
-
-async def too_many_outstanding_requests_handler(
-    request: fastapi.Request, _: TooManyOutStandingRequests
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class TooManyOutStandingRequests(core_exceptions.BaseError):
+    def __init__(self):
+        super().__init__(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail={
-                "err_code": "LOKI_TOO_MANY_OUTSTANDING_REQUESTS",
-                "reason": "Too many outstanding requests. Please try again later.",
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        TooManyOutStandingRequests, too_many_outstanding_requests_handler  # type: ignore[arg-type]
-    )
+            title="Too many outstanding requests",
+            reason="Too many outstanding requests. Please try again later.",
+            err_code="LOKI_TOO_MANY_OUTSTANDING_REQUESTS",
+        )

--- a/backend/capellacollab/projects/toolmodels/backups/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/backups/exceptions.py
@@ -3,8 +3,9 @@
 
 import enum
 
-import fastapi
-from fastapi import exception_handlers, status
+from fastapi import status
+
+from capellacollab.core import exceptions as core_exceptions
 
 
 class PipelineOperation(enum.Enum):
@@ -12,32 +13,15 @@ class PipelineOperation(enum.Enum):
     DELETE = "delete"
 
 
-class PipelineOperationFailedT4CServerUnreachable(Exception):
+class PipelineOperationFailedT4CServerUnreachable(core_exceptions.BaseError):
     def __init__(self, operation: PipelineOperation):
         self.operation = operation
-
-
-async def pipeline_creation_failed_t4c_server_unreachable_handler(
-    request: fastapi.Request, exc: PipelineOperationFailedT4CServerUnreachable
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+        super().__init__(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "err_code": "PIPELINE_OPERATION_FAILED_T4C_SERVER_UNREACHABLE",
-                "title": f"The '{exc.operation.value}' operation on the pipeline failed",
-                "reason": (
-                    f"We're not able to connect to the TeamForCapella server and therefore cannot {exc.operation.value} the pipeline.",
-                    "Please try again later or contact your administrator.",
-                ),
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        PipelineOperationFailedT4CServerUnreachable,
-        pipeline_creation_failed_t4c_server_unreachable_handler,  # type: ignore[arg-type]
-    )
+            title=f"The '{operation.value}' operation on the pipeline failed",
+            reason=(
+                f"We're not able to connect to the TeamForCapella server and therefore cannot {operation.value} the pipeline. "
+                "Please try again later or contact your administrator."
+            ),
+            err_code="PIPELINE_OPERATION_FAILED_T4C_SERVER_UNREACHABLE",
+        )

--- a/backend/capellacollab/projects/toolmodels/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/exceptions.py
@@ -1,30 +1,17 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import fastapi
-from fastapi import exception_handlers, status
+from fastapi import status
+
+from capellacollab.core import exceptions as core_exceptions
 
 
-class VersionIdNotSetError(Exception):
+class VersionIdNotSetError(core_exceptions.BaseError):
     def __init__(self, toolmodel_id: int):
         self.toolmodel_id = toolmodel_id
-
-
-async def version_id_not_set_exception_handler(
-    request: fastapi.Request, exc: VersionIdNotSetError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+        super().__init__(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": f"The toolmodel with id {exc.toolmodel_id} does not have a version set."
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        VersionIdNotSetError, version_id_not_set_exception_handler  # type: ignore[arg-type]
-    )
+            title="Toolmodel version not set",
+            reason=f"The toolmodel with id {toolmodel_id} does not have a version set.",
+            err_code="VERSION_ID_NOT_SET",
+        )

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
@@ -1,66 +1,34 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
 
-import fastapi
-from fastapi import exception_handlers, status
+from fastapi import status
 
 from .. import exceptions as git_exceptions
 
 
 class GitlabAccessDeniedError(git_exceptions.AccessDeniedError):
-    pass
-
-
-@dataclasses.dataclass
-class GitlabProjectNotFoundError(git_exceptions.RepositoryNotFoundError):
-    project_name: str
-
-
-async def gitlab_access_denied_handler(
-    request: fastapi.Request, _: GitlabAccessDeniedError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+    def __init__(self):
+        super().__init__(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "err_code": "GITLAB_ACCESS_DENIED",
-                "reason": (
-                    "The registered token has not enough permissions to access the Gitlab API.",
-                    "Access scope 'read_api' is required. Please contact your project lead.",
-                ),
-            },
-        ),
-    )
+            title="Insufficient Gitlab API access scope",
+            reason=(
+                "The registered token has not enough permissions to access the Gitlab API. "
+                "Access scope 'read_api' is required. Please contact your project lead."
+            ),
+            err_code="GITLAB_ACCESS_DENIED",
+        )
 
 
-async def gitlab_project_not_found_handler(
-    request: fastapi.Request, exc: GitlabProjectNotFoundError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class GitlabProjectNotFoundError(git_exceptions.RepositoryNotFoundError):
+    def __init__(self, project_name: str):
+        self.project_name = project_name
+        super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "err_code": "PROJECT_NOT_FOUND",
-                "reason": (
-                    "We couldn't find the project in your Gitlab instance.",
-                    f"Please make sure that a project with the encoded name '{exc.project_name}' does exist.",
-                ),
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        GitlabAccessDeniedError,
-        gitlab_access_denied_handler,  # type: ignore[arg-type]
-    )
-
-    app.add_exception_handler(
-        GitlabProjectNotFoundError,
-        gitlab_project_not_found_handler,  # type: ignore[arg-type]
-    )
+            title="Project not found",
+            reason=(
+                f"We couldn't find the project in your Gitlab instance. "
+                f"Please make sure that a project with the encoded name '{project_name}' does exist."
+            ),
+            err_code="PROJECT_NOT_FOUND",
+        )

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/handler/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/handler/exceptions.py
@@ -1,63 +1,29 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
+from fastapi import status
 
-import fastapi
-from fastapi import exception_handlers, status
-
-
-@dataclasses.dataclass
-class GitInstanceUnsupportedError(Exception):
-    instance_name: str
+from capellacollab.core import exceptions as core_exceptions
 
 
-class NoMatchingGitInstanceError(Exception):
-    pass
+class GitInstanceUnsupportedError(core_exceptions.BaseError):
+    def __init__(self, instance_name: str):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            title="Git instance unsupported",
+            reason=f"The Git instance '{instance_name}' doesn't support the requested operation.",
+            err_code="GIT_INSTANCE_UNSUPPORTED",
+        )
 
 
-async def git_instance_unsupported_handler(
-    request: fastapi.Request, exc: GitInstanceUnsupportedError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            detail={
-                "err_code": "GIT_INSTANCE_UNSUPPORTED",
-                "reason": (
-                    f"The Git instance '{exc.instance_name}' doesn't support the requested operation.",
-                ),
-            },
-        ),
-    )
-
-
-async def no_matching_git_instance_handler(
-    request: fastapi.Request, _: NoMatchingGitInstanceError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class NoMatchingGitInstanceError(core_exceptions.BaseError):
+    def __init__(self):
+        super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "err_code": "NO_MATCHING_GIT_INSTANCE",
-                "reason": (
-                    "No matching git instance was found for the primary git model.",
-                    "Please contact your administrator.",
-                ),
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        GitInstanceUnsupportedError,
-        git_instance_unsupported_handler,  # type: ignore[arg-type]
-    )
-
-    app.add_exception_handler(
-        NoMatchingGitInstanceError,
-        no_matching_git_instance_handler,  # type: ignore[arg-type]
-    )
+            title="No matching git instance",
+            reason=(
+                "No matching git instance was found for the primary git model. "
+                "Please contact your administrator."
+            ),
+            err_code="NO_MATCHING_GIT_INSTANCE",
+        )

--- a/backend/capellacollab/sessions/exceptions.py
+++ b/backend/capellacollab/sessions/exceptions.py
@@ -1,124 +1,74 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
+from fastapi import status
 
-import fastapi
-from fastapi import exception_handlers, status
-
+from capellacollab.core import exceptions as core_exceptions
 from capellacollab.projects.toolmodels import models as toolmodels_models
 from capellacollab.sessions import models as sessions_models
 from capellacollab.tools import models as tools_models
 
 
-@dataclasses.dataclass
-class UnsupportedSessionTypeError(Exception):
-    tool: tools_models.DatabaseTool
-    session_type: sessions_models.SessionType
-
-
-@dataclasses.dataclass
-class ConflictingSessionError(Exception):
-    tool: tools_models.DatabaseTool
-    version: tools_models.DatabaseVersion
-    session_type: sessions_models.SessionType
-
-
-@dataclasses.dataclass
-class ToolAndModelMismatchError(Exception):
-    version: tools_models.DatabaseVersion
-    model: toolmodels_models.DatabaseToolModel
-
-
-@dataclasses.dataclass
-class InvalidConnectionMethodIdentifierError(Exception):
-    tool: tools_models.DatabaseTool
-    connection_method_id: str
-
-
-async def unsupported_session_type_handler(
-    request: fastapi.Request, exc: UnsupportedSessionTypeError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class UnsupportedSessionTypeError(core_exceptions.BaseError):
+    def __init__(
+        self,
+        tool: tools_models.DatabaseTool,
+        session_type: sessions_models.SessionType,
+    ):
+        super().__init__(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "err_code": "SESSION_TYPE_UNSUPPORTED",
-                "reason": (
-                    f"The tool {exc.tool.name} doesn't support the session type '{exc.session_type.value}'"
-                ),
-            },
-        ),
-    )
+            title="Session type unsupported",
+            reason=(
+                f"The tool {tool.name} doesn't support the session type '{session_type.value}'."
+            ),
+            err_code="SESSION_TYPE_UNSUPPORTED",
+        )
 
 
-async def conflicting_session_handler(
-    request: fastapi.Request, exc: ConflictingSessionError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class ConflictingSessionError(core_exceptions.BaseError):
+    def __init__(
+        self,
+        tool: tools_models.DatabaseTool,
+        version: tools_models.DatabaseVersion,
+    ):
+        super().__init__(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "err_code": "EXISTING_SESSION",
-                "reason": (
-                    f"You already have a '{exc.tool.name}' session with version '{exc.version.name}'. "
-                    "Please terminate the existing session or reconnect to it."
-                ),
-            },
-        ),
-    )
+            title="Conflicting session",
+            reason=(
+                f"You already have a '{tool.name}' session with version '{version.name}'. "
+                "Please terminate the existing session or reconnect to it."
+            ),
+            err_code="EXISTING_SESSION",
+        )
 
 
-async def tool_and_model_mismatch_handler(
-    request: fastapi.Request, exc: ToolAndModelMismatchError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class ToolAndModelMismatchError(core_exceptions.BaseError):
+    def __init__(
+        self,
+        version: tools_models.DatabaseVersion,
+        model: toolmodels_models.DatabaseToolModel,
+    ):
+        super().__init__(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "err_code": "MODEL_VERSION_MISMATCH",
-                "reason": (
-                    f"The model '{exc.model.name}' is not compatible with the tool {exc.version.tool.name} ({exc.version.name})'."
-                ),
-            },
-        ),
-    )
+            title="Model version mismatch",
+            reason=(
+                f"The model '{model.name}' is not compatible with the tool {version.tool.name} ({version.name})'."
+            ),
+            err_code="MODEL_VERSION_MISMATCH",
+        )
 
 
-async def invalid_connection_method_identifier_handler(
-    request: fastapi.Request, exc: InvalidConnectionMethodIdentifierError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class InvalidConnectionMethodIdentifierError(core_exceptions.BaseError):
+    def __init__(
+        self,
+        tool: tools_models.DatabaseTool,
+        connection_method_id: str,
+    ):
+        super().__init__(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={
-                "err_code": "CONNECTION_METHOD_UNKNOWN",
-                "reason": (
-                    f"The connection method with identifier '{exc.connection_method_id}' doesn't exist on the tool '{exc.tool.name}'."
-                ),
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        UnsupportedSessionTypeError,
-        unsupported_session_type_handler,  # type: ignore[arg-type]
-    )
-    app.add_exception_handler(
-        ConflictingSessionError,
-        conflicting_session_handler,  # type: ignore[arg-type]
-    )
-    app.add_exception_handler(
-        ToolAndModelMismatchError,
-        tool_and_model_mismatch_handler,  # type: ignore[arg-type]
-    )
-    app.add_exception_handler(
-        InvalidConnectionMethodIdentifierError,
-        invalid_connection_method_identifier_handler,  # type: ignore[arg-type]
-    )
+            title="Connection method unknown",
+            reason=(
+                f"The connection method with identifier '{connection_method_id}' doesn't exist on the tool '{tool.name}'."
+            ),
+            err_code="CONNECTION_METHOD_UNKNOWN",
+        )

--- a/backend/capellacollab/sessions/util.py
+++ b/backend/capellacollab/sessions/util.py
@@ -90,7 +90,7 @@ def raise_if_conflicting_sessions(
         version.id,
         workspace_type,
     ) in existing_tool_version_workspace_combinations:
-        raise exceptions.ConflictingSessionError(tool, version, workspace_type)
+        raise exceptions.ConflictingSessionError(tool, version)
 
 
 def resolve_environment_variables(

--- a/backend/capellacollab/settings/modelsources/t4c/exceptions.py
+++ b/backend/capellacollab/settings/modelsources/t4c/exceptions.py
@@ -1,46 +1,24 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
-
-import fastapi
-from fastapi import exception_handlers, status
+from fastapi import status
 
 from capellacollab.core import exceptions as core_exceptions
 
 
-class T4CInstanceIsArchivedError(Exception):
+class T4CInstanceIsArchivedError(core_exceptions.BaseError):
     def __init__(self, t4c_instance_id: int):
         self.t4c_instance_id = t4c_instance_id
-
-
-async def t4c_instance_is_archived_exception_handler(
-    request: fastapi.Request, exc: T4CInstanceIsArchivedError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+        super().__init__(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={
-                "reason": f"The T4C instance identified by {exc.t4c_instance_id} is archived, thus prohibiting the execution of the requested operation."
-            },
-        ),
-    )
+            title="T4C instance is archived",
+            reason=f"The T4C instance identified by {t4c_instance_id} is archived, thus prohibiting the execution of the requested operation.",
+            err_code="T4C_INSTANCE_IS_ARCHIVED",
+        )
 
 
-@dataclasses.dataclass
 class T4CInstanceWithNameAlreadyExistsError(
     core_exceptions.ResourceAlreadyExistsError
 ):
     def __init__(self):
         super().__init__(resource_name="T4C Instance", identifier_name="name")
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        T4CInstanceIsArchivedError, t4c_instance_is_archived_exception_handler  # type: ignore[arg-type]
-    )
-    app.add_exception_handler(
-        T4CInstanceWithNameAlreadyExistsError,
-        core_exceptions.resource_already_exists_exception_handler,  # type: ignore[arg-type]
-    )

--- a/backend/capellacollab/tools/exceptions.py
+++ b/backend/capellacollab/tools/exceptions.py
@@ -1,53 +1,29 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import fastapi
-from fastapi import exception_handlers, status
+from fastapi import status
+
+from capellacollab.core import exceptions as core_exceptions
 
 
-class ToolVersionNotFoundError(Exception):
+class ToolVersionNotFoundError(core_exceptions.BaseError):
     def __init__(self, version_id: int):
         self.version_id = version_id
-
-
-async def tool_version_not_found_exception_handler(
-    request: fastapi.Request, exc: ToolVersionNotFoundError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+        super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": f"The tool version with id {exc.version_id} was not found."
-            },
-        ),
-    )
+            title="Tool version not found",
+            reason=f"The tool version with id {version_id} was not found.",
+            err_code="TOOL_VERSION_NOT_FOUND",
+        )
 
 
-class ToolImageNotFoundError(Exception):
+class ToolImageNotFoundError(core_exceptions.BaseError):
     def __init__(self, tool_id: int, image_name: str):
         self.tool_id = tool_id
         self.image_name = image_name
-
-
-async def tool_image_not_found_exception_handler(
-    request: fastapi.Request, exc: ToolImageNotFoundError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+        super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "reason": f"The tool with id {exc.tool_id} doesn't have a {exc.image_name} image."
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        ToolVersionNotFoundError, tool_version_not_found_exception_handler  # type: ignore[arg-type]
-    )
-    app.add_exception_handler(
-        ToolImageNotFoundError, tool_image_not_found_exception_handler  # type: ignore[arg-type]
-    )
+            title="Tool image not found",
+            reason=f"The tool with id {tool_id} doesn't have a {image_name} image.",
+            err_code="TOOL_IMAGE_NOT_FOUND",
+        )

--- a/backend/capellacollab/users/exceptions.py
+++ b/backend/capellacollab/users/exceptions.py
@@ -1,34 +1,19 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
+from fastapi import status
 
-import fastapi
-from fastapi import exception_handlers, status
-
-
-@dataclasses.dataclass
-class UserNotFoundError(Exception):
-    username: str | None = None
-    user_id: int | None = None
+from capellacollab.core import exceptions as core_exceptions
 
 
-async def user_not_found_exception_handler(
-    request: fastapi.Request, exc: UserNotFoundError
-) -> fastapi.Response:
-    return await exception_handlers.http_exception_handler(
-        request,
-        fastapi.HTTPException(
+class UserNotFoundError(core_exceptions.BaseError):
+
+    def __init__(
+        self, username: str | None = None, user_id: int | None = None
+    ):
+        super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "title": "User not found",
-                "reason": f"The user '{exc.username or exc.user_id}' doesn't exist.",
-            },
-        ),
-    )
-
-
-def register_exceptions(app: fastapi.FastAPI):
-    app.add_exception_handler(
-        UserNotFoundError, user_not_found_exception_handler  # type: ignore[arg-type]
-    )
+            title="User not found",
+            reason=f"The user '{username or user_id}' doesn't exist.",
+            err_code="USER_NOT_FOUND",
+        )

--- a/backend/capellacollab/users/routes.py
+++ b/backend/capellacollab/users/routes.py
@@ -37,7 +37,10 @@ def get_current_user(
     return user
 
 
-@router.get("/{user_id}", response_model=models.User)
+@router.get(
+    "/{user_id}",
+    response_model=models.User,
+)
 def get_user(
     own_user: models.DatabaseUser = fastapi.Depends(injectables.get_own_user),
     user: models.DatabaseUser = fastapi.Depends(injectables.get_existing_user),

--- a/backend/tests/settings/teamforcapella/test_t4c_instances.py
+++ b/backend/tests/settings/teamforcapella/test_t4c_instances.py
@@ -82,7 +82,7 @@ def test_create_t4c_instance_already_existing_name(
         "A T4C Instance with a similar name already exists."
         in detail["reason"]
     )
-    assert "name already used" in detail["technical"]
+    assert "name already used" in detail["title"]
 
 
 @pytest.mark.usefixtures("t4c_instance")
@@ -245,7 +245,7 @@ def test_patch_t4c_instance_already_existing_name(
         "A T4C Instance with a similar name already exists."
         in detail["reason"]
     )
-    assert "name already used" in detail["technical"]
+    assert "name already used" in detail["title"]
 
 
 def test_injectables_raise_when_archived_instance(

--- a/docs/docs/development/backend/exception.md
+++ b/docs/docs/development/backend/exception.md
@@ -8,38 +8,38 @@
 Various errors can occur in the backend, which must be made understandable to
 the end user and the developers when calling the API.
 
-In general, please use the following syntax to return a error message from the
-backend:
+In order to maintain consistency and benefit from automatic exception
+registration, define exceptions in a route-specific exceptions.py file in the
+following manner:
 
-```py title="routes.py"
-from fastapi import HTTPException
+```py title="exceptions.py"
+from fastapi import status
+from capellacollab.core import exceptions as core_exceptions
 
-raise HTTPException(
-    status_code=403,  # (1)
-    detail={
-        "err_code": "project_deletion_permission_denied",  # (2)
-        "title": "Permission denied",  # (3)
-        "reason": (
-            "You don't have the permission to delete projects.",
-            "Please ask your administrator to delete the project.",
-        ),  # (4)
-        "technical": "The role administrator is required.",  # (5)
-    },
-)
+class UserNotFoundError(core_exceptions.BaseError): # (1)
+    def __init__(
+        self, username: str | None = None, user_id: int | None = None # (2)
+    ):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND, # (3)
+            title="User not found", # (4)
+            reason=f"The user '{username or user_id}' doesn't exist.", # (5)
+            err_code="USER_NOT_FOUND" # (6)
+        )
 ```
 
-## Important Hints for Exceptions
-
-1. Please use the corresponding HTTP response status code here. More
-   information about status codes:
+1. Exceptions should be defined as subclasses of BaseError from the core
+   exceptions module.
+2. Any additional data beyond the required BaseError parameters can be supplied
+   when initializing an exception.
+3. _Required_: Supply the corresponding HTTP response status code for the
+   exception. More information about status codes:
    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Status>
-1. _Optional_: Unique error code (as string). Can be evaluated in the frontend
-   to identify a specific error.
-1. _Optional_: Use a title that is automatically displayed in the frontend
-   (only works when the `reason` parameter is provided).
-1. _Optional_: Use a message that is automatically displayed in the frontend
-   for users. Since the message will be displayed to end users, it should
-   contain context for classification and should be user-friendly (not
-   technical!)
-1. _Optional_: Technical message for developers, not displayed in the frontend.
-   Is part of the error response json.
+4. _Required_: Supply a descriptive title for the exception. This will be
+   displayed in the frontend.
+5. _Required_: Supply the reason the exception occurred. This will be displayed
+   in the frontend. It should contain context for classification and should be
+   user-friendly, or contain information on a resolution or next step.
+6. _Required_: Supply a unique error code (as string). This can be evaluated in
+   the frontend to identify a specific error, or more easily filtered for in
+   logs.


### PR DESCRIPTION
As a step towards resolving issue #1369, this PR:

- Adds a class BaseError to the core exceptions module for other exceptions to inherit from
   - Required: _status_code_, _title_, _reason_. Optional: _err_code_. (_technical_ was not included as it only existed on one error at this time)
- Updates all existing exceptions defined in external exceptions files to use BaseError, and updates them to meet its requirements if they did not already
- Generates and registers exception handlers for all of BaseErrors children in the main application
   - (and as a result removes all excess handler definitions, handler registrations, and imports throughout the exception files and main app file)
- Updates the documentation to reflect the new format 