### PR TITLE
fix: Pass resources to manually schedules jobs

### DIFF
--- a/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/interface.py
@@ -80,6 +80,7 @@ def _schedule_pending_jobs():
                         pending_run.pipeline.t4c_password,
                         pending_run.pipeline.include_commit_history,
                     ),
+                    tool_resources=pending_run.pipeline.model.tool.config.resources,
                 )
                 pending_run.reference_id = job_name
                 pending_run.status = models.PipelineRunStatus.SCHEDULED


### PR DESCRIPTION
This fixes a bug that pipelines weren't scheduled when triggered manually.