### PR TITLE
build: Reenable 'no-unused-imports' eslint rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -56,9 +56,7 @@ module.exports = {
             caughtErrorsIgnorePattern: "^_",
           },
         ],
-        // Reenable when the following bug is fixed:
-        // https://github.com/sweepline/eslint-plugin-unused-imports/issues/77
-        // "unused-imports/no-unused-imports": "error",
+        "unused-imports/no-unused-imports": "error",
         "no-console": ["error", { allow: ["error"] }],
         "deprecation/deprecation": "error",
         "@angular-eslint/use-lifecycle-interface": "error",


### PR DESCRIPTION
https://github.com/sweepline/eslint-plugin-unused-imports/issues/77 is fixed. That's why we can reenable the rule.