### PR TITLE
fix(monitoring): Don't refresh "Active sessions" dashboard automatically

### DIFF
--- a/helm/config/grafana/active-sessions.json
+++ b/helm/config/grafana/active-sessions.json
@@ -455,7 +455,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],


### PR DESCRIPTION
A refresh of the dashboard produces many requests. It can still be done manually via the button in the top right corner.