### PR TITLE
fix: Update proxy buffering options on Ingress

### DIFF
--- a/helm/templates/routing/routing.ingress.yaml
+++ b/helm/templates/routing/routing.ingress.yaml
@@ -8,8 +8,13 @@ metadata:
   labels:
     id: {{ .Release.Name }}-nginx
   annotations:
+    nginx.ingress.kubernetes.io/fastcgi_buffer_size: 16k
+    nginx.ingress.kubernetes.io/fastcgi_buffers: 16 16k
+    nginx.ingress.kubernetes.io/fastcgi_busy_buffers_size: 16k
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     {{- if eq .Values.cluster.kind "OpenShift" }}
     route.openshift.io/insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Due to the new authentication workflow, the headers of requests. Nginx has refused those large requests in a few cases. This commit increases the buffer size.