### PR TITLE
fix: Remove special handling of Jupyter idletime

### DIFF
--- a/helm/templates/prometheus/prometheus.configmap.yaml
+++ b/helm/templates/prometheus/prometheus.configmap.yaml
@@ -13,10 +13,6 @@ data:
     groups:
       - name: Inactivity
         rules:
-            # This metric adds idle times for jupyter notebooks. pynb does not support an activity metric out of the box.
-            # We check if the request count is over 4 (scrape interval is 30s). If so, we assume activity.
-          - record: idletime_minutes
-            expr: (time() - max_over_time(timestamp(sum by (app) (increase(http_request_duration_seconds_count[2m])) > 4.5)[{{ add .Values.sessions.timeout 5 }}m:2m])) / 60 OR ON (app) ((group by (app) (http_request_duration_seconds_created)) * -1)
           - alert: Inactive session
             expr: idletime_minutes >= {{ .Values.sessions.timeout }}
             for: 1m


### PR DESCRIPTION
Instead, the Jupyter container has to report the idletime via an metrics endpoint.

This commit contributes to the goal of removing the Jupyter specific integration from the Collaboration Manager and replace it with abstract tool support.

Requires https://github.com/DSD-DBS/capella-dockerimages/pull/292