### PR TITLE
fix: List files in file browser works again

### DIFF
--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -934,7 +934,7 @@ class KubernetesOperator:
                     "--stdin",
                     pod_name,
                     "--container",
-                    _id,
+                    "session",
                     "--",
                     "python",
                     "-",


### PR DESCRIPTION
It was broken since it still referenced the id as container ID. It was changed to "session" in an earlier PR.