### PR TITLE
feat: Disable persistent workspace sessions for specific tools

### DIFF
--- a/backend/capellacollab/sessions/exceptions.py
+++ b/backend/capellacollab/sessions/exceptions.py
@@ -74,6 +74,21 @@ class InvalidConnectionMethodIdentifierError(core_exceptions.BaseError):
         )
 
 
+class WorkspaceMountingNotAllowed(core_exceptions.BaseError):
+    def __init__(
+        self,
+        tool: tools_models.DatabaseTool,
+    ):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            title="Tool doesn't support workspace mounting",
+            reason=(
+                f"The tool '{tool.name}' doesn't support workspace mounting."
+            ),
+            err_code="WORKSPACE_MOUNTING_NOT_ALLOWED",
+        )
+
+
 class TooManyModelsRequestedToProvisionError(core_exceptions.BaseError):
     def __init__(self, max_number_of_models: int):
         super().__init__(

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -217,6 +217,16 @@ class ToolModelProvisioning(pydantic.BaseModel):
     )
 
 
+class PersistentWorkspaceSessionConfiguration(pydantic.BaseModel):
+    mounting_enabled: bool = pydantic.Field(
+        default=True,
+        description=(
+            "Enables workspace mounting to persistent workspace sessions of this tool. "
+            "If disabled, persistent workspace sessions can no longer be requested."
+        ),
+    )
+
+
 class ToolSessionConfiguration(pydantic.BaseModel):
     resources: Resources = pydantic.Field(default=Resources())
     environment: dict[str, str] = pydantic.Field(
@@ -238,6 +248,12 @@ class ToolSessionConfiguration(pydantic.BaseModel):
     provisioning: ToolModelProvisioning = pydantic.Field(
         default=ToolModelProvisioning(),
         description="Configuration regarding read-only sessions & automatic session provisioning.",
+    )
+    persistent_workspaces: PersistentWorkspaceSessionConfiguration = (
+        pydantic.Field(
+            default=PersistentWorkspaceSessionConfiguration(),
+            description="Configuration for persistent workspaces.",
+        )
     )
 
 

--- a/backend/tests/sessions/hooks/test_persistent_workspace.py
+++ b/backend/tests/sessions/hooks/test_persistent_workspace.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from capellacollab.sessions import exceptions as sessions_exceptions
+from capellacollab.sessions import models as sessions_models
+from capellacollab.sessions import operators
+from capellacollab.sessions.hooks import persistent_workspace
+from capellacollab.tools import models as tools_models
+from capellacollab.users import models as users_models
+
+
+def test_persistent_workspace_mounting_not_allowed(
+    tool: tools_models.DatabaseTool,
+    user: users_models.DatabaseUser,
+):
+    tool.config.persistent_workspaces.mounting_enabled = False
+
+    with pytest.raises(sessions_exceptions.WorkspaceMountingNotAllowed):
+        persistent_workspace.PersistentWorkspaceHook().configuration_hook(
+            operator=operators.KubernetesOperator(),
+            user=user,
+            session_type=sessions_models.SessionType.PERSISTENT,
+            tool=tool,
+        )

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.html
@@ -25,7 +25,7 @@
             (selectionChange)="toolSelectionChange($event.value)"
           >
             <mat-option
-              *ngFor="let tool of toolService.tools"
+              *ngFor="let tool of toolsWithWorkspaceEnabled | async"
               [value]="tool.id"
             >
               {{ tool.name }}

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-persistent-session/create-persistent-session.component.ts
@@ -6,6 +6,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Observable, map } from 'rxjs';
 import {
   Session,
   SessionService,
@@ -115,5 +116,15 @@ export class CreatePersistentSessionComponent implements OnInit {
           );
         }
       });
+  }
+
+  get toolsWithWorkspaceEnabled(): Observable<Tool[] | undefined> {
+    return this.toolService.tools$.pipe(
+      map((tools) =>
+        tools?.filter(
+          (tool) => tool.config.persistent_workspaces.mounting_enabled,
+        ),
+      ),
+    );
   }
 }

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
@@ -58,6 +58,9 @@ const tool: Tool = {
       ],
     },
     provisioning: { max_number_of_models: 1 },
+    persistent_workspaces: {
+      mounting_enabled: true,
+    },
   },
 };
 

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.stories.ts
@@ -23,7 +23,13 @@ const tool: Tool = {
   id: 1,
   name: 'Tool 1',
   integrations: { t4c: true, pure_variants: true, jupyter: false },
-  config: { connection: { methods: [] }, provisioning: {} },
+  config: {
+    connection: { methods: [] },
+    provisioning: {},
+    persistent_workspaces: {
+      mounting_enabled: true,
+    },
+  },
 };
 
 const version: ToolVersion = {

--- a/frontend/src/app/settings/core/tools-settings/tool.service.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool.service.ts
@@ -24,9 +24,14 @@ export type ToolSessionConnectionConfiguration = {
   methods: ConnectionMethod[];
 };
 
+export type WorkspaceConfiguration = {
+  mounting_enabled: boolean;
+};
+
 export type ToolSessionConfiguration = {
   connection: ToolSessionConnectionConfiguration;
   provisioning: ToolSessionProvisioningConfiguration;
+  persistent_workspaces: WorkspaceConfiguration;
 };
 
 export type CreateTool = {
@@ -92,6 +97,9 @@ export class ToolService {
   _tools = new BehaviorSubject<Tool[] | undefined>(undefined);
   get tools(): Tool[] | undefined {
     return this._tools.getValue();
+  }
+  get tools$(): Observable<Tool[] | undefined> {
+    return this._tools.asObservable();
   }
 
   init(): void {


### PR DESCRIPTION
Some tools can't handle persistent workspaces. Instead, they only support read-only sessions.