### PR TITLE
feat: Add cascading deletion of tool natures & versions

### DIFF
--- a/backend/capellacollab/alembic/versions/aa88e6d1333b_remove_versions_without_tool.py
+++ b/backend/capellacollab/alembic/versions/aa88e6d1333b_remove_versions_without_tool.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Remove versions without tool
+
+Revision ID: aa88e6d1333b
+Revises: e06d616469ec
+Create Date: 2024-04-25 10:48:56.205850
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "aa88e6d1333b"
+down_revision = "e06d616469ec"
+branch_labels = None
+depends_on = None
+
+t_versions = sa.Table(
+    "versions",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer()),
+    sa.Column("tool_id", sa.Integer()),
+)
+
+t_natures = sa.Table(
+    "types",
+    sa.MetaData(),
+    sa.Column("id", sa.Integer()),
+    sa.Column("tool_id", sa.Integer()),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute(
+        sa.delete(t_versions).where(t_versions.c.tool_id.is_(None))
+    )
+    connection.execute(
+        sa.delete(t_natures).where(t_natures.c.tool_id.is_(None))
+    )
+    op.alter_column(
+        "types", "tool_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.alter_column(
+        "versions", "tool_id", existing_type=sa.INTEGER(), nullable=False
+    )

--- a/backend/capellacollab/tools/models.py
+++ b/backend/capellacollab/tools/models.py
@@ -259,10 +259,14 @@ class DatabaseTool(database.Base):
     )
 
     versions: orm.Mapped[list[DatabaseVersion]] = orm.relationship(
-        default_factory=list, back_populates="tool"
+        default_factory=list,
+        back_populates="tool",
+        cascade="all, delete-orphan",
     )
     natures: orm.Mapped[list[DatabaseNature]] = orm.relationship(
-        default_factory=list, back_populates="tool"
+        default_factory=list,
+        back_populates="tool",
+        cascade="all, delete-orphan",
     )
 
 
@@ -335,7 +339,7 @@ class DatabaseVersion(database.Base):
 
     name: orm.Mapped[str]
 
-    tool_id: orm.Mapped[int | None] = orm.mapped_column(
+    tool_id: orm.Mapped[int] = orm.mapped_column(
         sa.ForeignKey("tools.id"),
         init=False,
     )
@@ -356,7 +360,7 @@ class DatabaseNature(database.Base):
     id: orm.Mapped[int] = orm.mapped_column(init=False, primary_key=True)
     name: orm.Mapped[str]
 
-    tool_id: orm.Mapped[int | None] = orm.mapped_column(
+    tool_id: orm.Mapped[int] = orm.mapped_column(
         sa.ForeignKey("tools.id"), init=False
     )
     tool: orm.Mapped[DatabaseTool] = orm.relationship(back_populates="natures")


### PR DESCRIPTION
When deleting a tool, versions and natures were not deleted. This commit cleans up orphan versions and natures and adds cascading deletion for future tool deletions.