### PR TITLE
refactor: Remove unused `audience` configuration field

### DIFF
--- a/backend/capellacollab/config/models.py
+++ b/backend/capellacollab/config/models.py
@@ -255,7 +255,6 @@ class ClaimMappingConfig(BaseConfig):
 
 class AuthenticationConfig(BaseConfig):
     endpoints: AuthOauthEndpointsConfig = AuthOauthEndpointsConfig()
-    audience: str = pydantic.Field(default="default")
     mapping: ClaimMappingConfig = ClaimMappingConfig()
     scopes: list[str] = pydantic.Field(
         default=["openid", "profile", "offline_access"],

--- a/docs/docs/admin/authentication/keycloak/index.md
+++ b/docs/docs/admin/authentication/keycloak/index.md
@@ -73,8 +73,6 @@ backend:
     endpoints:
       wellKnown: [...]/.well-known/openid-configuration # (1)!
 
-    audience: default
-
     claimMapping: # (2)!
       idpIdentifier: sub
       username: preferred_username

--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -45,7 +45,6 @@ authentication:
   endpoints:
     authorization: "{{ .Values.backend.authentication.endpoints.authorization }}"
     wellKnown: "{{ .Values.backend.authentication.endpoints.wellKnown }}"
-  audience: "{{ .Values.backend.authentication.audience }}"
   mapping:
     identifier: "{{ .Values.backend.authentication.claimMapping.idpIdentifier }}"
     username: "{{ .Values.backend.authentication.claimMapping.username }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -150,8 +150,6 @@ backend:
       # - HTTPS: https://localhost/default/authorize
       authorization: null
 
-    audience: default
-
     claimMapping:
       idpIdentifier: sub
       username: preferred_username


### PR DESCRIPTION
This removes the unused `audience` configuration field. The field is not used because `authentication.client_id` is the expected audience for the issued identity tokens, so we do not need a separate field for it.

Resolves #1685 