### PR TITLE
fix: Apply executable flag to askpass.py

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,7 +46,7 @@ ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /tmp/backend
-RUN pip install .
+RUN pip install . && chmod +x $VIRTUAL_ENV/lib/python3.11/site-packages/capellacollab/settings/modelsources/git/askpass.py
 
 RUN mkdir -p /var/log/backend && \
     chmod -R 777 /var/log/backend


### PR DESCRIPTION
For some reason, the executable flag isn't preserved during `pip install`. I couldn't find the root cause for it, but this PR provides a fix by adapting the executable flag manually.

Resolves https://github.com/DSD-DBS/capella-collab-manager/issues/1618