### PR TITLE
ci: Run Chromatic on 'main' branch

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,13 +2,17 @@
 # SPDX-License-Identifier: CC0-1.0
 name: 'Storybook'
 
-on: pull_request
+on:
+  pull_request:
+    branches: ["**"]
+  push:
+    branches: ["main"]
 
 jobs:
   chromatic:
     runs-on: ubuntu-latest
     concurrency:
-      group: chromatic-pr-${{ github.event.pull_request.number }}
+      group: chromatic-${{ github.event_name }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - name: Checkout code
@@ -16,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Find Storybook comment on PR
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3
         id: fc
         with:
@@ -23,6 +28,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Storybook
       - name: Create or update Storybook comment on PR
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
         id: cc
         with:
@@ -43,6 +49,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: ./frontend
       - name: Create or update Storybook comment on PR
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.cc.outputs.comment-id }}


### PR DESCRIPTION
For a clear history, we have to build Chromatic on the main branch to have a comparision baseline.