### PR TITLE
feat: Limit the number of models requested

### DIFF
--- a/backend/capellacollab/sessions/exceptions.py
+++ b/backend/capellacollab/sessions/exceptions.py
@@ -72,3 +72,15 @@ class InvalidConnectionMethodIdentifierError(core_exceptions.BaseError):
             ),
             err_code="CONNECTION_METHOD_UNKNOWN",
         )
+
+
+class TooManyModelsRequestedToProvisionError(core_exceptions.BaseError):
+    def __init__(self, max_number_of_models: int):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            title="Too many models requested",
+            reason=(
+                f"The selected tool only supports up to {max_number_of_models} provisioned model(s) per session."
+            ),
+            err_code="TOO_MANY_MODELS_REQUESTED",
+        )

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -205,6 +205,14 @@ class ToolModelProvisioning(pydantic.BaseModel):
         ),
         examples=["/models", "/provisioned"],
     )
+    max_number_of_models: int | None = pydantic.Field(
+        default=None,
+        description=(
+            "Maximum number of models that can be provisioned. "
+            "If set to None, there is no limit."
+        ),
+        examples=[None, 1],
+    )
 
 
 class ToolSessionConfiguration(pydantic.BaseModel):

--- a/backend/tests/tools/fixtures.py
+++ b/backend/tests/tools/fixtures.py
@@ -77,14 +77,26 @@ def fixture_tool_nature(
     return nature
 
 
+@pytest.fixture(name="capella_tool", params=["6.0.0"])
+def fixture_capella_tool(db: orm.Session) -> tools_models.DatabaseTool:
+    capella_tool = tools_crud.get_tool_by_name(db, "Capella")
+    assert capella_tool
+
+    return capella_tool
+
+
 @pytest.fixture(name="capella_tool_version", params=["6.0.0"])
 def fixture_capella_tool_version(
     db: orm.Session,
+    capella_tool: tools_models.DatabaseTool,
     request: pytest.FixtureRequest,
 ) -> tools_models.DatabaseVersion:
-    return tools_crud.get_version_by_tool_id_version_name(
-        db, tools_crud.get_tool_by_name(db, "Capella").id, request.param
+    capella_tool_version = tools_crud.get_version_by_tool_id_version_name(
+        db, capella_tool.id, request.param
     )
+    assert capella_tool_version
+
+    return capella_tool_version
 
 
 @pytest.fixture(name="jupyter_tool")

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: CC0-1.0
+
+**/*.mdx

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -127,8 +127,6 @@ import { FileBrowserDialogComponent } from './sessions/user-sessions-wrapper/act
 import { FileExistsDialogComponent } from './sessions/user-sessions-wrapper/active-sessions/file-browser-dialog/file-exists-dialog/file-exists-dialog.component';
 import { CreateReadonlySessionComponent } from './sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component';
 import { CreatePersistentSessionComponent } from './sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component';
-import { CreateReadonlyModelOptionsComponent } from './sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component';
-import { CreateReadonlySessionDialogComponent } from './sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component';
 import { UserSessionsWrapperComponent } from './sessions/user-sessions-wrapper/user-sessions-wrapper.component';
 import { AlertSettingsComponent } from './settings/core/alert-settings/alert-settings.component';
 import { ConfigurationSettingsComponent } from './settings/core/configuration-settings/configuration-settings.component';
@@ -174,9 +172,7 @@ import { UsersProfileComponent } from './users/users-profile/users-profile.compo
     CreateModelComponent,
     CreatePersistentSessionComponent,
     CreateProjectComponent,
-    CreateReadonlyModelOptionsComponent,
     CreateReadonlySessionComponent,
-    CreateReadonlySessionDialogComponent,
     CreateT4cModelNewRepositoryComponent,
     CreateToolComponent,
     DeleteGitSettingsDialogComponent,

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component.html
@@ -9,44 +9,48 @@
       modelOptions.model.name
     }}</mat-checkbox>
   </h2>
-  <fieldset *ngIf="form.controls.include.value">
-    <mat-form-field appearance="fill">
-      <mat-label>Branch, tag or revision</mat-label>
-      <input
-        (ngModelChange)="filterRevisionsByPrefix($event)"
-        matInput
-        formControlName="revision"
-        [matAutocomplete]="auto"
-      />
-      <mat-error *ngIf="form.controls.revision.errors?.required">
-        A revision is required
-      </mat-error>
-      <mat-error
-        *ngIf="
-          form.controls.revision.errors?.revisionNotFoundError &&
-          form.controls.revision.value
-        "
-      >
-        {{ form.controls.revision.errors?.revisionNotFoundError }}
-      </mat-error>
-    </mat-form-field>
-    <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
-      <mat-optgroup label="branch">
-        <mat-option
-          *ngFor="let branch of filteredRevisions?.branches"
-          [value]="branch"
+  @if (form.controls.include.value) {
+    <fieldset>
+      <mat-form-field appearance="fill">
+        <mat-label>Branch, tag or revision</mat-label>
+        <input
+          (ngModelChange)="filterRevisionsByPrefix($event)"
+          matInput
+          formControlName="revision"
+          [matAutocomplete]="auto"
+        />
+        <mat-error *ngIf="form.controls.revision.errors?.required">
+          A revision is required
+        </mat-error>
+        <mat-error
+          *ngIf="
+            form.controls.revision.errors?.revisionNotFoundError &&
+            form.controls.revision.value
+          "
         >
-          {{ branch }}
-        </mat-option>
-      </mat-optgroup>
-      <mat-optgroup label="tag">
-        <mat-option *ngFor="let tag of filteredRevisions?.tags" [value]="tag">
-          {{ tag }}
-        </mat-option>
-      </mat-optgroup>
-    </mat-autocomplete>
-  </fieldset>
-  <fieldset *ngIf="form.controls.include.value">
-    <mat-slide-toggle formControlName="deepClone">Deep clone</mat-slide-toggle>
-  </fieldset>
+          {{ form.controls.revision.errors?.revisionNotFoundError }}
+        </mat-error>
+      </mat-form-field>
+      <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
+        <mat-optgroup label="branch">
+          <mat-option
+            *ngFor="let branch of filteredRevisions?.branches"
+            [value]="branch"
+          >
+            {{ branch }}
+          </mat-option>
+        </mat-optgroup>
+        <mat-optgroup label="tag">
+          <mat-option *ngFor="let tag of filteredRevisions?.tags" [value]="tag">
+            {{ tag }}
+          </mat-option>
+        </mat-optgroup>
+      </mat-autocomplete>
+    </fieldset>
+    <fieldset>
+      <mat-slide-toggle formControlName="deepClone">
+        Deep clone
+      </mat-slide-toggle>
+    </fieldset>
+  }
 </div>

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component.ts
@@ -3,8 +3,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NgFor, NgIf } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
-import { Validators, FormBuilder } from '@angular/forms';
+import {
+  Validators,
+  FormBuilder,
+  ReactiveFormsModule,
+  FormsModule,
+} from '@angular/forms';
+import {
+  MatAutocomplete,
+  MatAutocompleteTrigger,
+  MatOptgroup,
+  MatOption,
+} from '@angular/material/autocomplete';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { filter } from 'rxjs';
 import { Model } from 'src/app/projects/models/service/model.service';
 import { GetGitModel } from 'src/app/projects/project-detail/model-overview/model-detail/git-model.service';
@@ -26,6 +42,23 @@ export type ModelOptions = {
   selector: 'create-readonly-model-options',
   templateUrl: './create-readonly-model-options.component.html',
   styleUrls: ['./create-readonly-model-options.component.css'],
+  standalone: true,
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    MatCheckbox,
+    NgIf,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatAutocompleteTrigger,
+    MatError,
+    MatAutocomplete,
+    MatOptgroup,
+    NgFor,
+    MatOption,
+    MatSlideToggle,
+  ],
 })
 export class CreateReadonlyModelOptionsComponent implements OnInit {
   @Input() projectSlug!: string;

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.docs.mdx
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.docs.mdx
@@ -1,0 +1,32 @@
+{/*
+    SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+    SPDX-License-Identifier: Apache-2.0
+*/}
+
+import * as CreateReadonlySessionDialog from "./create-readonly-session-dialog.stories.ts";
+import {Meta, Title, Story, Canvas, Unstyled} from "@storybook/blocks";
+
+<Meta of={CreateReadonlySessionDialog} />
+
+<Title />
+
+The Create read-only session dialog lets users select the models they
+want to load into their read-only session.
+
+## Large devices
+
+If a model is selected and there is either no limit on the number of
+models that can be provisioned or the limit has not been reached, the
+"Start Session" button can be used to request the read-only session.
+<Story of={CreateReadonlySessionDialog.ModelSelectedAndStartSessionPossible}/>
+
+If there are no models to display, the "Start Session" button is disabled
+and a banner is displayed that there are no models with read-only support.
+
+<Story of={CreateReadonlySessionDialog.NoModelsToShow}/>
+
+If the tool only supports a limited number of models that can be deployed
+in a single session, and this limit is exceeded, the Start Session button will be
+disabled and a banner will appear indicating the maximum number of sessions possible.
+
+<Story of={CreateReadonlySessionDialog.MaxNumberOfModelsExceeded}/>

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.html
@@ -7,10 +7,7 @@
   <form [formGroup]="form" (ngSubmit)="requestSession()">
     <h2>Open read-only Session</h2>
 
-    @if (
-      modelOptions.length &&
-      modelOptions[0].model.tool.config.connection.methods.length > 1
-    ) {
+    @if (modelOptions.length && connectionMethods.length > 1) {
       <div class="mb-2">
         <p class="text-sm">
           Select the connection method for your read-only session:
@@ -20,20 +17,22 @@
           formControlName="connectionMethodId"
         >
           @for (
-            connectionMethod of modelOptions[0].model.tool.config.connection
-              .methods;
+            connectionMethod of connectionMethods;
             track connectionMethod.id
           ) {
-            <mat-radio-button [value]="connectionMethod.id">{{
-              connectionMethod.name
-            }}</mat-radio-button>
+            <mat-radio-button [value]="connectionMethod.id">
+              {{ connectionMethod.name }}
+            </mat-radio-button>
           }
         </mat-radio-group>
       </div>
 
-      @if (this.getSelectedConnectionMethod().description) {
+      @if (
+        getSelectedConnectionMethod().description;
+        as selectedConnectionMethodDescription
+      ) {
         <div class="mb-2 border p-2 text-sm shadow">
-          {{ getSelectedConnectionMethod().description }}
+          {{ selectedConnectionMethodDescription }}
         </div>
       }
     }
@@ -41,26 +40,38 @@
     <p class="text-sm">
       Select the models and revisions you want to load in a readonly session:
     </p>
-    @if (modelOptions.length > 0) {
-      @for (options of modelOptions; track options) {
-        <create-readonly-model-options
-          [projectSlug]="data.projectSlug"
-          [modelOptions]="options"
-        >
-        </create-readonly-model-options>
-        <hr class="m-2" />
-      }
-    } @else {
+    @for (options of modelOptions; track options) {
+      <create-readonly-model-options
+        [projectSlug]="data.projectSlug"
+        [modelOptions]="options"
+      >
+      </create-readonly-model-options>
+      <hr class="m-2" />
+    } @empty {
       <div class="my-1 border p-2 text-sm shadow">
         No models have read-only session support. Please contact your
         administrator or project lead.
       </div>
     }
+
+    @if (maxNumberOfModelsExceeded()) {
+      <div class="my-1 border p-2 text-sm shadow">
+        <p class="text-error">
+          The selected tool only supports up to
+          {{ maxNumberOfModels }} provisioned model(s) at a time.
+        </p>
+      </div>
+    }
+
     <div class="flex justify-between">
       <button mat-flat-button mat-dialog-close type="button">Cancel</button>
       <button
         mat-flat-button
-        [disabled]="this.selectedModelOptions().length === 0 || loading"
+        [disabled]="
+          selectedModelOptions().length === 0 ||
+          maxNumberOfModelsExceeded() ||
+          loading
+        "
         color="primary"
         type="submit"
       >

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.ts
@@ -25,6 +25,9 @@ import { ConnectionMethod } from 'src/app/settings/core/tools-settings/tool.serv
   styleUrls: ['./create-readonly-session-dialog.component.css'],
 })
 export class CreateReadonlySessionDialogComponent implements OnInit {
+  maxNumberOfModels?: number;
+  connectionMethods: ConnectionMethod[] = [];
+
   constructor(
     public sessionService: SessionService,
     @Inject(MAT_DIALOG_DATA)
@@ -60,6 +63,15 @@ export class CreateReadonlySessionDialogComponent implements OnInit {
         continue;
       }
 
+      if (this.modelOptions.length === 0) {
+        this.connectionMethods = model.tool.config.connection.methods;
+        this.maxNumberOfModels =
+          model.tool.config.provisioning.max_number_of_models;
+        this.form.controls.connectionMethodId.setValue(
+          this.connectionMethods[0].id,
+        );
+      }
+
       this.modelOptions.push({
         model: model,
         primaryGitModel: primaryGitModel,
@@ -67,12 +79,6 @@ export class CreateReadonlySessionDialogComponent implements OnInit {
         include: false,
         deepClone: false,
       });
-    }
-
-    if (this.modelOptions.length) {
-      this.form.controls.connectionMethodId.setValue(
-        this.modelOptions[0].model.tool.config.connection.methods[0].id,
-      );
     }
   }
 
@@ -119,8 +125,16 @@ export class CreateReadonlySessionDialogComponent implements OnInit {
       });
   }
 
+  maxNumberOfModelsExceeded(): boolean {
+    return (
+      this.maxNumberOfModels !== null &&
+      this.maxNumberOfModels !== undefined &&
+      this.selectedModelOptions().length > this.maxNumberOfModels
+    );
+  }
+
   getSelectedConnectionMethod(): ConnectionMethod {
-    return this.modelOptions[0].model.tool.config.connection.methods.find(
+    return this.connectionMethods.find(
       (method) => method.id === this.form.controls.connectionMethodId.value,
     )!;
   }

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.ts
@@ -5,8 +5,17 @@
 
 import { DialogRef } from '@angular/cdk/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogClose } from '@angular/material/dialog';
+
+import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import { Router } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
@@ -15,7 +24,10 @@ import {
   Model,
 } from 'src/app/projects/models/service/model.service';
 import { SessionService } from 'src/app/sessions/service/session.service';
-import { ModelOptions } from 'src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component';
+import {
+  CreateReadonlyModelOptionsComponent,
+  ModelOptions,
+} from 'src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-model-options/create-readonly-model-options.component';
 import { ConnectionMethod } from 'src/app/settings/core/tools-settings/tool.service';
 
 @UntilDestroy()
@@ -23,6 +35,16 @@ import { ConnectionMethod } from 'src/app/settings/core/tools-settings/tool.serv
   selector: 'create-readonly-session-dialog',
   templateUrl: './create-readonly-session-dialog.component.html',
   styleUrls: ['./create-readonly-session-dialog.component.css'],
+  standalone: true,
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    MatRadioGroup,
+    MatRadioButton,
+    CreateReadonlyModelOptionsComponent,
+    MatButton,
+    MatDialogClose,
+  ],
 })
 export class CreateReadonlySessionDialogComponent implements OnInit {
   maxNumberOfModels?: number;

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DialogRef } from '@angular/cdk/dialog';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Model } from 'src/app/projects/models/service/model.service';
+import { GetGitModel } from 'src/app/projects/project-detail/model-overview/model-detail/git-model.service';
+import { SessionService } from 'src/app/sessions/service/session.service';
+import {
+  Tool,
+  ToolVersion,
+} from 'src/app/settings/core/tools-settings/tool.service';
+import { CreateReadonlySessionDialogComponent } from './create-readonly-session-dialog.component';
+
+class MockSessionService implements Partial<SessionService> {}
+
+const meta: Meta<CreateReadonlySessionDialogComponent> = {
+  title: 'Session Components / Create Readonly Session Dialog',
+  component: CreateReadonlySessionDialogComponent,
+};
+
+const primaryGitModel: GetGitModel = {
+  id: 1,
+  primary: true,
+  path: 'fakePath',
+  revision: 'fakeRevision',
+  entrypoint: 'fakeEntrypoint',
+  password: false,
+  username: 'fakeUsername',
+};
+
+const version: ToolVersion = {
+  id: 1,
+  name: 'fakeVersion',
+  config: { is_recommended: true, is_deprecated: false },
+};
+
+const tool: Tool = {
+  id: 1,
+  name: 'fakeTool',
+  integrations: { t4c: true, pure_variants: null, jupyter: null },
+  config: {
+    connection: {
+      methods: [
+        {
+          id: '1',
+          name: 'fakeConnectionMethod',
+          description: 'fakeConnectionMethodDescription',
+          type: 'http' as const,
+        },
+      ],
+    },
+    provisioning: { max_number_of_models: 1 },
+  },
+};
+
+function createModelWithId(id: number): Model {
+  return {
+    id: 1,
+    name: `fakeModelName-${id}`,
+    slug: `fakeModelSlug-${id}`,
+    project_slug: 'fakeProjectSlug',
+    description: `fakeModelDescription-${id}`,
+    tool: tool,
+    version: version,
+    t4c_models: [],
+    git_models: [primaryGitModel],
+    restrictions: { allow_pure_variants: false },
+    display_order: 1,
+  };
+}
+
+export default meta;
+type Story = StoryObj<CreateReadonlySessionDialogComponent>;
+
+export const ModelSelectedAndStartSessionPossible: Story = {
+  args: {
+    modelOptions: [
+      {
+        model: createModelWithId(1),
+        primaryGitModel: primaryGitModel,
+        revision: primaryGitModel.revision,
+        include: true,
+        deepClone: false,
+      },
+    ],
+  },
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: SessionService,
+          useFactory: () => new MockSessionService(),
+        },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: DialogRef, useValue: {} },
+      ],
+    }),
+  ],
+};
+
+export const NoModelsToShow: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: SessionService,
+          useFactory: () => new MockSessionService(),
+        },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: DialogRef, useValue: {} },
+      ],
+    }),
+  ],
+};
+
+export const MaxNumberOfModelsExceeded: Story = {
+  args: {
+    maxNumberOfModels: 1,
+    modelOptions: [
+      {
+        model: createModelWithId(1),
+        primaryGitModel: primaryGitModel,
+        revision: primaryGitModel.revision,
+        include: true,
+        deepClone: false,
+      },
+      {
+        model: createModelWithId(2),
+        primaryGitModel: primaryGitModel,
+        revision: primaryGitModel.revision,
+        include: true,
+        deepClone: false,
+      },
+    ],
+  },
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: SessionService,
+          useFactory: () => new MockSessionService(),
+        },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
+        { provide: DialogRef, useValue: {} },
+      ],
+    }),
+  ],
+};

--- a/frontend/src/app/settings/core/tools-settings/tool.service.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool.service.ts
@@ -15,12 +15,17 @@ export type ConnectionMethod = {
   type: 'http' | 'guacamole';
 };
 
+export type ToolSessionProvisioningConfiguration = {
+  max_number_of_models?: number;
+};
+
 export type ToolSessionConnectionConfiguration = {
   methods: ConnectionMethod[];
 };
 
 export type ToolSessionConfiguration = {
   connection: ToolSessionConnectionConfiguration;
+  provisioning: ToolSessionProvisioningConfiguration;
 };
 
 export type CreateTool = {


### PR DESCRIPTION
This allows the administrator to configure the maximum number of models of a tool that can be provisioned. This is initially required for the Model Explorer, which currently supports only a single model. To do this, the backend will throw an exception if a user requests more than the specified number of sessions. In addition, we will also tell the user the maximum number of selectable sessions in the frontend in case they select more than possible.

Based on #1469 
Resolves #1446 