### PR TITLE
build: Update Guacamole to 1.5.5

### DIFF
--- a/helm/templates/guacamole/guacd.deployment.yaml
+++ b/helm/templates/guacamole/guacd.deployment.yaml
@@ -42,7 +42,7 @@ spec:
           {{ if .Values.docker.images.guacamole.guacd }}
           image: {{ .Values.docker.images.guacamole.guacd }}
           {{ else }}
-          image: {{ .Values.docker.registry.external }}/guacamole/guacd:1.5.2
+          image: {{ .Values.docker.registry.external }}/guacamole/guacd:1.5.5
           {{ end }}
           command: ["/bin/sh", "-c", "mkdir -p /home/guacd/logs; /opt/guacamole/sbin/guacd -b 0.0.0.0 -L $GUACD_LOG_LEVEL -f > >(tee -a /home/guacd/logs/stdout.log) 2> >(tee -a /home/guacd/logs/stderr.log >&2)"]
           ports:

--- a/images/guacamole/Dockerfile
+++ b/images/guacamole/Dockerfile
@@ -11,7 +11,7 @@ COPY ext /tmp/ext
 WORKDIR /tmp/ext
 RUN zip -r /tmp/guacamole-capellacollab.jar .
 
-FROM guacamole/guacamole:1.5.2
+FROM guacamole/guacamole:1.5.5
 
 USER root
 


### PR DESCRIPTION
The update contains several bug fixes and stability improvements.
Release notes are available here: https://guacamole.apache.org/releases/

> [!NOTE]
> During the update of Guacamole, it will be restarted. A restart will interrupt sessions for about one minute. After the update, existing sessions will reconnect. Consider updating outside of business hours.