### PR TITLE
build: Derive helm version from Git tags

### DIFF
--- a/ci-templates/gitlab/k8s-deploy.yml
+++ b/ci-templates/gitlab/k8s-deploy.yml
@@ -64,13 +64,20 @@ variables:
   # prettier-ignore
   - DOCKER_TAG=$(echo $REVISION | sed 's/[^a-zA-Z0-9.]/-/g')-$CI_COMMIT_REF_SLUG
   - helm repo add grafana-helm-remote ${GRAFANA_HELM_CHART}
+  - helm dependency update ./helm
+  - HELM_PACKAGE_DIR=$(mktemp -d)
+  - >
+    helm package \
+      --app-version="$DOCKER_TAG" \
+      --version="$(git describe --tags)" \
+      -d "$HELM_PACKAGE_DIR" \
+      helm
   - >
     helm upgrade ${RELEASE} \
-      --dependency-update \
       --namespace ${NAMESPACE} \
       --set docker.tag=${DOCKER_TAG} \
       -f ../${TARGET}/general.values.yaml \
-      -f ../plain.values.yaml helm
+      -f ../plain.values.yaml "$HELM_PACKAGE_DIR"/collab-manager-*.tgz
   - kubectl rollout restart deployment ${RELEASE}-backend
   - kubectl rollout restart deployment ${RELEASE}-frontend
   - kubectl rollout restart deployment ${RELEASE}-docs

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,8 +6,8 @@ name: collab-manager
 description: Capella Collaboration Manager
 home: https://github.com/DSD-DBS/capella-collab-manager
 type: application
-version: 0.0.0 # The version is not used. The version is managed via Git tags.
-appVersion: "1.0.0"
+version: 0.0.0 # The version is automatically updated by the release process.
+appVersion: 0.0.0 # The appVersion is automatically updated by the release process.
 dependencies:
   - name: loki
     alias: loki


### PR DESCRIPTION
Currently, we tag all helm releases with 1.0.0 / 0.0.0. The versions are displayed when running `helm history`.