### PR TITLE
fix: Correctly handle disabling version selection

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.html
@@ -36,13 +36,7 @@
 
         <mat-form-field appearance="fill" class="w-full">
           <mat-label>Version</mat-label>
-          <mat-select
-            formControlName="versionId"
-            [disabled]="
-              toolSelectionForm.controls.toolId.value === null ||
-              toolSelectionForm.controls.toolId.value < 0
-            "
-          >
+          <mat-select formControlName="versionId">
             <mat-option
               *ngFor="let version of this.versions"
               [value]="version.id"

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
@@ -34,7 +34,10 @@ export class CreatePersistentSessionComponent implements OnInit {
 
   public toolSelectionForm = new FormGroup({
     toolId: new FormControl(null, Validators.required),
-    versionId: new FormControl<number | null>(null, Validators.required),
+    versionId: new FormControl<number | null>(
+      { value: null, disabled: true },
+      Validators.required,
+    ),
     connectionMethodId: new FormControl<string | undefined>(
       undefined,
       Validators.required,
@@ -89,6 +92,7 @@ export class CreatePersistentSessionComponent implements OnInit {
     this.toolSelectionForm.controls.connectionMethodId.setValue(
       this.selectedTool?.config.connection.methods[0].id,
     );
+    this.toolSelectionForm.controls.versionId.enable();
   }
 
   getSelectedConnectionMethod(): ConnectionMethod | undefined {


### PR DESCRIPTION
This moves the logic of enabling version selection from an attribute to the actual logic. First of all, this removes the warning that angular always showed in the console about how we handled disabling the selection here. Second, once a tool is selected, there is no way to go back to the state where the version dropdown should be disabled, so just handling the enable case in the logic is quite simple. Finally, the current approach was not working properly because even without a tool selected, the version selector seemed to be enabled, i.e. we were even able to interact with it.