### PR TITLE
fix: Automount service token to prometheus

### DIFF
--- a/helm/templates/grafana/grafana.deployment.yaml
+++ b/helm/templates/grafana/grafana.deployment.yaml
@@ -16,6 +16,8 @@ spec:
   selector:
     matchLabels:
       id: {{ .Release.Name }}-deployment-grafana-server
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -15,6 +15,8 @@ spec:
   selector:
     matchLabels:
       id: {{ .Release.Name }}-deployment-prometheus-server
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/prometheus/prometheus.configmap.yaml") . | sha256sum }}
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       serviceAccountName: {{ .Release.Name }}-prometheus
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:


### PR DESCRIPTION
This PR reverses a change that was introduced in https://github.com/DSD-DBS/capella-collab-manager/pull/1414, where the automatic mounting of service accounts for Prometheus was disabled. This is necessary because Prometheus needs access to the kubernetees API for its service discovery. 
Additionally, this PR adds the `Recreate` strategy to two deployments that use at least one volume with the `ReadWriteOnce` storage access mode. This is required to properly apply changes and deploy these components, because otherwise the creation will be blocked by the existing pod.