### PR TITLE
fix: Reduce Storybook log level and fix warnings

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -6,7 +6,7 @@
 import type { StorybookConfig } from '@storybook/angular';
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.ts'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',

--- a/frontend/.storybook/tsconfig.json
+++ b/frontend/.storybook/tsconfig.json
@@ -6,6 +6,6 @@
     "resolveJsonModule": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
-  "include": ["../src/**/*", "./preview.ts"],
+  "include": ["./preview.ts", "../src/polyfills.ts", "../src/**/*.stories.ts"],
   "files": ["./typings.d.ts"]
 }

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -16,7 +16,7 @@ test:
 	fi
 
 storybook:
-	ng run capellacollab:storybook
+	ng run capellacollab:storybook --quiet
 
 openapi:
 	rm -rf src/app/openapi && mkdir -p src/app/openapi


### PR DESCRIPTION
Storybook did spam the terminal with messages, which is especially annoying when running `make dev`.

This PR reduces the log level by adding the --quite flag.

In addition, there were some valid WARN messages about wrong usage of the files attribute in the `tsconfig.json`. Those warnings are resolved.