### PR TITLE
fix: Don't mount service account token to session containers

### DIFF
--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -521,6 +521,7 @@ class KubernetesOperator:
                         labels={"app": name, "workload": "session"}
                     ),
                     spec=client.V1PodSpec(
+                        automount_service_account_token=False,
                         security_context=pod_security_context,
                         containers=containers,
                         volumes=k8s_volumes,


### PR DESCRIPTION
The sessions don't need the service account token. For increased security, I remove it.