### PR TITLE
docs: Users have to log in before project assignment

### DIFF
--- a/docs/docs/user/projects/access/index.md
+++ b/docs/docs/user/projects/access/index.md
@@ -10,6 +10,9 @@ The project lead can add you as user to the project. After you've been added,
 you should have direct access. If you don't see the project yet, just reload
 the page with `F5`.
 
+Before a project lead can add you to a project, you have to log in once. The
+first login automatically registers your user in the database.
+
 Your project manager can find more information here:
 [Add a user to a project](../add-user/index.md)
 

--- a/docs/docs/user/projects/add-user/index.md
+++ b/docs/docs/user/projects/add-user/index.md
@@ -10,6 +10,10 @@
 
 ## Add User to Project
 
+!!! info
+
+    To add a user to a project, the user has to log in to the platform at least once.
+
 1.  Select your project in the project overview.
 2.  On the right side you should now see user management options:
     ![Add user](./add-user-empty.png)


### PR DESCRIPTION
Was unclear for a user, let's add it to the documentation.