### PR TITLE
fix: Trust proxy headers to avoid https -> http redirects

### DIFF
--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -7,4 +7,4 @@ set -e
 # When running inside the cluster, the k8s service host should not use the proxy
 export no_proxy=$no_proxy,$KUBERNETES_SERVICE_HOST,$no_proxy_additional,svc.cluster.local
 export NO_PROXY=$NO_PROXY,$KUBERNETES_SERVICE_HOST,$no_proxy_additional,svc.cluster.local
-uvicorn capellacollab.__main__:app --host 0.0.0.0
+uvicorn capellacollab.__main__:app --host 0.0.0.0 --forwarded-allow-ips '*'


### PR DESCRIPTION
When FastAPI sent a temporary redirect, it didn't respect the `X-Forwarded-Proto` header of the proxy.

Therefore, it did default to `http` and sent an http URL as response.

In this commit we tell uvicorn to trust all IPs. Since the backend is firewalled and only reachable behind the Kubernetes Ingress / proxy, this is safe.