### PR TITLE
fix: Update styling and deprecated `highlight.js`-method

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -34,7 +34,9 @@
               "@angular/material/prebuilt-themes/indigo-pink.css",
               "monaco-editor/min/vs/editor/editor.main.css",
               "src/styles.css",
-              "node_modules/ngx-toastr/toastr.css"
+              "node_modules/ngx-toastr/toastr.css",
+              "monaco-editor/min/vs/editor/editor.main.css",
+              "node_modules/highlight.js/styles/default.css"
             ],
             "loader": {
               ".ttf": "file"
@@ -151,7 +153,8 @@
               "@angular/material/prebuilt-themes/indigo-pink.css",
               "monaco-editor/min/vs/editor/editor.main.css",
               "src/styles.css",
-              "node_modules/ngx-toastr/toastr.css"
+              "node_modules/ngx-toastr/toastr.css",
+              "node_modules/highlight.js/styles/default.css"
             ]
           }
         },
@@ -168,7 +171,8 @@
               "@angular/material/prebuilt-themes/indigo-pink.css",
               "monaco-editor/min/vs/editor/editor.main.css",
               "src/styles.css",
-              "node_modules/ngx-toastr/toastr.css"
+              "node_modules/ngx-toastr/toastr.css",
+              "node_modules/highlight.js/styles/default.css"
             ]
           }
         }

--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component.html
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component.html
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<mat-expansion-panel color="bg-slate-400">
+<mat-expansion-panel [expanded]="expanded" color="bg-slate-400">
   <mat-expansion-panel-header>
     <mat-panel-title>
       Learn how to use the diagram cache with capellambse!

--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component.ts
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.component.ts
@@ -71,6 +71,9 @@ export class ModelDiagramCodeBlockComponent implements OnInit, AfterViewInit {
   @Input({ required: true })
   project!: Project;
 
+  @Input()
+  expanded = false;
+
   ngAfterViewInit(): void {
     hljs.highlightAll();
   }
@@ -138,6 +141,6 @@ model = capellambse.MelodyModel(
 })
 export class HighlightPipeTransform implements PipeTransform {
   transform(value: string, language: string): string {
-    return hljs.highlight(language, value).value;
+    return hljs.highlight(value, { language }).value;
   }
 }

--- a/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.stories.ts
+++ b/frontend/src/app/projects/models/diagrams/model-diagram-dialog/model-diagram-code-block/model-diagram-code-block.stories.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Meta, StoryObj } from '@storybook/angular';
+import { mockModel } from 'src/storybook/model';
+import { mockProject } from 'src/storybook/project';
+import { ModelDiagramCodeBlockComponent } from './model-diagram-code-block.component';
+
+const meta: Meta<ModelDiagramCodeBlockComponent> = {
+  title: 'Model Components / Model Diagram Code Block',
+  component: ModelDiagramCodeBlockComponent,
+};
+
+export default meta;
+type Story = StoryObj<ModelDiagramCodeBlockComponent>;
+
+export const CodeBlock: Story = {
+  args: {
+    model: mockModel,
+    project: mockProject,
+    expanded: true,
+  },
+};


### PR DESCRIPTION
Styling of the code block was broken. See Chromatic for more details. Also, a deprecated hightlight.js function was replaced.