### PR TITLE
fix: Remove deprecated interface in authentication

### DIFF
--- a/backend/capellacollab/core/authentication/__init__.py
+++ b/backend/capellacollab/core/authentication/__init__.py
@@ -11,9 +11,9 @@ def get_authentication_entrypoint():
     try:
         ep = next(
             i
-            for i in metadata.entry_points()[
-                "capellacollab.authentication.providers"
-            ]
+            for i in metadata.entry_points().select(
+                group="capellacollab.authentication.providers"
+            )
             if i.name == config["authentication"]["provider"]
         )
         return ep

--- a/docs/docs/development/backend/extensions.md
+++ b/docs/docs/development/backend/extensions.md
@@ -78,7 +78,7 @@ The `routes` and `models` components are then imported in the code: For
 example, to include the routers, we use the following code:
 
 ```py title="routes.py"
-eps = metadata.entry_points()["capellacollab.extensions"]
+eps = metadata.entry_points().select(group="capellacollab.extensions")
 for ep in eps:
     log.info("Add routes of extension %s", ep.name)
     router.include_router(


### PR DESCRIPTION
Fix for the following deprecation warning:

capellacollab/core/authentication/__init__.py:14
capellacollab/core/authentication/__init__.py:14
  /Users/nicholasromeo/code/capella-collab-manager/backend/capellacollab/core/authentication/__init__.py:14: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for i in metadata.entry_points()[
