### PR TITLE
build: Listen to all hosts when running dev mode

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -36,7 +36,7 @@ app:
 		source $(VENV)/Scripts/activate;
 	fi
 	export OAUTHLIB_INSECURE_TRANSPORT=1;
-	uvicorn --reload --reload-dir $$(pwd) --reload-include "*.py" --reload-include "*.yaml" --reload-include "*.yml" capellacollab.__main__:app
+	uvicorn --host 0.0.0.0 --reload --reload-dir $$(pwd) --reload-include "*.py" --reload-include "*.yaml" --reload-include "*.yml" capellacollab.__main__:app
 
 coverage:
 	pytest \

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -4,7 +4,7 @@
 export NG_FORCE_TTY=false
 
 dev:
-	ng serve --open
+	ng serve --host 0.0.0.0 --open
 
 test:
 	if [ $(shell which chromium) ]; \


### PR DESCRIPTION
When developing in a devcontainer but using the browser on the development host, the backend (`uvicorn`) and live-reload server (`ng serve`) must listen to all hosts.