### PR TITLE
feat: Allow communication between sessions of same user

### DIFF
--- a/backend/capellacollab/sessions/hooks/__init__.py
+++ b/backend/capellacollab/sessions/hooks/__init__.py
@@ -8,6 +8,7 @@ from . import (
     http,
     interface,
     jupyter,
+    networking,
     persistent_workspace,
     provisioning,
     pure_variants,
@@ -29,6 +30,7 @@ REGISTER_HOOKS_AUTO_USE: dict[str, interface.HookRegistration] = {
     "read_only_hook": read_only_workspace.ReadOnlyWorkspaceHook(),
     "provisioning": provisioning.ProvisionWorkspaceHook(),
     "session_preparation": session_preparation.GitRepositoryCloningHook(),
+    "networking": networking.NetworkingIntegration(),
 }
 
 

--- a/backend/capellacollab/sessions/hooks/networking.py
+++ b/backend/capellacollab/sessions/hooks/networking.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from capellacollab.sessions import operators
+from capellacollab.users import models as users_models
+
+from .. import models as sessions_models
+from . import interface
+
+
+class NetworkingIntegration(interface.HookRegistration):
+    """Allow sessions of the same user to talk to each other."""
+
+    def post_session_creation_hook(  # type: ignore
+        self,
+        session_id: str,
+        operator: operators.KubernetesOperator,
+        user: users_models.DatabaseUser,
+        **kwargs,
+    ) -> interface.PostSessionCreationHookResult:
+        """Allow sessions of the user to talk to each other."""
+
+        operator.create_network_policy_from_pod_to_label(
+            session_id,
+            {"capellacollab/session-id": session_id},
+            {"capellacollab/owner-id": str(user.id)},
+        )
+
+        return interface.PostSessionCreationHookResult()
+
+    def pre_session_termination_hook(  # type: ignore
+        self,
+        operator: operators.KubernetesOperator,
+        session: sessions_models.DatabaseSession,
+        **kwargs,
+    ):
+        operator.delete_network_policy(session.id)

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -178,6 +178,11 @@ def request_session(
         "capellacollab/connection-method-name": connection_method.name,
     }
 
+    labels: dict[str, str] = {
+        "capellacollab/session-id": session_id,
+        "capellacollab/owner-id": str(user.id),
+    }
+
     session = operator.start_session(
         session_id=session_id,
         image=docker_image,
@@ -191,6 +196,7 @@ def request_session(
         volumes=volumes,
         init_volumes=init_volumes,
         annotations=annotations,
+        labels=labels,
         prometheus_path=tool.config.monitoring.prometheus.path,
         prometheus_port=connection_method.ports.metrics,
     )

--- a/backend/tests/sessions/hooks/test_networking_hook.py
+++ b/backend/tests/sessions/hooks/test_networking_hook.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+import kubernetes.client
+import pytest
+
+from capellacollab.sessions import models as sessions_models
+from capellacollab.sessions import operators
+from capellacollab.sessions.hooks import networking as networking_hook
+from capellacollab.users import models as users_models
+
+
+def test_network_policy_created(
+    user: users_models.DatabaseUser, monkeypatch: pytest.MonkeyPatch
+):
+    network_policy_counter = 0
+
+    def mock_create_namespaced_network_policy(
+        self,
+        namespace: str,
+        network_policy: kubernetes.client.V1PersistentVolumeClaim,
+    ):
+        nonlocal network_policy_counter
+        network_policy_counter += 1
+
+    monkeypatch.setattr(
+        kubernetes.client.NetworkingV1Api,
+        "create_namespaced_network_policy",
+        mock_create_namespaced_network_policy,
+    )
+
+    networking_hook.NetworkingIntegration().post_session_creation_hook(
+        session_id="test",
+        operator=operators.KubernetesOperator(),
+        user=user,
+    )
+
+    assert network_policy_counter == 1
+
+
+def test_network_policy_deleted(
+    session: sessions_models.DatabaseSession, monkeypatch: pytest.MonkeyPatch
+):
+    network_policy_del_counter = 0
+
+    def mock_delete_namespaced_network_policy(
+        self,
+        name: str,
+        namespace: str,
+    ):
+        nonlocal network_policy_del_counter
+        network_policy_del_counter += 1
+
+    monkeypatch.setattr(
+        kubernetes.client.NetworkingV1Api,
+        "delete_namespaced_network_policy",
+        mock_delete_namespaced_network_policy,
+    )
+
+    networking_hook.NetworkingIntegration().pre_session_termination_hook(
+        operator=operators.KubernetesOperator(),
+        session=session,
+    )
+
+    assert network_policy_del_counter == 1

--- a/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
+++ b/backend/tests/sessions/k8s_operator/test_session_k8s_operator.py
@@ -73,6 +73,7 @@ def test_start_session(monkeypatch: pytest.MonkeyPatch):
         ports={"rdp": 3389},
         volumes=[],
         init_volumes=[],
+        labels={},
         annotations={},
     )
 

--- a/helm/templates/backend/backend.serviceaccount.yaml
+++ b/helm/templates/backend/backend.serviceaccount.yaml
@@ -43,7 +43,7 @@ rules:
   resources: ["poddisruptionbudgets"]
   verbs: ["create", "delete"]
 - apiGroups: ["networking.k8s.io"]
-  resources: ["ingresses"]
+  resources: ["ingresses", "networkpolicies"]
   verbs: ["create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
A requirement for the training mode is that a Jupyter session can talk to a Capella session.

This PR adds network policies so that Pods can reach the ports of other Pods from the same user.