### PR TITLE
fix(front): Reload active session in DOM only on change or modification

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.css
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.css
@@ -1,7 +1,7 @@
 /*
- * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
- * SPDX-License-Identifier: Apache-2.0
- */
+* SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+* SPDX-License-Identifier: Apache-2.0
+*/
 
 .error {
   background-color: var(--error-color);
@@ -17,21 +17,4 @@
 
 .primary {
   background-color: var(--primary-color);
-}
-
-.sessionContent {
-  margin-bottom: 5px;
-}
-
-.state {
-  color: white;
-  border-radius: 10px;
-}
-
-h2 {
-  margin-bottom: 2px;
-}
-
-#creationTime {
-  margin-top: 5px;
 }

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.docs.mdx
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.docs.mdx
@@ -1,0 +1,38 @@
+{/*
+    SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+    SPDX-License-Identifier: Apache-2.0
+*/}
+
+import * as ActiveSessions from "./active-sessions.stories.ts";
+import {Meta, Title, Story, Canvas, Unstyled} from "@storybook/blocks";
+
+<Meta of={ActiveSessions} />
+
+<Title />
+
+The Active Session component shows users information about their current
+sessions, including the session type, such as read-only or persistent,
+creation type, tool, and connection method, and displays the current session state.
+
+When loading sessions, it looks like this:
+<Story of={ActiveSessions.LoadingStory}/>
+
+If there are no active sessions, it looks like this:
+<Story of={ActiveSessions.NoActiveStories}/>
+
+If the session starts successfully, it look like this:
+<Story of={ActiveSessions.SessionSuccessStateStory}/>
+
+During session creation, when no error has occurred, it looks like this:
+<Story of={ActiveSessions.SessionWarningStateStory}/>
+
+If there is an error during creation, it looks like this:
+<Story of={ActiveSessions.SessionErrorStateStory}/>
+
+Even though we cover a variety of possible states, the session may end
+in an unknown state that looks like this:
+<Story of={ActiveSessions.SessionUnknownStateStory}/>
+
+The only difference between a persistent session and a read-only session is the title.
+Since we only covered persistent sessions above, this is a read-only session:
+<Story of={ActiveSessions.ReadonlySessionSuccessStateStory}/>

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.html
@@ -1,110 +1,103 @@
 <!--
- ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
- ~ SPDX-License-Identifier: Apache-2.0
- -->
+~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+~ SPDX-License-Identifier: Apache-2.0
+-->
 
-<div class="flex-center">
-  <h1 class="text-2xl">Active Sessions</h1>
-</div>
+<h1 class="text-2xl">Active Sessions</h1>
 
