### PR TITLE
feat: Overwrite individual images in `values.yaml`

### DIFF
--- a/docs/docs/admin/installation.md
+++ b/docs/docs/admin/installation.md
@@ -175,6 +175,12 @@ chmod 600 values.yaml
 
 Adjust all values according to your needs.
 
+!!! info
+
+    You can overwrite individual images by setting the `docker.images.*` values.
+    This is useful to set Guacamole to a fixed version to avoid restarts during updates,
+    which would lead to session interruptions.
+
 ## Step 7: Install the Application in the Cluster
 
 Run the following commands in the root directory of the repository:

--- a/helm/templates/backend/backend.deployment.yaml
+++ b/helm/templates/backend/backend.deployment.yaml
@@ -44,7 +44,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-backend
+          {{ if .Values.docker.images.backend }}
+          image: {{ .Values.docker.images.backend }}
+          {{ else }}
           image: {{ .Values.docker.registry.internal }}/backend:{{ .Values.docker.tag }}
+          {{ end }}
           ports:
             - name: http
               containerPort: 8000
@@ -96,7 +100,11 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
+          {{ if .Values.docker.images.promtail }}
+          image: {{ .Values.docker.images.promtail }}
+          {{ else }}
           image: {{ .Values.docker.registry.external -}}/grafana/promtail
