### PR TITLE
fix: Unify buttons in authentication components

### DIFF
--- a/frontend/src/app/general/auth/auth/auth.component.html
+++ b/frontend/src/app/general/auth/auth/auth.component.html
@@ -63,7 +63,7 @@
         color="primary"
         target="_blank"
         rel="noopener"
-        >Open Documentation <mat-icon iconPositionEnd>open_in_new</mat-icon>
+        >Documentation <mat-icon iconPositionEnd>open_in_new</mat-icon>
       </a>
       <a
         mat-stroked-button


### PR DESCRIPTION
Remove the "Open" from "Open Documentation".