### PR TITLE
docs: Disable font loading from Google fonts

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,6 +4,7 @@
 site_name: Capella Collaboration Manager Documentation
 theme:
   name: material
+  font: false
   custom_dir: custom_theme/
   features:
     - content.code.copy


### PR DESCRIPTION
Loading fonts from Google Fonts is not GDPR compliant. Instead, fall-back to the system font.