### PR TITLE
feat: Add tool info to session deletion dialog

### DIFF
--- a/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.css
+++ b/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.css
@@ -1,4 +1,0 @@
-/*
- * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
- * SPDX-License-Identifier: Apache-2.0
- */

--- a/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.html
+++ b/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.html
@@ -8,13 +8,14 @@
   <div>
     <p>Do you want to terminate the following session(s)?</p>
     <hr />
-    <div *ngFor="let session of sessions">
+    @for (session of sessions; track session.id) {
       <div class="my-2">
         ID: {{ session.id }} <br />
         Owner: {{ session.owner.name }} <br />
+        Tool: {{ session.version!.tool.name }} ({{ session.version!.name }})
       </div>
       <hr />
-    </div>
+    }
     <div class="my-2">
       This will force close the sessions and all unsaved work will be lost!
     </div>

--- a/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.ts
+++ b/frontend/src/app/sessions/delete-session-dialog/delete-session-dialog.component.ts
@@ -10,7 +10,6 @@ import { Session, SessionService } from '../service/session.service';
 
 @Component({
   templateUrl: './delete-session-dialog.component.html',
-  styleUrls: ['./delete-session-dialog.component.css'],
 })
 export class DeleteSessionDialogComponent {
   constructor(


### PR DESCRIPTION
This PR adds the tool information to the session termination dialog in the same format as it is displayed in the session card. This makes it easier for a user to identify which session is being closed when they click on "Terminate", as the ID is not known to the user. In addition, the empty css file has been removed and the new Angular control is now used in the component.