### PR TITLE
feat: Cancel previous sessions requests

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/user-sessions-wrapper.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/user-sessions-wrapper.component.ts
@@ -5,7 +5,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { tap, timer } from 'rxjs';
+import { delay, expand, of } from 'rxjs';
 import { UserSessionService } from '../service/user-session.service';
 
 @UntilDestroy()
@@ -19,10 +19,13 @@ export class UserSessionsWrapperComponent implements OnInit {
   constructor(private userSessionService: UserSessionService) {}
 
   ngOnInit(): void {
-    timer(0, 2000)
+    of(undefined)
       .pipe(
-        untilDestroyed(this),
-        tap(() => this.userSessionService.loadSessions()),
+        expand(() =>
+          this.userSessionService
+            .loadSessionsObservable()
+            .pipe(delay(2000), untilDestroyed(this)),
+        ),
       )
       .subscribe();
   }


### PR DESCRIPTION
This PR ensures that pending requests against the sessions endpoint are canceled when a new request is made. This improves performance when the backend is unavailable for a period of time, as it will no longer be flooded with session requests when it becomes available again.

Resolves #1134 