### PR TITLE
fix: Infinite authentication loop

### DIFF
--- a/backend/capellacollab/core/authentication/basic_auth.py
+++ b/backend/capellacollab/core/authentication/basic_auth.py
@@ -45,7 +45,7 @@ class HTTPBasicAuth(security.HTTPBasic):
             if db_token.expiration_date < datetime.date.today():
                 logger.info("Token expired for user %s", credentials.username)
                 if self.auto_error:
-                    raise exceptions.TokenSignatureExpired()
+                    raise exceptions.PersonalAccessTokenExpired()
                 return None
         return self.get_username(credentials)
 

--- a/backend/capellacollab/core/authentication/exceptions.py
+++ b/backend/capellacollab/core/authentication/exceptions.py
@@ -65,8 +65,19 @@ class TokenSignatureExpired(core_exceptions.BaseError):
         super().__init__(
             status_code=status.HTTP_401_UNAUTHORIZED,
             title="Token signature expired",
-            reason="The Signature of the token is expired. Please request a new access token.",
+            reason="The Signature of the token is expired. Please refresh the token or request a new access token.",
             err_code="TOKEN_SIGNATURE_EXPIRED",
+            headers={"WWW-Authenticate": "Bearer, Basic"},
+        )
+
+
+class RefreshTokenSignatureExpired(core_exceptions.BaseError):
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            title="Refresh token signature expired",
+            reason="The Signature of the refresh token is expired. Please request a new access token.",
+            err_code="REFRESH_TOKEN_EXPIRED",
             headers={"WWW-Authenticate": "Bearer, Basic"},
         )
 
@@ -109,5 +120,19 @@ class InvalidPersonalAccessTokenError(core_exceptions.BaseError):
             title="Personal access token not valid.",
             reason="The used token is not valid.",
             err_code="BASIC_TOKEN_INVALID",
+            headers={"WWW-Authenticate": "Bearer, Basic"},
+        )
+
+
+class PersonalAccessTokenExpired(core_exceptions.BaseError):
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            title="PAT expired",
+            reason=(
+                "The personal access token is expired."
+                "Please request a new access token."
+            ),
+            err_code="PAT_EXPIRED",
             headers={"WWW-Authenticate": "Bearer, Basic"},
         )

--- a/backend/capellacollab/core/authentication/provider/oauth/flow.py
+++ b/backend/capellacollab/core/authentication/provider/oauth/flow.py
@@ -57,7 +57,7 @@ def refresh_token(_refresh_token: str) -> dict[str, t.Any]:
         )
     except Exception as e:
         logger.debug("Could not refresh token because of exception %s", str(e))
-        raise auth_exceptions.TokenSignatureExpired()
+        raise auth_exceptions.RefreshTokenSignatureExpired()
 
 
 def read_well_known() -> dict[str, t.Any]:

--- a/backend/capellacollab/core/responses.py
+++ b/backend/capellacollab/core/responses.py
@@ -59,9 +59,11 @@ def api_exceptions(
         excs += [
             authentication_exceptions.JWTInvalidToken(),
             authentication_exceptions.TokenSignatureExpired(),
+            authentication_exceptions.RefreshTokenSignatureExpired(),
             authentication_exceptions.JWTValidationFailed(),
             authentication_exceptions.UnauthenticatedError(),
             authentication_exceptions.InvalidPersonalAccessTokenError(),
+            authentication_exceptions.PersonalAccessTokenExpired(),
             authentication_exceptions.UnknownScheme("unknown"),
         ]
 


### PR DESCRIPTION
When the refresh token was expired, the backend sent the error "TOKEN_SIGNATURE_EXPIRED". The frontend did then request a new refresh token, leading to an infinite loop and a DDOS attack on our backend.

The error was accidentially added in #1569.