### PR TITLE
ci: Replace existing commitlint PR comments

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -11,6 +11,9 @@ jobs:
   conventional-commits:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
+    concurrency:
+      group: commit-check-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,11 +32,21 @@ jobs:
           npx commitlint --from "$SHA_FROM" --to "$SHA_TO" >> "$GITHUB_OUTPUT" 2>&1 || r=$?
           echo "$delim" >> "$GITHUB_OUTPUT"
           exit $r
-      - name: Post comment if validation failed
+      - name: Find conventional commit comment on PR
+        uses: peter-evans/find-comment@v3
         if: always() && steps.conventional-commits.outcome == 'failure'
-        uses: actions/github-script@v7
-        env:
-          TEXT: |-
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: conventional commit
+      - name: Post comment if validation failed
+        uses: peter-evans/create-or-update-comment@v4
+        if: always() && steps.conventional-commits.outcome == 'failure'
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
             The pull request does not conform to the conventional commit specification. Please ensure that your commit messages follow the spec: <https://www.conventionalcommits.org/>.
             We also strongly recommend that you set up your development environment with pre-commit, as described in our [Developer documentation](https://dsd-dbs.github.io/capella-collab-manager/development/). This will run all the important checks right before you commit your changes, and avoids lengthy CI wait time and round trips.
 
@@ -48,11 +61,4 @@ jobs:
             docs(user): Add model creation workflow
             feat: Add a monitoring dashboard
             ```
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: process.env.TEXT
-            })
+          edit-mode: replace


### PR DESCRIPTION
This can avoid a spam of comments when the comment is ignored. Instead, alter the existing comment.