### PR TITLE
feat: Enable pylints' invalid name rule C0103

### DIFF
--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -352,7 +352,7 @@ def create_t4c_instance_and_repositories(db):
     default_instance = settings_t4c_models.DatabaseT4CInstance(
         name="default",
         license="placeholder",
-        protocol=settings_t4c_models.Protocol.tcp,
+        protocol=settings_t4c_models.Protocol.TCP,
         host="localhost",
         port=2036,
         cdo_port=12036,

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -46,7 +46,7 @@ loki_enabled: bool = cfg.promtail.loki_enabled
 
 image_pull_policy: str = cfg.cluster.image_pull_policy
 
-pod_security_context = None
+pod_security_context = None  # pylint: disable=invalid-name
 if _pod_security_context := cfg.cluster.pod_security_context:
     pod_security_context = client.V1PodSecurityContext(
         **_pod_security_context.__dict__

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -42,10 +42,10 @@ class GetSessionUsageResponse(core_pydantic.BaseModel):
 
 
 class Protocol(str, enum.Enum):
-    tcp = "tcp"
-    ssl = "ssl"
-    ws = "ws"
-    wss = "wss"
+    TCP = "tcp"
+    SSL = "ssl"
+    WS = "ws"
+    WSS = "wss"
 
 
 class DatabaseT4CInstance(database.Base):
@@ -86,7 +86,7 @@ class DatabaseT4CInstance(database.Base):
         sa.CheckConstraint("cdo_port >= 0 AND cdo_port <= 65535"),
         default=12036,
     )
-    protocol: orm.Mapped[Protocol] = orm.mapped_column(default=Protocol.tcp)
+    protocol: orm.Mapped[Protocol] = orm.mapped_column(default=Protocol.TCP)
 
     is_archived: orm.Mapped[bool] = orm.mapped_column(default=False)
 

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -23,9 +23,9 @@ from . import crud, injectables, interface, models
 router = fastapi.APIRouter()
 log = logging.getLogger(__name__)
 
-T4CRepositoriesResponseModel: t.TypeAlias = core_models.PayloadResponseModel[
-    list[models.T4CRepository]
-]
+T4CRepositoriesResponseModel: t.TypeAlias = (  # pylint: disable=invalid-name
+    core_models.PayloadResponseModel[list[models.T4CRepository]]
+)
 
 
 @router.get("", response_model=T4CRepositoriesResponseModel)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -159,7 +159,6 @@ disable = [
   "cyclic-import",
   "global-statement",
   "import-outside-toplevel",
-  "invalid-name",
   "missing-class-docstring",
   "missing-function-docstring",
   "missing-module-docstring",

--- a/backend/tests/settings/teamforcapella/conftest.py
+++ b/backend/tests/settings/teamforcapella/conftest.py
@@ -24,7 +24,7 @@ def fixture_t4c_instance(
         rest_api="http://localhost:8080/api/v1.0",
         username="user",
         password="pass",
-        protocol=t4c_models.Protocol.tcp,
+        protocol=t4c_models.Protocol.TCP,
         version=test_tool_version,
     )
 


### PR DESCRIPTION
This PR enables pylints' invalid-name rule, i.e., C0130 and fixes resulting issues. One issue was properly fixed by changing constant enum fields to uppercase and two other issues were simply ignored. The first ignored issue, i.e., the naming problem of `T4CRepositoriesResponseModel` is not compliant due to the two directly preceding capital letters `CR`, which is intended here. The second problem is a false positive, since `pod_security_context` is considered a *constant*, but there are two places where we assign it a value, i.e., it is not actually constant.

Resolves #1379