-<ngx-skeleton-loader
-  *ngIf="(userSessionService.sessions$ | async) === undefined"
-  appearance="circle"
-  [theme]="{
-    'border-radius': '5px',
-    height: '240px',
-    width: '432px',
-    border: '1px solid white'
-  }"
-></ngx-skeleton-loader>
-
-<div
-  *ngIf="(userSessionService.sessions$ | async)?.length === 0"
-  class="mat-card collab-card w-full"
->
-  <h2 class="mb-3 text-xl font-medium">No active sessions</h2>
-  <div class="text-sm">
-    There are no active sessions for your user in our system. <br />
-  </div>
-</div>
-
-<div
-  class="flex flex-col gap-2"
-  *ngIf="(userSessionService.sessions$ | async)?.length"
->
-  <a
-    class="w-full max-w-[85vw]"
-    matInput
-    mat-stroked-button
-    color="primary"
-    type="submit"
-    routerLink="/session"
-  >
-    <span> Open internal session viewer </span>
-    <mat-icon iconPositionEnd>keyboard_arrow_right</mat-icon>
-  </a>
-
-  <div
-    *ngFor="let session of userSessionService.sessions$ | async"
-    class="collab-card"
-  >
-    <div>
-      <b>
-        <h2 *ngIf="isPersistentSession(session)">
-          Persistent workspace session
-        </h2>
-        <h2 *ngIf="isReadonlySession(session)">Read-only session</h2>
-      </b>
+@if ((userSessionService.sessions$ | async) === undefined) {
+  <ngx-skeleton-loader
+    appearance="circle"
+    [theme]="{
+      'border-radius': '5px',
+      height: '240px',
+      width: '432px',
+      border: '1px solid white'
+    }"
+  ></ngx-skeleton-loader>
+} @else if ((userSessionService.sessions$ | async)?.length === 0) {
+  <div class="mat-card collab-card w-full">
+    <h2 class="mb-3 text-xl font-medium">No active sessions</h2>
+    <div class="text-sm">
+      There are no active sessions for your user in our system. <br />
     </div>
-    <div class="sessionContent">
-      <h3
-        class="state text-center"
-        [ngClass]="sessionService.beautifyState(session.state).css"
-      >
-        {{ sessionService.beautifyState(session.state).text }}
-      </h3>
-      <p id="creationTime">
-        The session was created
-        {{ beautifyService.beatifyDate(session.created_at) }}
-      </p>
-      <span>
-        Tool: {{ session.version!.tool.name }} ({{ session.version!.name }})
-        <br />
-        Connection Method: {{ session.connection_method?.name }}
-      </span>
+  </div>
+} @else if ((userSessionService.sessions$ | async)?.length !== 0) {
+  <div class="flex flex-col gap-2">
+    <a
+      class="w-full max-w-[85vw]"
+      matInput
+      mat-stroked-button
+      color="primary"
+      type="submit"
+      routerLink="/session"
+    >
+      <span> Open internal session viewer </span>
+      <mat-icon iconPositionEnd>keyboard_arrow_right</mat-icon>
+    </a>
 
-      <div *ngIf="session.download_in_progress" class="mat-card collab-card">
-        <mat-card-content>
-          <p>Your download is being prepared…</p>
-          <p>Depending on the model size, this can take a few minutes.</p>
-          <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-        </mat-card-content>
+    @for (session of userSessionService.sessions$ | async; track session.id) {
+      <div class="collab-card">
+        <b>
+          @if (isPersistentSession(session)) {
+            <h2>Persistent workspace session</h2>
+          } @else if (isReadonlySession(session)) {
+            <h2>Read-only session</h2>
+          }
+        </b>
+        <div>
+          <h3
+            class="rounded-lg text-center !text-white"
+            [ngClass]="sessionService.beautifyState(session.state).css"
+          >
+            {{ sessionService.beautifyState(session.state).text }}
+          </h3>
+          <p class="mt-1.5">
+            The session was created
+            {{ beautifyService.beatifyDate(session.created_at) }}
+          </p>
+          <span>
+            Tool: {{ session.version!.tool.name }} ({{ session.version!.name }})
+            <br />
+            Connection Method: {{ session.connection_method?.name }}
+          </span>
+
+          @if (session.download_in_progress) {
+            <div class="mat-card collab-card">
+              <mat-card-content>
+                <p>Your download is being prepared…</p>
+                <p>Depending on the model size, this can take a few minutes.</p>
+                <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+              </mat-card-content>
+            </div>
+          }
+        </div>
+        <div class="flex justify-between">
+          <button
+            mat-button
+            color="primary"
+            (click)="openDeletionDialog([session])"
+          >
+            Terminate
+          </button>
+          <button
+            mat-button
+            color="primary"
+            (click)="openConnectDialog(session)"
+            [disabled]="!sessionService.beautifyState(session.state).success"
+          >
+            Connect
+          </button>
+          <button
+            mat-button
+            color="primary"
+            (click)="uploadFileDialog(session)"
+            [disabled]="!sessionService.beautifyState(session.state).success"
+          >
+            File browser
+          </button>
+        </div>
       </div>
-    </div>
-    <div class="flex justify-between">
-      <button
-        mat-button
-        color="primary"
-        (click)="openDeletionDialog([session])"
-      >
-        Terminate
-      </button>
-      <button
-        mat-button
-        color="primary"
-        (click)="openConnectDialog(session)"
-        [disabled]="!sessionService.beautifyState(session.state).success"
-      >
-        Connect
-      </button>
-      <button
-        mat-button
-        color="primary"
-        (click)="uploadFileDialog(session)"
-        [disabled]="!sessionService.beautifyState(session.state).success"
-      >
-        File browser
-      </button>
-    </div>
+    }
   </div>
-</div>
+}

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NgIf, NgFor, NgClass, AsyncPipe } from '@angular/common';
+import { NgClass, AsyncPipe } from '@angular/common';
 import { Component } from '@angular/core';
 import { MatAnchor, MatButton } from '@angular/material/button';
 import { MatCardContent } from '@angular/material/card';
