### PR TITLE
feat: Never restart session containers

### DIFF
--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -563,7 +563,7 @@ class KubernetesOperator:
                             )
                         ],
                         volumes=k8s_volumes,
-                        restart_policy="Always",
+                        restart_policy="Never",
                     ),
                 ),
             ),


### PR DESCRIPTION
Failing session containers can result in restart loop until the garbage cleaner terminates the session after 90 minutes.
Most of the failing containers do fail after restarts again and produce unnecessary costs.

In the rare cases of one-time failures, the session can be created again in the frontend / via the API.