### PR TITLE
docs: Add new deployment strategy by pulling images from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ To deploy the application you need:
 
 If you'd like to run it locally, these tools are additionally required:
 
-- [k3d](https://k3d.io/) - a lightweight k8s cluster simulator
-- On some systems: `nss-myhostname` to access the local container registry (on
-  Ubuntu you can get it via `sudo apt install libnss-myhostname`)
+- [k3d](https://k3d.io/) - a lightweight k8s cluster
 
 When you have all that installed you can do the following:
 
@@ -94,20 +92,38 @@ When you have all that installed you can do the following:
 git clone --recurse-submodules https://github.com/DSD-DBS/capella-collab-manager.git
 cd capella-collab-manager
 
-# Create a Local k3d Cluster
-make create-cluster
+# Create a local k3d cluster and test the registry reachability
+make create-cluster reach-registry
 ```
 
-Then, choose one of the three options and run the corresponding command:
+Then, choose one of the four options and run the corresponding command. The
+options can be changed at any time later:
 
-1. Fetch Capella images from Github (without initial TeamForCapella support)
+<!-- prettier-ignore -->
+> [!NOTE]
+> Currently, we only provide amd64 images. If you want to run the
+> application on arm64, you need to build the images yourself (option 3 or 4).
+
+1. Fetch management portal and session images from Github (without
+   TeamForCapella support). This option is recommended for the first
+   deployment.
+
+   ```zsh
+   export DOCKER_REGISTRY=ghcr.io/dsd-dbs/capella-collab-manager
+   export CAPELLACOLLAB_SESSIONS_REGISTRY=ghcr.io/dsd-dbs/capella-dockerimages
+   DEVELOPMENT_MODE=1 make helm-deploy open
+   ```
+
+1. Build management portal images and fetch session images from Github (without
+   initial TeamForCapella support)
 
    ```zsh
    export CAPELLACOLLAB_SESSIONS_REGISTRY=ghcr.io/dsd-dbs/capella-dockerimages
    DEVELOPMENT_MODE=1 make build helm-deploy open rollout
    ```
 
-2. Build Capella images locally (without initial TeamForCapella support) \
+1. Build management portal and session images locally (without initial
+   TeamForCapella support) \
    To reduce the build time, the default configutation only builds images for
    Capella 6.0.0. If you want to build more images for different versions, set
    the environment variable `CAPELLA_VERSIONS` with a space-separated list of
@@ -115,6 +131,7 @@ Then, choose one of the three options and run the corresponding command:
 
    ```
    export CAPELLA_VERSIONS="6.0.0 6.1.0"
+   export BUILD_ARCHITECTURE=amd64 # or arm64
    ```
 
    Then, run the following command:
@@ -123,7 +140,7 @@ Then, choose one of the three options and run the corresponding command:
    DEVELOPMENT_MODE=1 make deploy
    ```
 
-3. Build Capella and TeamForCapella images locally (with initial TeamForCapella
+1. Build Capella and TeamForCapella images locally (with initial TeamForCapella
    support)
 
    Read and execute the preparation in the Capella Docker images documentation:

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -43,7 +43,7 @@ The backend uses various configuration settings. You can find them in the
 `backend/config` directory. A `config.yaml` with default values will be
 generated the first time you run the application.
 
-_Hint_: If you already have the k8d cluster running and if you have the
+_Hint_: If you already have the k3d cluster running and if you have the
 application deployed, then no configuration values need to be adjusted.
 
 ### Getting Started

--- a/docs/docs/development/troubleshooting.md
+++ b/docs/docs/development/troubleshooting.md
@@ -1,0 +1,28 @@
+<!--
+ ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ ~ SPDX-License-Identifier: Apache-2.0
+ -->
+
+# Troubleshooting
+
+## The `k3d` Registry is Unreachable
+
+If the k3d registry is unreachable, i.e. the `make reach-registry` command
+fails with errors like "Could not resolve host", `k3d-myregistry.localhost`
+isn't resolved properly to `127.0.0.1`. To resolve this, you can try the
+following options:
+
+<!-- prettier-ignore -->
+- On Debian/Ubuntu based systems, you can install nss-myhostname.
+  `nss-myhostname` resolves all subdomains of localhost to localhost:
+   ```sh
+   sudo apt install libnss-myhostname
+   ```
+
+- Add the following line to the `/etc/hosts` on the host machine:
+   ```
+   127.0.0.1 k3d-myregistry.localhost
+   ```
+
+After applying the steps, verify that the registry is reachable by running
+`make reach-registry` again.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
           - Measure Resource Usage: development/k8s/resources.md
       - Documentation: development/docs.md
       - Pull Request Acceptance Criteria: development/pull_requests.md
+      - Troubleshooting: development/troubleshooting.md
 
 repo_url: https://github.com/DSD-DBS/capella-collab-manager
 edit_uri: edit/master/docs/docs


### PR DESCRIPTION
To simplify the first deployment, this commit adds a new option, which pulls management portal and session images from GitHub.

Local image building is no longer required and therefore speeds up the deployment time.

The PR also contains instructions to debug issues with the reachability of the k3d registry. Related to https://github.com/DSD-DBS/capella-collab-manager/issues/1536.