### PR TITLE
fix: Hide "Unauthenticated" error in the frontend

### DIFF
--- a/frontend/src/app/general/error-handling/error-handling.interceptor.ts
+++ b/frontend/src/app/general/error-handling/error-handling.interceptor.ts
@@ -63,7 +63,8 @@ export class ErrorHandlingInterceptor implements HttpInterceptor {
         error: (err) => {
           if (
             this.isErrorHandlingSkipped(request) ||
-            err.error.detail?.err_code == 'TOKEN_SIGNATURE_EXPIRED'
+            err.error.detail?.err_code == 'TOKEN_SIGNATURE_EXPIRED' ||
+            err.error.detail?.err_code == 'UNAUTHENTICATED'
           ) {
             return;
           }


### PR DESCRIPTION
Unauthenticated redirects to the login page. It's not an error itself and should not be displayed with error message.