### PR TITLE
feat(routing): Add redundancy and 401 error handling to session routing

### DIFF
--- a/helm/templates/sessions/guacamole.disruptionbudget.yml
+++ b/helm/templates/sessions/guacamole.disruptionbudget.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-session-nginx
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-session-nginx

--- a/helm/templates/sessions/sessions.configmap.yaml
+++ b/helm/templates/sessions/sessions.configmap.yaml
@@ -27,6 +27,7 @@ data:
 
             root /usr/share/nginx/html;
             error_page 502 /502.html;
+            error_page 401 /401.html;
 
             resolver {{ .Values.cluster.dns.service }}.{{ .Values.cluster.dns.namespace }}.svc.cluster.local;
 
@@ -79,6 +80,30 @@ data:
         </div>
         <div>
           If this error is persistent, please contact your system administrator.
+        </div>
+      </body>
+    </html>
+  401.html: |-
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <style>
+          body {
+            font-family: Arial, sans-serif;
+          }
+        </style>
+      </head>
+      <body>
+        <h2>Not authenticated against session - 401 Authorization Required</h2>
+
+        <div>
+          The error can occur for various reasons:
+          <ul>
+            <li>The session has been terminated in the Capella Collaboration Manager.</li>
+            <li>You've tried to connect to a session directly. You have to connect via the Capella Collaboration Manager.</li>
+        </div>
+        <div>
+          If you think this error shouldn't appear, please contact your system administrator.
         </div>
       </body>
     </html>

--- a/helm/templates/sessions/sessions.deployment.yaml
+++ b/helm/templates/sessions/sessions.deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/sessions/sessions.configmap.yaml") . | sha256sum }}
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       id: {{ .Release.Name }}-deployment-session-nginx
@@ -63,6 +63,9 @@ spec:
             - name: {{ .Release.Name }}-session-nginx
               mountPath: /usr/share/nginx/html/502.html
               subPath: 502.html
+            - name: {{ .Release.Name }}-session-nginx
+              mountPath: /usr/share/nginx/html/401.html
+              subPath: 401.html
           {{ if .Values.cluster.containers }}
           {{- toYaml .Values.cluster.containers | nindent 10 }}
           {{ end }}


### PR DESCRIPTION
When a user connects to a terminated or foreign session, nginx raises an 401 error, which is displayed to the user. Since it doesn't contain more information, it might be confusing. This PR adds possible reasons and solution approaches to the error message.

In addition, increase the replica for the nginx sessions router to 2 and introduce a PodDisruptionBudget to ensure that there is always one Pod available.