### PR TITLE
fix: Update user test to eliminate deprecation warning in request

### DIFF
--- a/backend/tests/test_event_creation.py
+++ b/backend/tests/test_event_creation.py
@@ -206,7 +206,7 @@ def test_create_user_removed_from_project_event(
     response = client.request(
         "DELETE",
         f"/api/v1/projects/{project.slug}/users/{user.id}",
-        data=reason,
+        content=reason,
         headers={"Content-Type": "text/plain"},
     )
 


### PR DESCRIPTION
Eliminates the following deprecation warning in test_create_user_removed_from_project_event.
https://www.python-httpx.org/compatibility/#request-content - "content" is preferred over "data" in this scenario

tests/test_event_creation.py::test_create_user_removed_from_project_event
  /Users/nicholasromeo/code/capella-collab-manager/.venv/lib/python3.11/site-packages/httpx/_content.py:204: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
    warnings.warn(message, DeprecationWarning)