### PR TITLE
fix: Termination of sessions

### DIFF
--- a/backend/capellacollab/sessions/idletimeout.py
+++ b/backend/capellacollab/sessions/idletimeout.py
@@ -29,7 +29,7 @@ def terminate_idle_session():
         log.error("Could not collect idle sessions from Prometheus")
         return
     for metric in response.json()["data"]["result"]:
-        if session_id := metric.get("metric", {}).get("app"):
+        if session_id := metric.get("metric", {}).get("session_id"):
             log.info("Terminating idle session %s", session_id)
             with database.SessionLocal() as db:
                 if session := crud.get_session_by_id(db, session_id):

--- a/backend/capellacollab/sessions/injection.py
+++ b/backend/capellacollab/sessions/injection.py
@@ -28,7 +28,7 @@ def get_last_seen(sid: str) -> str:
         response.raise_for_status()
 
         for session in response.json()["data"]["result"]:
-            if sid == session["metric"]["app"]:
+            if sid == session["metric"]["session_id"]:
                 return _get_last_seen(float(session["value"][1]))
 
         log.error("No session was found.")

--- a/backend/tests/sessions/test_session_idletimeout.py
+++ b/backend/tests/sessions/test_session_idletimeout.py
@@ -53,7 +53,9 @@ def test_idle_sessions(monkeypatch):
     monkeypatch.setattr(
         requests,
         "get",
-        lambda *args, **kwargs: MockResponse({"metric": {"app": session_id}}),
+        lambda *args, **kwargs: MockResponse(
+            {"metric": {"session_id": session_id}}
+        ),
     )
     monkeypatch.setattr(
         capellacollab.sessions.operators,


### PR DESCRIPTION
The automatic termination of idle sessions stopped working with #1573. Reason is that the app label was removed from Prometheus.

This commit migrates the old app references to the new session_id label.