@@ -30,12 +30,10 @@ import { FileBrowserDialogComponent } from './file-browser-dialog/file-browser-d
   styleUrls: ['./active-sessions.component.css'],
   standalone: true,
   imports: [
-    NgIf,
     NgxSkeletonLoaderModule,
     MatAnchor,
     RouterLink,
     MatIcon,
-    NgFor,
     NgClass,
     MatCardContent,
     MatProgressBar,
@@ -46,8 +44,6 @@ import { FileBrowserDialogComponent } from './file-browser-dialog/file-browser-d
 export class ActiveSessionsComponent {
   isReadonlySession = isReadonlySession;
   isPersistentSession = isPersistentSession;
-
-  sessions?: Session[] = undefined;
 
   constructor(
     public sessionService: SessionService,

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/active-sessions.stories.ts
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { Observable, of } from 'rxjs';
+import { User } from 'src/app/services/user/user.service';
+import {
+  ConnectionMethod,
+  Tool,
+  ToolVersionWithTool,
+} from 'src/app/settings/core/tools-settings/tool.service';
+import { Session } from '../../service/session.service';
+import { UserSessionService } from '../../service/user-session.service';
+import { ActiveSessionsComponent } from './active-sessions.component';
+
+class MockUserSessionService implements Partial<UserSessionService> {
+  public readonly sessions$: Observable<Session[] | undefined> = of(undefined);
+
+  constructor(session?: Session, empty?: boolean) {
+    if (session !== undefined) {
+      this.sessions$ = of([session]);
+    } else if (empty === true) {
+      this.sessions$ = of([]);
+    }
+  }
+}
+
+const meta: Meta<ActiveSessionsComponent> = {
+  title: 'Session Components / Active Sessions',
+  component: ActiveSessionsComponent,
+};
+
+export default meta;
+type Story = StoryObj<ActiveSessionsComponent>;
+
+const connectionMethod: ConnectionMethod = {
+  id: '1',
+  name: 'fakeConnectionMethod',
+  type: 'http',
+};
+
+const user: User = {
+  id: 1,
+  name: 'fakeUser',
+  role: 'user',
+  created: '2024-04-29T14:00:00Z',
+  last_login: '2024-04-29T14:59:00Z',
+};
+
+const tool: Tool = {
+  id: 1,
+  name: 'fakeTool',
+  integrations: {
+    t4c: true,
+    pure_variants: false,
+    jupyter: false,
+  },
+  config: {
+    connection: {
+      methods: [connectionMethod],
+    },
+    provisioning: {},
+    persistent_workspaces: { mounting_enabled: true },
+  },
+};
+
+const versionWithTool: ToolVersionWithTool = {
+  id: 1,
+  name: 'fakeVersion',
+  config: {
+    is_recommended: false,
+    is_deprecated: false,
+    compatible_versions: [],
+  },
+  tool: tool,
+};
+
+function createPersistentSessionWithState(state: string): Session {
+  return {
+    id: '1',
+    created_at: '2024-04-29T15:00:00Z',
+    last_seen: '2024-04-29T15:30:00Z',
+    type: 'persistent',
+    project: undefined,
+    version: versionWithTool,
+    state: state,
+    owner: user,
+    download_in_progress: false,
+    connection_method: connectionMethod,
+  };
+}
+
+const successReadonlySession = {
+  id: '1',
+  created_at: '2024-04-29T15:00:00Z',
+  last_seen: '2024-04-29T15:30:00Z',
+  type: 'readonly' as const,
+  project: {
+    name: 'fake-name',
+    slug: 'fake-slug',
+    description: 'fake-description',
+    visibility: 'private' as const,
+    type: 'general' as const,
+    users: { leads: 1, contributors: 0, subscribers: 0 },
+    is_archived: false,
+  },
+  version: versionWithTool,
+  state: 'Started',
+  owner: user,
+  download_in_progress: false,
+  connection_method: connectionMethod,
+};
+
+export const LoadingStory: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () => new MockUserSessionService(),
+        },
+      ],
+    }),
+  ],
+};
+
+export const NoActiveStories: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () => new MockUserSessionService(undefined, true),
+        },
+      ],
+    }),
+  ],
+};
+
+export const SessionSuccessStateStory: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () =>
+            new MockUserSessionService(
+              createPersistentSessionWithState('Started'),
+            ),
+        },
+      ],
+    }),
+  ],
+};
+
+export const SessionWarningStateStory: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () =>
+            new MockUserSessionService(
+              createPersistentSessionWithState('Created'),
+            ),
+        },
+      ],
+    }),
+  ],
+};
+
+export const SessionErrorStateStory: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () =>
+            new MockUserSessionService(
+              createPersistentSessionWithState('Failed'),
+            ),
+        },
+      ],
+    }),
+  ],
+};
+
+export const SessionUnknownStateStory: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () =>
+            new MockUserSessionService(
+              createPersistentSessionWithState('unknown'),
+            ),
+        },
+      ],
+    }),
+  ],
+};
+
+export const ReadonlySessionSuccessStateStory: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: UserSessionService,
+          useFactory: () => new MockUserSessionService(successReadonlySession),
+        },
+      ],
+    }),
+  ],
+};

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
@@ -18,7 +18,7 @@ import { CreateReadonlySessionDialogComponent } from './create-readonly-session-
 class MockSessionService implements Partial<SessionService> {}
 
 const meta: Meta<CreateReadonlySessionDialogComponent> = {
-  title: 'Session Component / Create Readonly Session Dialog',
+  title: 'Session Components / Create Readonly Session Dialog',
   component: CreateReadonlySessionDialogComponent,
 };
 

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.stories.ts
@@ -18,7 +18,7 @@ import { CreateReadonlySessionDialogComponent } from './create-readonly-session-
 class MockSessionService implements Partial<SessionService> {}
 
 const meta: Meta<CreateReadonlySessionDialogComponent> = {
-  title: 'Session Components / Create Readonly Session Dialog',
+  title: 'Session Component / Create Readonly Session Dialog',
   component: CreateReadonlySessionDialogComponent,
 };
 

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.stories.ts
@@ -12,7 +12,7 @@ import {
 import { CreateSessionHistoryComponent } from './create-session-history.component';
 
 const meta: Meta<CreateSessionHistoryComponent> = {
-  title: 'Session Component / Session History',
+  title: 'Session Components / Session History',
   component: CreateSessionHistoryComponent,
 };
 


### PR DESCRIPTION
This first introduces the new angular control flow in this component. By doing so, we can easily add `track session.id` to the session loop. By tracking sessions by their id, only newly created or modified sessions are reloaded in the DOM. This not only improves performance by reducing the number of reloads, but also allows us to properly select parts of the session information, since previously each reload removed the selection. Finally, we also cleaned up the unused `sessions` variable and converted most of the styling to tailwind.

In addition, this PR also introduces stories for the Active Sessions component. These stories cover loading sessions, no active sessions, success, warning, error, and unknown states, as well as persistent and read-only sessions. It also includes a small fix that moves the Create Read-Only Dialog stories to the correct story group.