+          {{ end }}
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/backend/postgres.deployment.yaml
+++ b/helm/templates/backend/postgres.deployment.yaml
@@ -30,7 +30,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-backend-postgres
+        {{ if .Values.docker.images.postgres }}
+          image: {{ .Values.docker.images.postgres }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/postgres:14.1
+          {{ end }}
           env:
             - name: PGDATA
               value: /var/lib/postgresql/data/data

--- a/helm/templates/docs/docs.deployment.yaml
+++ b/helm/templates/docs/docs.deployment.yaml
@@ -21,7 +21,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-docs
+          {{ if .Values.docker.images.docs }}
+          image: {{ .Values.docker.images.docs }}
+          {{ else }}
           image: {{ .Values.docker.registry.internal }}/docs:{{ .Values.docker.tag }}
+          {{ end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm/templates/frontend/frontend.deployment.yaml
+++ b/helm/templates/frontend/frontend.deployment.yaml
@@ -39,7 +39,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-frontend
+          {{ if .Values.docker.images.frontend }}
+          image: {{ .Values.docker.images.frontend }}
+          {{ else }}
           image: {{ .Values.docker.registry.internal }}/frontend:{{ .Values.docker.tag }}
+          {{ end }}
           ports:
             - name: http
               containerPort: 8080
@@ -74,7 +78,11 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
+          {{ if .Values.docker.images.promtail }}
+          image: {{ .Values.docker.images.promtail }}
+          {{ else }}
           image: {{ .Values.docker.registry.external -}}/grafana/promtail
+          {{ end }}
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/grafana/grafana.deployment.yaml
+++ b/helm/templates/grafana/grafana.deployment.yaml
@@ -31,7 +31,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: grafana
+          {{ if .Values.docker.images.grafana }}
+          image: {{ .Values.docker.images.grafana }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/grafana/grafana:10.0.1
+          {{ end }}
           ports:
             - containerPort: 3000
           resources:

--- a/helm/templates/grafana/nginx.deployment.yaml
+++ b/helm/templates/grafana/nginx.deployment.yaml
@@ -30,7 +30,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-grafana-nginx
+          {{ if .Values.docker.images.nginxUnprivileged }}
+          image: {{ .Values.docker.images.nginxUnprivileged }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/nginxinc/nginx-unprivileged
+          {{ end }}
           ports:
             - name: grafui
               containerPort: 3118

--- a/helm/templates/guacamole/guacamole.deployment.yaml
+++ b/helm/templates/guacamole/guacamole.deployment.yaml
@@ -41,7 +41,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-guacamole-guacamole
+          {{ if .Values.docker.images.guacamole.guacamole }}
+          image: {{ .Values.docker.images.guacamole.guacamole }}
+          {{ else }}
           image: {{ .Values.docker.registry.internal }}/guacamole:{{ .Values.docker.tag }}
+          {{ end }}
           env:
             - name: GUACD_HOSTNAME
               value: {{ .Release.Name }}-guacamole-guacd
@@ -109,7 +113,11 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
+          {{ if .Values.docker.images.promtail }}
+          image: {{ .Values.docker.images.promtail }}
+          {{ else }}
           image: {{ .Values.docker.registry.external -}}/grafana/promtail
+          {{ end }}
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/guacamole/guacd.deployment.yaml
+++ b/helm/templates/guacamole/guacd.deployment.yaml
@@ -39,7 +39,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-guacamole-guacd
+          {{ if .Values.docker.images.guacamole.guacd }}
+          image: {{ .Values.docker.images.guacamole.guacd }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/guacamole/guacd:1.5.2
+          {{ end }}
           command: ["/bin/sh", "-c", "mkdir -p /home/guacd/logs; /opt/guacamole/sbin/guacd -b 0.0.0.0 -L $GUACD_LOG_LEVEL -f > >(tee -a /home/guacd/logs/stdout.log) 2> >(tee -a /home/guacd/logs/stderr.log >&2)"]
           ports:
             - name: guacd
@@ -81,7 +85,11 @@ spec:
           {{ end }}
         {{ if .Values.loki.enabled }}
         - name: promtail
+          {{ if .Values.docker.images.promtail }}
+          image: {{ .Values.docker.images.promtail }}
+          {{ else }}
           image: {{ .Values.docker.registry.external -}}/grafana/promtail
+          {{ end }}
           args:
             - "--config.file=/etc/promtail/promtail.yaml"
             - "-log-config-reverse-order"

--- a/helm/templates/guacamole/postgres.deployment.yaml
+++ b/helm/templates/guacamole/postgres.deployment.yaml
@@ -35,7 +35,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-guacamole-postgres
+          {{ if .Values.docker.images.postgres }}
+          image: {{ .Values.docker.images.postgres }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/postgres:14.1
+          {{ end }}
           env:
             - name: PGDATA
               value: /var/lib/postgresql/data/data

--- a/helm/templates/mock/oauth.deployment.yaml
+++ b/helm/templates/mock/oauth.deployment.yaml
@@ -30,7 +30,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-oauth-mock
+          {{ if .Values.docker.images.mockOauth2Server }}
+          image: {{ .Values.docker.images.mockOauth2Server }}
+          {{ else }}
           image: {{ .Values.docker.registry.github }}/navikt/mock-oauth2-server:0.5.8
+          {{ end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm/templates/prometheus/nginx.deployment.yaml
+++ b/helm/templates/prometheus/nginx.deployment.yaml
@@ -29,7 +29,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-prometheus-nginx
+          {{ if .Values.docker.images.nginxUnprivileged }}
+          image: {{ .Values.docker.images.nginxUnprivileged }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/nginxinc/nginx-unprivileged
+          {{ end }}
           ports:
             - name: promui
               containerPort: 9118

--- a/helm/templates/prometheus/prometheus.deployment.yaml
+++ b/helm/templates/prometheus/prometheus.deployment.yaml
@@ -29,7 +29,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: prometheus
+          {{ if .Values.docker.images.prometheus }}
+          image: {{ .Values.docker.images.prometheus }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/prom/prometheus
+          {{ end }}
           args:
             - "--storage.tsdb.retention.time=1y"
             - "--config.file=/etc/prometheus/prometheus.yml"

--- a/helm/templates/sessions/sessions.deployment.yaml
+++ b/helm/templates/sessions/sessions.deployment.yaml
@@ -29,7 +29,11 @@ spec:
       {{- include "capellacollab.pod.spec" . | indent 6 -}}
       containers:
         - name: {{ .Release.Name }}-session-nginx
+          {{ if .Values.docker.images.nginxUnprivileged }}
+          image: {{ .Values.docker.images.nginxUnprivileged }}
+          {{ else }}
           image: {{ .Values.docker.registry.external }}/nginxinc/nginx-unprivileged
+          {{ end }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,6 +39,26 @@ docker:
   # Docker tag for the internal images (e.g. main)
   tag: main
 
+  # Optional section to overwrite images.
+  # The images have to be in the format <registry>/<image>:<tag>
+  # If not set, the images are derived from registry, image name and tag.
+  images:
+    guacamole:
+      # To avoid Guacamole restarts on every deployment, the Guacamole image can be set to a specific version.
+      guacamole: null
+      guacd: null
+
+    frontend: null
+    backend: null
+    docs: null
+
+    promtail: null
+    postgres: null
+    grafana: null
+    nginxUnprivileged: null
+    mockOauth2Server: null
+    prometheus: null
+
 general:
   # Base URL on which the service listens
   host: localhost


### PR DESCRIPTION
This enables greater flexibility and adaptability in highly restricted environments while keeping the simple configuration as default.

The feature can also be used to set Guacamole to a fixed version to avoid restarts and session interruptions during (possibly frequent) updates of the management portal.