### PR TITLE
ci: Disable some Actions for dependabot PRs

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   conventional-commits:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   push-images:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     name: Build and push ${{ matrix.name }} image
     strategy:
       matrix:
@@ -69,6 +70,7 @@ jobs:
           push: true
   install-chart:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     needs: [push-images]
     name: Install chart in kind cluster
     steps:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   chromatic:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     concurrency:
       group: chromatic-${{ github.event_name }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
Some actions always fail for dependabot PRs.
We should disable those.