### PR TITLE
Revert "feat: Enable pylints' invalid name rule C0103"

### DIFF
--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -352,7 +352,7 @@ def create_t4c_instance_and_repositories(db):
     default_instance = settings_t4c_models.DatabaseT4CInstance(
         name="default",
         license="placeholder",
-        protocol=settings_t4c_models.Protocol.TCP,
+        protocol=settings_t4c_models.Protocol.tcp,
         host="localhost",
         port=2036,
         cdo_port=12036,

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -46,7 +46,7 @@ loki_enabled: bool = cfg.promtail.loki_enabled
 
 image_pull_policy: str = cfg.cluster.image_pull_policy
 
-pod_security_context = None  # pylint: disable=invalid-name
+pod_security_context = None
 if _pod_security_context := cfg.cluster.pod_security_context:
     pod_security_context = client.V1PodSecurityContext(
         **_pod_security_context.__dict__

--- a/backend/capellacollab/settings/modelsources/t4c/models.py
+++ b/backend/capellacollab/settings/modelsources/t4c/models.py
@@ -42,10 +42,10 @@ class GetSessionUsageResponse(core_pydantic.BaseModel):
 
 
 class Protocol(str, enum.Enum):
-    TCP = "tcp"
-    SSL = "ssl"
-    WS = "ws"
-    WSS = "wss"
+    tcp = "tcp"
+    ssl = "ssl"
+    ws = "ws"
+    wss = "wss"
 
 
 class DatabaseT4CInstance(database.Base):
@@ -86,7 +86,7 @@ class DatabaseT4CInstance(database.Base):
         sa.CheckConstraint("cdo_port >= 0 AND cdo_port <= 65535"),
         default=12036,
     )
-    protocol: orm.Mapped[Protocol] = orm.mapped_column(default=Protocol.TCP)
+    protocol: orm.Mapped[Protocol] = orm.mapped_column(default=Protocol.tcp)
 
     is_archived: orm.Mapped[bool] = orm.mapped_column(default=False)
 

--- a/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/routes.py
@@ -23,9 +23,9 @@ from . import crud, injectables, interface, models
 router = fastapi.APIRouter()
 log = logging.getLogger(__name__)
 
-T4CRepositoriesResponseModel: t.TypeAlias = (  # pylint: disable=invalid-name
-    core_models.PayloadResponseModel[list[models.T4CRepository]]
-)
+T4CRepositoriesResponseModel: t.TypeAlias = core_models.PayloadResponseModel[
+    list[models.T4CRepository]
+]
 
 
 @router.get("", response_model=T4CRepositoriesResponseModel)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -159,6 +159,7 @@ disable = [
   "cyclic-import",
   "global-statement",
   "import-outside-toplevel",
+  "invalid-name",
   "missing-class-docstring",
   "missing-function-docstring",
   "missing-module-docstring",

--- a/backend/tests/settings/teamforcapella/conftest.py
+++ b/backend/tests/settings/teamforcapella/conftest.py
@@ -24,7 +24,7 @@ def fixture_t4c_instance(
         rest_api="http://localhost:8080/api/v1.0",
         username="user",
         password="pass",
-        protocol=t4c_models.Protocol.TCP,
+        protocol=t4c_models.Protocol.tcp,
         version=test_tool_version,
     )
 


### PR DESCRIPTION
This reverts commit addaf07d5542f9bfb5c92a4553b680c1ac71c0dd.

Reason is a failing backend startup with the following stacktrace:

```python
ERROR:    Traceback (most recent call last):
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/sql/sqltypes.py", line 1637, in _object_value_for_elem
    return self._object_lookup[elem]
           ~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'tcp'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/starlette/routing.py", line 677, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/opt/homebrew/Cellar/python@3.11/3.11.8/Frameworks/Python.framework/Versions/3.11/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/fastapi_pagination/api.py", line 382, in lifespan
    async with _original_lifespan_context(app) as maybe_state:
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/starlette/routing.py", line 566, in __aenter__
    await self._router.startup()
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/starlette/routing.py", line 656, in startup
    handler()
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/capellacollab/settings/modelsources/t4c/metrics.py", line 65, in register
    prometheus_client.REGISTRY.register(UsedT4CLicensesCollector())
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/prometheus_client/registry.py", line 26, in register
    names = self._get_names(collector)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/prometheus_client/registry.py", line 66, in _get_names
    for metric in desc_func():
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/capellacollab/settings/modelsources/t4c/metrics.py", line 23, in collect
    instances = crud.get_t4c_instances(db)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/capellacollab/settings/modelsources/t4c/crud.py", line 17, in get_t4c_instances
    return db.execute(sa.select(models.DatabaseT4CInstance)).scalars().all()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 1786, in all
    return self._allrows()
           ^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 554, in _allrows
    rows = self._fetchall_impl()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 1693, in _fetchall_impl
    return self._real_result._fetchall_impl()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 2293, in _fetchall_impl
    return list(self.iterator)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/orm/loading.py", line 191, in chunks
    fetch = cursor._raw_all_rows()
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 547, in _raw_all_rows
    return [make_row(row) for row in rows]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 547, in <listcomp>
    return [make_row(row) for row in rows]
            ^^^^^^^^^^^^^
  File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 16, in sqlalchemy.cyextension.resultproxy.BaseRow.__init__
  File "lib/sqlalchemy/cyextension/resultproxy.pyx", line 73, in sqlalchemy.cyextension.resultproxy._apply_processors
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/sql/sqltypes.py", line 1757, in process
    value = self._object_value_for_elem(value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/moritzweber/Projects/github/capella-collab-manager/backend/.venv/lib/python3.11/site-packages/sqlalchemy/sql/sqltypes.py", line 1639, in _object_value_for_elem
    raise LookupError(
LookupError: 'tcp' is not among the defined enum values. Enum name: protocol. Possible values: TCP, SSL, WS, WSS
```