### PR TITLE
fix(sessions): Don't resolve encodings in sessions proxy

### DIFF
--- a/helm/templates/sessions/sessions.configmap.yaml
+++ b/helm/templates/sessions/sessions.configmap.yaml
@@ -39,8 +39,9 @@ data:
 
             location ~ ^/session/([a-z]+)/(.*)$ {
               set $ccm_session_id $1;
+              set $query $2;
               auth_request /auth;
-              proxy_pass http://$ccm_session_id.{{ .Values.backend.k8sSessionNamespace }}.svc.cluster.local:80/session/$ccm_session_id/$2$is_args$args;
+              proxy_pass http://$ccm_session_id.{{ .Values.backend.k8sSessionNamespace }}.svc.cluster.local:80/session/$ccm_session_id/$query$is_args$args;
             }
 
             location ~ ^/session/([a-z]+) {


### PR DESCRIPTION
nginx did resolve some encodings in the sessions proxy, for example %20 was rewritten to a whitespace. This led to "Bad request" errors in sessions.

The behaviour itself is interesting, the workaround too. I found the solution on StackOverflow:
https://stackoverflow.com/a/31440150