### PR TITLE
feat: Name project roles consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ multiple organizations. Here are some of the key features:
 - Single sign-on (SSO) via [OAuth2](https://oauth.net/2/)
 - No need to install or maintain local Capella clients - clients are made on
   demand in an underlaying [Kubernetes](https://kubernetes.io/) cluster
-- Access to projects and models is self-managed by project leads, model owners
+- Access to projects and models is self-managed by project admins, model owners
   or delegates
 - Within a project a user could have read or read & write access. Read-only
   users don't consume licenses in Team for Capella projects.
@@ -60,7 +60,7 @@ In addition, we have integrated commercial products:
 
 - [pure::variants](https://www.pure-systems.com/purevariants)
   - Automatic license injection
-  - Access to licenses is self-managed by project leads
+  - Access to licenses is self-managed by project admins
 
 We've prepared a small video, where we showcase the diagram cache feature and
 show how you can use Capella and Jupyter in split view in the browser:

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/gitlab/exceptions.py
@@ -14,7 +14,7 @@ class GitlabAccessDeniedError(git_exceptions.AccessDeniedError):
             title="Insufficient Gitlab API access scope",
             reason=(
                 "The registered token has not enough permissions to access the Gitlab API. "
-                "Access scope 'read_api' is required. Please contact your project lead."
+                "Access scope 'read_api' is required. Please contact your project administrator."
             ),
             err_code="GITLAB_ACCESS_DENIED",
         )

--- a/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelsources/git/routes.py
@@ -88,7 +88,7 @@ async def get_revisions_of_primary_git_model(
     ],
 )
 async def get_revisions_with_model_credentials(
-    url: str = fastapi.Body(),
+    url: str = fastapi.Body(media_type="text/plain"),
     git_model: models.DatabaseGitModel = fastapi.Depends(
         injectables.get_existing_git_model
     ),

--- a/backend/capellacollab/projects/toolmodels/restrictions/routes.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/routes.py
@@ -10,15 +10,15 @@ from capellacollab.projects.toolmodels import (
     injectables as toolmodels_injectables,
 )
 from capellacollab.projects.toolmodels import models as toolmodels_models
-from capellacollab.projects.users import models as projects_users_models
+from capellacollab.users import models as users_models
 
 from . import crud, exceptions, injectables, models
 
 router = fastapi.APIRouter(
     dependencies=[
         fastapi.Depends(
-            auth_injectables.ProjectRoleVerification(
-                required_role=projects_users_models.ProjectUserRole.ADMIN
+            auth_injectables.RoleVerification(
+                required_role=users_models.Role.ADMIN
             )
         )
     ],

--- a/backend/capellacollab/projects/users/exceptions.py
+++ b/backend/capellacollab/projects/users/exceptions.py
@@ -44,9 +44,9 @@ class PermissionForProjectLeadsNotAllowedError(core_exceptions.BaseError):
         super().__init__(
             status_code=status.HTTP_403_FORBIDDEN,
             err_code="PERMISSION_FOR_PROJECT_LEADS_NOT_ALLOWED",
-            title="Permission for project leads not allowed",
+            title="Permission for project administrator not allowed",
             reason=(
-                "Project leads can't be given permissions. "
+                "Project administrators can't be given permissions. "
                 "They already have full access to the project."
             ),
         )

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -5,6 +5,7 @@
 import enum
 import typing as t
 
+import pydantic
 import sqlalchemy as sa
 from sqlalchemy import orm
 
@@ -35,7 +36,13 @@ class ProjectUser(core_pydantic.BaseModel):
 
 
 class PostProjectUser(core_pydantic.BaseModel):
-    role: ProjectUserRole
+    role: ProjectUserRole = pydantic.Field(
+        description=(
+            "The role of the user in the project. "
+            "Can be 'user' or 'manager'. Manager is also referred "
+            "to as project administrator in the documentation."
+        )
+    )
     permission: ProjectUserPermission
     username: str
     reason: str

--- a/backend/capellacollab/projects/users/routes.py
+++ b/backend/capellacollab/projects/users/routes.py
@@ -225,7 +225,7 @@ def update_project_user(
     ],
 )
 def remove_user_from_project(
-    reason: str = fastapi.Body(),
+    reason: str = fastapi.Body(media_type="text/plain"),
     project: projects_models.DatabaseProject = fastapi.Depends(
         projects_injectables.get_existing_project
     ),

--- a/backend/capellacollab/settings/modelsources/git/exceptions.py
+++ b/backend/capellacollab/settings/modelsources/git/exceptions.py
@@ -13,7 +13,7 @@ class GitRepositoryAccessError(core_exceptions.BaseError):
             title="Error while accessing the Git repository",
             reason=(
                 "There was an error accessing the model. "
-                "Please ask your project lead for more information. "
+                "Please ask your project administrator for more information. "
                 "In most cases, the credentials need to be updated."
             ),
             err_code="GIT_REPOSITORY_ACCESS_ERROR",

--- a/docs/docs/development/docs.md
+++ b/docs/docs/development/docs.md
@@ -101,7 +101,7 @@ subsections:
     </tr>
     <tr>
         <td><b>/admin</b></td>
-        <td>Administrator documentation</td>
+        <td>System Administrator documentation</td>
         <td>For System administrators and businesses, who are interested in administering their own instances.</td>
     </tr>
     <tr>

--- a/docs/docs/user/projects/access/index.md
+++ b/docs/docs/user/projects/access/index.md
@@ -5,13 +5,13 @@
 
 # How do I Get Access to a Project?
 
-Please ask a [project lead](../roles.md) of the specific project for access.
-The project lead can add you as user to the project. After you've been added,
-you should have direct access. If you don't see the project yet, just reload
-the page with `F5`.
+Please ask a [project administrator](../roles.md) of the specific project for
+access. The project administrator can add you as user to the project. After
+you've been added, you should have direct access. If you don't see the project
+yet, just reload the page with `F5`.
 
-Before a project lead can add you to a project, you have to log in once. The
-first login automatically registers your user in the database.
+Before a project administrator can add you to a project, you have to log in
+once. The first login automatically registers your user in the database.
 
 Your project manager can find more information here:
 [Add a user to a project](../add-user/index.md)

--- a/docs/docs/user/projects/add-user/index.md
+++ b/docs/docs/user/projects/add-user/index.md
@@ -5,7 +5,7 @@
 
 !!! warning
 
-    You need to have the Administrator or Project Lead role for a
+    You need to have the administrator or project administrator role for a
     project to perform the following steps.
 
 ## Add User to Project
@@ -37,7 +37,8 @@
     You can select from the following options:
 
     -   Remove a user from the project
-    -   Set role of the user to [project lead](../../projects/roles.md) or
+    -   Set role of the user to
+        [project administrator](../../projects/roles.md) or
         [user](../../projects/roles.md)
     -   Set permission of the user to
         [read/write](../../sessions/types/index.md) or

--- a/docs/docs/user/projects/create/index.md
+++ b/docs/docs/user/projects/create/index.md
@@ -7,8 +7,9 @@
 
 In the Collaboration Manager, you can follow a guided process to create
 projects. Any user can create a project. After creation, you get the role
-[project lead](../../projects/roles.md) for the project. To create a project,
-go to the _Projects_ tab of the navigation bar, and click on _Add new project_.
+[project administrator](../../projects/roles.md) for the project. To create a
+project, go to the _Projects_ tab of the navigation bar, and click on _Add new
+project_.
 
 Please follow the steps:
 
@@ -21,9 +22,9 @@ changed! Additionally, you may want to add a description.
 
 ## Step 2: Add Team Members
 
-This page allows to manage the project user. By default, you are project lead
-of the project. If you don't want to add an additional user, you can skip this
-step. Users can be added later at any time.
+This page allows to manage the project user. By default, you are project
+administrator of the project. If you don't want to add an additional user, you
+can skip this step. Users can be added later at any time.
 
 ![Step 2: Team members](./step-2.png)
 

--- a/docs/docs/user/projects/models/backups/remove.md
+++ b/docs/docs/user/projects/models/backups/remove.md
@@ -7,7 +7,7 @@
 
 !!! warning
 
-    Only administrators and project leads can remove pipelines.
+    Only global administrators and project administrators can remove pipelines.
 
 1. Select the project in the `Projects` overview.
 1. In the model overview, select the `Synchronize`-button

--- a/docs/docs/user/projects/models/backups/setup.md
+++ b/docs/docs/user/projects/models/backups/setup.md
@@ -7,7 +7,7 @@
 
 !!! warning
 
-    You need to have the Administrator or Project Lead role for a
+    You need to have the global administrator or project administrator role for a
     project to perform the following steps.
 
 !!! danger

--- a/docs/docs/user/projects/models/complexity_badge.md
+++ b/docs/docs/user/projects/models/complexity_badge.md
@@ -13,7 +13,7 @@
 
     - A file called `model-complexity-badge.svg` has to exist in the repository.
       We provide a Gitlab CI template and a Github action to generate the file. Find more information below.
-    - Only project leads can set up the model complexity badge. In addition, one needs access to the Git repository of the model.
+    - Only project administrators can set up the model complexity badge. In addition, one needs access to the Git repository of the model.
 
 1.  To set up the model complexity badge, you need to add the Git API URL to
     your Git instance. More information

--- a/docs/docs/user/projects/models/create.md
+++ b/docs/docs/user/projects/models/create.md
@@ -6,9 +6,9 @@
 # Create a _Collaboration Manager_ Model
 
 We offer a guided process to create models in a project. To create a model, you
-have to be at least [project lead](../../projects/roles.md). If you're coming
-from project creation, you're ready to go. Otherwise, please navigate to the
-_Projects_ tab of the navigation bar, open the project in which you want to
+have to be at least [project administrator](../../projects/roles.md). If you're
+coming from project creation, you're ready to go. Otherwise, please navigate to
+the _Projects_ tab of the navigation bar, open the project in which you want to
 create a model, and click on the “+” icon.
 
 The creation can be interrupted at any step, however an unfinished model will
@@ -30,14 +30,15 @@ following options:
 1. Create a new **Git** repository. This option is not supported yet. Please
    create the repository yourself and continue with the first option.
 1. Link a **TeamForCapella** repository. Only available for the `Capella` tool.
-   If you're project lead and not administrator, you are not able to select
-   this option. You'll need assistance by an administrator. You can abort the
-   process here and continue with the help of an administrator later on.
+   If you're project administrator and not global administrator, you are not
+   able to select this option. You'll need assistance by an administrator. You
+   can abort the process here and continue with the help of an administrator
+   later on.
 1. Create a **TeamForCapella** repository. Only available for the `Capella`
-   tool. If you're project lead and not administrator, you are not able to
-   select this option. You'll need assistance by an administrator. You can
-   abort the process here and continue with the help of an administrator later
-   on.
+   tool. If you're project administrator and not global administrator, you are
+   not able to select this option. You'll need assistance by an administrator.
+   You can abort the process here and continue with the help of an
+   administrator later on.
 
 ## Step 3: Add Source
 
@@ -84,7 +85,7 @@ You have to enter the following information:
 
          The credentials should be scoped and should only work for the required
          repository. When changing the repository URL and the credentials are not
-         changed, other project leads can gain access to different repositories
+         changed, other project administrators can gain access to different repositories
          with your token.
 
 ### Step 3.2 Link Existing T4C Repository

--- a/docs/docs/user/projects/roles.md
+++ b/docs/docs/user/projects/roles.md
@@ -11,7 +11,7 @@ Projects are self-managed. There are different roles for this:
         <th>Permissions</th>
     </tr>
     <tr>
-        <td>`Administrator`</td>
+        <td>`Global Administrator`</td>
         <td>
             :material-check-all: All permissions <br>
             :material-check: Manage TeamForCapella instances <br>
@@ -19,7 +19,7 @@ Projects are self-managed. There are different roles for this:
             :material-check: Manage Git repositories</td>
     </tr>
     <tr>
-        <td>`Project lead`</td>
+        <td>`Project administrator`</td>
         <td>
             :material-check: Manage users of a project <br>
             :material-check: Manage model sources <br>

--- a/docs/docs/user/sessions/troubleshooting/index.md
+++ b/docs/docs/user/sessions/troubleshooting/index.md
@@ -42,12 +42,12 @@
     <span id="modelloading-failed" />
 
     This happens if the loading of one of the models fails.
-    Please reach out your project lead. If you are project lead, please check
+    Please reach out your project administrator. If you are project administrator, please check
     the primary Git models with a matching tool version of your project.
     These are used for the `read-only` session. Common mistakes are wrong
     credentials, wrong entrypoints (e.g. with typos) and missing `aird`-files.
 
-    If you have no success, please reach out your administrator. Administrators
+    If you have no success, please reach out your global administrator. They
     can see the logs of read-only sessions.
 
 <!-- prettier-ignore -->

--- a/docs/docs/user/tools/capella/troubleshooting/index.md
+++ b/docs/docs/user/tools/capella/troubleshooting/index.md
@@ -15,7 +15,7 @@
     reported to the Eclipse Capella team directly in the
     [Github repository](https://github.com/eclipse/capella/issues).
 
-    Administrators can see the logs of all sessions to identify the issues
+    Global administrators can see the logs of all sessions to identify the issues
     remotely. In addition, the session owner can also see the events in the UI.
     In your session, please follow these steps:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,7 +72,7 @@ nav:
       - api/swagger.md
       - api/redoc.md
       - api/openapi.md
-  - Administrator Documentation:
+  - System Administrator Documentation:
       - Introduction: admin/index.md
       - Installation: admin/installation.md
       - Authentication:

--- a/frontend/src/app/helpers/input-dialog/input-dialog.component.html
+++ b/frontend/src/app/helpers/input-dialog/input-dialog.component.html
@@ -5,7 +5,7 @@
 
 <div class="dialog">
   <form [formGroup]="form" (submit)="onSubmit()">
-    <h2>{{ data.title }}</h2>
+    <h2 class="text-xl font-medium">{{ data.title }}</h2>
     <p>{{ data.text }}</p>
 
     <mat-form-field class="my-2 w-full" appearance="fill">

--- a/frontend/src/app/openapi/api/projects-models-git.service.ts
+++ b/frontend/src/app/openapi/api/projects-models-git.service.ts
@@ -557,7 +557,7 @@ export class ProjectsModelsGitService {
 
         // to determine the Content-Type header
         const consumes: string[] = [
-            'application/json'
+            'text/plain'
         ];
         const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
         if (httpContentTypeSelected !== undefined) {

--- a/frontend/src/app/openapi/api/projects.service.ts
+++ b/frontend/src/app/openapi/api/projects.service.ts
@@ -758,7 +758,7 @@ export class ProjectsService {
 
         // to determine the Content-Type header
         const consumes: string[] = [
-            'application/json'
+            'text/plain'
         ];
         const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
         if (httpContentTypeSelected !== undefined) {

--- a/frontend/src/app/openapi/model/post-project-user.ts
+++ b/frontend/src/app/openapi/model/post-project-user.ts
@@ -14,6 +14,9 @@ import { ProjectUserPermission } from './project-user-permission';
 
 
 export interface PostProjectUser { 
+    /**
+     * The role of the user in the project. Can be \'user\' or \'manager\'. Manager is also referred to as project administrator in the documentation.
+     */
     role: ProjectUserRole;
     permission: ProjectUserPermission;
     username: string;

--- a/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-complexity-badge/model-complexity-badge.component.html
@@ -50,7 +50,7 @@
       <span class="model-complexity-error-text"
         ><b>Error loading the complexity badge.</b> <br />{{
           errorMessage ||
-            "Please ask your project lead or administrator for help."
+            "Please ask your project administrator or global administrator for help."
         }}</span
       >
     </div>

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.html
@@ -4,7 +4,7 @@
  -->
 
 <div>
-  <div class="mt-1.5 flex items-center">
+  <div class="mb-2 mt-1.5 flex items-center">
     <h2 class="text-xl font-medium">Models</h2>
     @if (projectUserService.verifyRole("manager")) {
       <a
@@ -44,171 +44,180 @@
       }
     }
   </div>
-  <div class="flex flex-wrap">
-    <div class="flex" *ngIf="(modelService.models$ | async) === undefined">
-      <div *ngFor="let card of [0, 1, 2]">
+  <div class="flex flex-wrap gap-2">
+    @if ((modelService.models$ | async) === undefined) {
+      @for (card of [0, 1, 2]; track $index) {
         <ngx-skeleton-loader
           appearance="circle"
           [theme]="{
             'border-radius': '5px',
             height: '280px',
             width: '500px',
-            margin: '10px',
+            margin: '0px',
+            padding: '0px',
             border: '1px solid white',
           }"
         ></ngx-skeleton-loader>
-      </div>
-    </div>
-
-    <div
-      class="collab-card m-[10px] flex min-h-[200px] w-[500px] max-w-[85vw] select-none flex-col !p-0"
-      *ngFor="let model of modelService.models$ | async"
-    >
+      }
+    }
+    @for (model of modelService.models$ | async; track model.id) {
       <div
-        class="flex justify-between rounded-t bg-primary p-2.5 align-middle text-white"
+        class="collab-card flex min-h-[200px] w-[500px] max-w-[85vw] select-none flex-col !p-0"
       >
-        <div class="ml-2.5">
-          <div class="select-text text-xl" style="word-break: break-word">
-            {{ model.name }}
+        <div
+          class="flex justify-between rounded-t bg-primary p-2.5 align-middle text-white"
+        >
+          <div class="ml-2.5">
+            <div class="select-text text-xl" style="word-break: break-word">
+              {{ model.name }}
+            </div>
+            <span class="select-text text-base">
+              {{ model.tool.name }}
+              @if (model.version) {
+                {{ model.version.name }}
+              } @else {
+                (Version not specified)
+              }
+            </span>
           </div>
-          <span class="select-text text-base">
-            {{ model.tool.name }}
-            <span *ngIf="model.version"> {{ model.version.name }}</span>
-            <span *ngIf="!model.version"> (Version not specified)</span>
-          </span>
-        </div>
 
-        <div class="flex items-center align-middle">
-          <div
-            class="collab-card mx-[4px] flex h-[50px] items-center !bg-green-800 !p-0 text-white"
-          >
-            <div class="mx-[8px] text-center">
-              <div class="text-xs">Nature</div>
-              <div *ngIf="model.nature" class="text-sm">
-                {{ model.nature.name }}
-              </div>
-              <div *ngIf="!model.nature" class="text-sm">Not specified</div>
-            </div>
-          </div>
-          <div
-            class="collab-card mx-[4px] flex h-[50px] items-center !bg-red-800 !p-0 text-white"
-          >
-            <div class="mx-[8px] text-center">
-              <div class="text-nowrap text-xs">Working mode</div>
-              <div class="text-sm">
-                {{ getPrimaryWorkingMode(model) }}
+          <div class="flex items-center align-middle">
+            <div
+              class="collab-card mx-[4px] flex h-[50px] items-center !bg-green-800 !p-0 text-white"
+            >
+              <div class="mx-[8px] text-center">
+                <div class="text-xs">Nature</div>
+                <span class="text-sm">
+                  @if (model.nature) {
+                    {{ model.nature.name }}
+                  } @else {
+                    Not specified
+                  }
+                </span>
               </div>
             </div>
+            <div
+              class="collab-card mx-[4px] flex h-[50px] items-center !bg-red-800 !p-0 text-white"
+            >
+              <div class="mx-[8px] text-center">
+                <div class="text-nowrap text-xs">Working mode</div>
+                <div class="text-sm">
+                  {{ getPrimaryWorkingMode(model) }}
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="flex grow flex-col justify-between">
-        <div class="m-2.5 select-text">
-          {{ model.description || "This model has no description." }}
-        </div>
-        <div class="flex justify-center">
-          <app-model-complexity-badge
-            class="w-[95%]"
-            *ngIf="model.tool.name === 'Capella'"
-            [modelSlug]="model.slug"
-          ></app-model-complexity-badge>
-        </div>
-        <div class="m-2.5">
-          <a
-            mat-mini-fab
-            color="primary"
-            matTooltip="Configure model"
-            class="!m-1.5"
-            [routerLink]="['model', model.slug, 'metadata']"
-            *ngIf="projectUserService.verifyRole('manager')"
-          >
-            <mat-icon>settings</mat-icon>
-          </a>
-          <a
-            mat-mini-fab
-            color="primary"
-            matTooltip="Model restrictions"
-            class="!m-1.5"
-            [routerLink]="['model', model.slug, 'restrictions']"
-            *ngIf="userService.user?.role === 'administrator'"
-          >
-            <mat-icon>key</mat-icon>
-          </a>
-          <button
-            mat-mini-fab
-            color="primary"
-            matTooltip="Move model to different project"
-            class="!m-1.5"
-            (click)="openMoveToProjectDialog(model)"
-            *ngIf="projectUserService.verifyRole('manager')"
-          >
-            <mat-icon>drive_file_move</mat-icon>
-          </button>
-          <a
-            mat-mini-fab
-            color="primary"
-            matTooltip="Configure model sources"
-            class="!m-1.5"
-            [routerLink]="['model', model.slug, 'modelsources']"
-            *ngIf="projectUserService.verifyRole('manager')"
-          >
-            <mat-icon>link</mat-icon>
-          </a>
-          <a
-            mat-mini-fab
-            color="primary"
-            matTooltip="Start synchronization"
-            class="!m-1.5"
-            (click)="openPipelineDialog(model)"
-            *ngIf="
-              projectUserService.verifyRole('manager') &&
+        <div class="flex grow flex-col justify-between">
+          <div class="m-2.5 select-text">
+            {{ model.description || "This model has no description." }}
+          </div>
+          <div class="flex justify-center">
+            @if (model.tool.name === "Capella") {
+              <app-model-complexity-badge
+                class="w-[95%]"
+                [modelSlug]="model.slug"
+              ></app-model-complexity-badge>
+            }
+          </div>
+          <div class="m-2.5">
+            @if (userService.user?.role === "administrator") {
+              <a
+                mat-mini-fab
+                color="primary"
+                matTooltip="Model restrictions"
+                class="!m-1.5"
+                [routerLink]="['model', model.slug, 'restrictions']"
+              >
+                <mat-icon>key</mat-icon>
+              </a>
+            }
+            @if (projectUserService.verifyRole("manager")) {
+              <a
+                mat-mini-fab
+                color="primary"
+                matTooltip="Configure model"
+                class="!m-1.5"
+                [routerLink]="['model', model.slug, 'metadata']"
+              >
+                <mat-icon>settings</mat-icon>
+              </a>
+              <button
+                mat-mini-fab
+                color="primary"
+                matTooltip="Move model to different project"
+                class="!m-1.5"
+                (click)="openMoveToProjectDialog(model)"
+              >
+                <mat-icon>drive_file_move</mat-icon>
+              </button>
+              <a
+                mat-mini-fab
+                color="primary"
+                matTooltip="Configure model sources"
+                class="!m-1.5"
+                [routerLink]="['model', model.slug, 'modelsources']"
+              >
+                <mat-icon>link</mat-icon>
+              </a>
+              @if (!project?.is_archived && project?.type !== "training") {
+                <a
+                  mat-mini-fab
+                  color="primary"
+                  matTooltip="Start synchronization"
+                  class="!m-1.5"
+                  (click)="openPipelineDialog(model)"
+                >
+                  <mat-icon>sync</mat-icon>
+                </a>
+              }
+            }
+
+            @if (model.git_models) {
+              <a
+                mat-mini-fab
+                color="primary"
+                matTooltip="Open git repository"
+                class="!m-1.5"
+                target="_blank"
+                [disabled]="!getPrimaryGitModelURL(model)"
+                [href]="getPrimaryGitModelURL(model)"
+              >
+                <mat-icon>open_in_new</mat-icon>
+              </a>
+              @if (model.tool.name === "Capella") {
+                <button
+                  mat-mini-fab
+                  color="primary"
+                  matTooltip="Show diagrams of model"
+                  class="!m-1.5"
+                  [disabled]="!getPrimaryGitModelURL(model)"
+                  (click)="openDiagramsDialog(model)"
+                >
+                  <mat-icon>image_search</mat-icon>
+                </button>
+              }
+            }
+
+            @if (
               !project?.is_archived &&
-              project?.type !== 'training'
-            "
-          >
-            <mat-icon>sync</mat-icon>
-          </a>
-          <a
-            mat-mini-fab
-            color="primary"
-            matTooltip="Open git repository"
-            class="!m-1.5"
-            target="_blank"
-            [disabled]="!getPrimaryGitModelURL(model)"
-            [href]="getPrimaryGitModelURL(model)"
-            *ngIf="model.git_models"
-          >
-            <mat-icon>open_in_new</mat-icon>
-          </a>
-          <a
-            mat-mini-fab
-            color="primary"
-            matTooltip="Request persistent session"
-            class="!m-1.5"
-            routerLink="/sessions"
-            *ngIf="
-              !project?.is_archived &&
-              project?.type !== 'training' &&
+              project?.type !== "training" &&
               model.t4c_models &&
-              projectUserService.verifyPermission('write')
-            "
-          >
-            <mat-icon>screen_share</mat-icon>
-          </a>
-
-          <button
-            mat-mini-fab
-            color="primary"
-            matTooltip="Show diagrams of model"
-            class="!m-1.5"
-            [disabled]="!getPrimaryGitModelURL(model)"
-            (click)="openDiagramsDialog(model)"
-            *ngIf="model.git_models && model.tool.name === 'Capella'"
-          >
-            <mat-icon>image_search</mat-icon>
-          </button>
+              projectUserService.verifyPermission("write")
+            ) {
+              <a
+                mat-mini-fab
+                color="primary"
+                matTooltip="Request persistent session"
+                class="!m-1.5"
+                routerLink="/sessions"
+              >
+                <mat-icon>screen_share</mat-icon>
+              </a>
+            }
+          </div>
         </div>
       </div>
-    </div>
+    }
   </div>
 </div>

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.component.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import {
   MatAnchor,
@@ -44,8 +44,6 @@ import { ModelComplexityBadgeComponent } from './model-complexity-badge/model-co
     MatTooltip,
     MatIcon,
     MatButton,
-    NgIf,
-    NgFor,
     NgxSkeletonLoaderModule,
     ModelComplexityBadgeComponent,
     MatMiniFabAnchor,

--- a/frontend/src/app/projects/project-detail/model-overview/model-overview.stories.ts
+++ b/frontend/src/app/projects/project-detail/model-overview/model-overview.stories.ts
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { ModelWrapperService } from 'src/app/projects/models/service/model.service';
+import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
+import { UserWrapperService } from 'src/app/services/user/user.service';
+import { mockModel, MockModelWrapperService } from 'src/storybook/model';
+import { MockProjectUserService } from 'src/storybook/project-users';
+import { mockUser, MockUserService } from 'src/storybook/user';
+import { ModelOverviewComponent } from './model-overview.component';
+
+const meta: Meta<ModelOverviewComponent> = {
+  title: 'Model Components / Model Overview',
+  component: ModelOverviewComponent,
+};
+
+export default meta;
+type Story = StoryObj<ModelOverviewComponent>;
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: ModelWrapperService,
+          useFactory: () =>
+            new MockModelWrapperService(mockModel, [
+              { ...mockModel, name: 'mockModel1' },
+              {
+                ...mockModel,
+                name: 'mockModel2',
+                description:
+                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+              },
+              {
+                ...mockModel,
+                name: 'ModelWithMissingInfo',
+                version: null,
+                nature: null,
+              },
+              {
+                ...mockModel,
+                name: 'Capella model',
+                tool: { ...mockModel.tool, name: 'Capella' },
+              },
+            ]),
+        },
+      ],
+    }),
+  ],
+};
+
+export const AsProjectAdmin: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: ModelWrapperService,
+          useFactory: () =>
+            new MockModelWrapperService(mockModel, [
+              { ...mockModel, name: 'mockModel1' },
+            ]),
+        },
+        {
+          provide: ProjectUserService,
+          useFactory: () => new MockProjectUserService('manager', 'write'),
+        },
+      ],
+    }),
+  ],
+};
+
+export const AsGlobalAdmin: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: ModelWrapperService,
+          useFactory: () =>
+            new MockModelWrapperService(mockModel, [
+              { ...mockModel, name: 'mockModel1' },
+            ]),
+        },
+        {
+          provide: ProjectUserService,
+          useFactory: () => new MockProjectUserService('manager', 'write'),
+        },
+        {
+          provide: UserWrapperService,
+          useFactory: () =>
+            new MockUserService({ ...mockUser, role: 'administrator' }),
+        },
+      ],
+    }),
+  ],
+};

--- a/frontend/src/app/projects/project-detail/project-details.component.html
+++ b/frontend/src/app/projects/project-detail/project-details.component.html
@@ -3,15 +3,15 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div class="flex flex-wrap justify-between">
+<div class="flex flex-wrap justify-between gap-2">
   <div class="grow basis-1">
-    <div class="flex flex-wrap items-stretch">
+    <div class="flex flex-wrap items-stretch gap-2">
       <app-project-metadata class="flex-1"></app-project-metadata>
       <app-create-readonly-session class="flex"></app-create-readonly-session>
     </div>
     <app-model-overview></app-model-overview>
   </div>
-  <div *ngIf="projectUserService.verifyRole('manager')">
+  @if (projectUserService.verifyRole("manager")) {
     <app-project-user-settings></app-project-user-settings>
-  </div>
+  }
 </div>

--- a/frontend/src/app/projects/project-detail/project-details.stories.ts
+++ b/frontend/src/app/projects/project-detail/project-details.stories.ts
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
+import { MockProjectUserService } from 'src/storybook/project-users';
+import { ProjectDetailsComponent } from './project-details.component';
+
+const meta: Meta<ProjectDetailsComponent> = {
+  title: 'Project Components / Project Details',
+  component: ProjectDetailsComponent,
+  parameters: {
+    chromatic: { viewports: [1920] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<ProjectDetailsComponent>;
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const LoadingAsProjectLead: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: ProjectUserService,
+          useFactory: () => new MockProjectUserService('manager'),
+        },
+      ],
+    }),
+  ],
+};

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.component.html
@@ -4,9 +4,9 @@
  -->
 
 <div class="flex h-full flex-col">
-  <h2 class="text-xl font-medium">Project Information</h2>
+  <h2 class="mb-2 text-xl font-medium">Project Information</h2>
   <div
-    class="collab-card [p-12px] m-[10px] flex min-h-[200px] grow flex-col justify-between gap-2"
+    class="collab-card [p-12px] flex min-h-[200px] grow flex-col justify-between gap-2"
   >
     @if (project !== undefined) {
       <div class="flex flex-col gap-2">

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.docs.mdx
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.docs.mdx
@@ -20,7 +20,7 @@ While loading the project, it looks the same for all users:
 A "normal" project user can see the title and description:
 <Story of={ProjectMetadata.NormalUser}/>
 
-Project leads have the option to modify some settings:
+Project Administrators have the option to modify some settings:
 <Story of={ProjectMetadata.ProjectAdmin} />
 
 This is how an archived projects looks like for normal users:

--- a/frontend/src/app/projects/project-detail/project-metadata/project-metadata.stories.ts
+++ b/frontend/src/app/projects/project-detail/project-metadata/project-metadata.stories.ts
@@ -3,25 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import {
-  ProjectUserRole,
-  ProjectUserService,
-} from 'src/app/projects/project-detail/project-users/service/project-user.service';
+import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
 import { mockProject } from 'src/storybook/project';
+import { MockProjectUserService } from 'src/storybook/project-users';
 import { ProjectMetadataComponent } from './project-metadata.component';
-
-class MockProjectUserService implements Partial<ProjectUserService> {
-  user: ProjectUserRole;
-
-  constructor(user: ProjectUserRole) {
-    this.user = user;
-  }
-
-  verifyRole(requiredRole: ProjectUserRole): boolean {
-    const roles = ['user', 'manager', 'administrator'];
-    return roles.indexOf(requiredRole) <= roles.indexOf(this.user);
-  }
-}
 
 const meta: Meta<ProjectMetadataComponent> = {
   title: 'Project Components / Project Metadata',

--- a/frontend/src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.component.html
+++ b/frontend/src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.component.html
@@ -4,58 +4,53 @@
  -->
 
 <div class="dialog">
-  <h2>Add user</h2>
+  <h2 class="mb-2 text-xl font-medium">Add User to Project</h2>
   <form [formGroup]="addUserToProjectForm">
     <mat-form-field appearance="fill">
       <mat-label>Username</mat-label>
       <input matInput formControlName="username" />
-      <mat-error *ngIf="username.getError('required')">
-        Please enter a username!
-      </mat-error>
-      <mat-error *ngIf="username.getError('lowerCaseError')">
-        Usernames can only contain lowercase letters!
-      </mat-error>
-      <mat-error *ngIf="username.getError('userAlreadyInProjectError')">
-        The user is already a member of this project!
-      </mat-error>
+      @if (username.getError("required")) {
+        <mat-error> Please enter a username! </mat-error>
+      } @else if (username.getError("lowerCaseError")) {
+        <mat-error> Usernames can only contain lowercase letters! </mat-error>
+      } @else if (username.getError("userAlreadyInProjectError")) {
+        <mat-error> The user is already a member of this project! </mat-error>
+      }
     </mat-form-field>
     <br />
-    <mat-form-field appearance="fill">
-      <mat-label>Role</mat-label>
-      <mat-select formControlName="role">
-        <mat-option
-          *ngFor="let role of projectUserService.ROLES | keyvalue"
-          [value]="role.key"
-          >{{ role.value }}</mat-option
-        >
-      </mat-select>
-      <mat-error>You have to select a role!</mat-error>
-    </mat-form-field>
-    <div *ngIf="addUserToProjectForm.value.role !== 'manager'">
-      <mat-form-field
-        appearance="fill"
-        *ngIf="addUserToProjectForm.value.role !== 'manager'"
-      >
-        <mat-label>Permission</mat-label>
-        <mat-select formControlName="permission">
-          <mat-option
-            *ngFor="let permission of projectUserService.PERMISSIONS | keyvalue"
-            [value]="permission.key"
-            >{{ permission.value }}</mat-option
-          >
-        </mat-select>
-        <mat-error>You have to select a permission!</mat-error>
-      </mat-form-field>
+    <div class="my-1">
+      Role: <br />
+      <mat-radio-group formControlName="role" aria-label="Role">
+        @for (role of roles | keyvalue; track role.key) {
+          <mat-radio-button [value]="role.key">{{
+            role.value
+          }}</mat-radio-button>
+        }
+      </mat-radio-group>
     </div>
+
+    @if (addUserToProjectForm.value.role !== "manager") {
+      <div class="my-1">
+        Permission: <br />
+        <mat-radio-group formControlName="permission" aria-label="Role">
+          @for (permission of permissions | keyvalue; track permission.key) {
+            <mat-radio-button [value]="permission.key">{{
+              permission.value
+            }}</mat-radio-button>
+          }
+        </mat-radio-group>
+      </div>
+    }
     <mat-form-field appearance="fill">
       <mat-label>Reason</mat-label>
       <textarea rows="10" matInput formControlName="reason"></textarea>
-      <mat-error *ngIf="addUserToProjectForm.controls.reason.errors?.required">
-        Please enter a reason!
-      </mat-error>
+      @if (addUserToProjectForm.controls.reason.errors?.required) {
+        <mat-error> Please enter a reason! </mat-error>
+      }
     </mat-form-field>
     <div class="flex justify-between">
-      <button (click)="addUser()" mat-flat-button color="primary">
+      <button (click)="close()" mat-stroked-button type="button">Cancel</button>
+      <button (click)="addUser()" mat-flat-button type="submit" color="primary">
         Add user <mat-icon iconPositionEnd>navigate_next</mat-icon>
       </button>
     </div>

--- a/frontend/src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.stories.ts
+++ b/frontend/src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.stories.ts
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { dialogWrapper } from 'src/storybook/decorators';
+import { mockProject } from 'src/storybook/project';
+import { AddUserToProjectDialogComponent } from './add-user-to-project.component';
+
+const meta: Meta<AddUserToProjectDialogComponent> = {
+  title: 'Project Components / Add User',
+  component: AddUserToProjectDialogComponent,
+  decorators: [dialogWrapper],
+};
+
+export default meta;
+type Story = StoryObj<AddUserToProjectDialogComponent>;
+
+export const Dialog: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            project: mockProject,
+          },
+        },
+      ],
+    }),
+  ],
+};

--- a/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.html
+++ b/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.html
@@ -3,24 +3,12 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div *ngIf="!hasRoute('projects/create')" class="mr-2.5">
-  <h2 class="text-xl font-medium">Project Members</h2>
-</div>
-<div class="collab-card w-[312px] max-w-[350px] sm:min-w-[420px]">
-  <div *ngIf="!hasRoute('projects/create')">
-    <button
-      class="flex items-center justify-between"
-      (click)="openAuditLogDialog()"
-      mat-stroked-button
-    >
-      <mat-icon>assignment</mat-icon>
-      <span> Review access changes </span>
-    </button>
-  </div>
+@if (!isInProjectCreation()) {
+  <h2 class="mb-2 mr-2.5 text-xl font-medium">Project Members</h2>
+}
 
-  <h3 class="pl-1">New members</h3>
-  <mat-divider></mat-divider>
-  <div class="my-[10px]">
+<div class="collab-card w-[312px] max-w-[350px] sm:min-w-[420px]">
+  <div class="mb-2 flex flex-wrap gap-2">
     <button
       class="flex items-center justify-between"
       (click)="openAddUserDialog()"
@@ -29,9 +17,18 @@
       <mat-icon>add</mat-icon>
       <span> Add User </span>
     </button>
+    @if (!isInProjectCreation()) {
+      <button
+        class="flex items-center justify-between"
+        (click)="openAuditLogDialog()"
+        mat-stroked-button
+      >
+        <mat-icon>assignment</mat-icon>
+        <span> Review access changes </span>
+      </button>
+    }
   </div>
 
-  <h3 class="pl-1">Current members</h3>
   <mat-divider></mat-divider>
   <mat-form-field
     class="mb-[-20px] mt-[10px] w-full pl-1 pr-4"
@@ -42,92 +39,102 @@
     <mat-icon matSuffix>search</mat-icon>
   </mat-form-field>
   <div class="max-h-[50vh] overflow-y-scroll">
-    <div *ngFor="let role of ['manager', 'user', 'administrator']">
+    @for (role of ["manager", "user", "administrator"]; track role) {
       <div class="mt-2.5 pl-1 text-lg font-bold text-gray-400">
-        {{ capitalizeFirstLetter(role) }}
+        @switch (role) {
+          @case ("manager") {
+            Project Administrator
+          }
+          @case ("administrator") {
+            Global Administrator
+          }
+          @case ("user") {
+            Project User
+          }
+        }
       </div>
-      <div
-        class="mx-1.5 my-2.5 flex items-center justify-between"
-        *ngFor="
-          let user of getProjectUsersByRole(
-            projectUserService.projectUsers$ | async,
-            role
-          )
-        "
-      >
-        <a class="flex" [routerLink]="['/user', user.user.id]">
-          <div class="ml-0 mr-4 flex items-center">
-            <mat-icon class="my-auto !h-8 !w-8 text-3xl" mat-list-icon
-              >account_circle</mat-icon
-            >
-          </div>
-          <div>
-            <div class="break-all text-[17.5px]">{{ user.user.name }}</div>
-            <div class="text-[14px] text-gray-500">
-              {{ projectUserService.ADVANCED_ROLES[user.role] }},
-              {{ projectUserService.PERMISSIONS[user.permission] }}
+      @for (
+        user of getProjectUsersByRole(
+          projectUserService.projectUsers$ | async,
+          role
+        );
+        track user.user.id
+      ) {
+        <div class="mx-1.5 my-2.5 flex items-center justify-between">
+          <a class="flex" [routerLink]="['/user', user.user.id]">
+            <div class="ml-0 mr-4 flex items-center">
+              <mat-icon class="my-auto !h-8 !w-8 text-3xl" mat-list-icon
+                >account_circle</mat-icon
+              >
             </div>
-          </div>
-        </a>
-        <div class="ml-1 mr-0 flex items-center">
-          <button
-            mat-icon-button
-            color="warn"
-            *ngIf="['user', 'manager'].includes(user.role)"
-            (click)="removeUserFromProject(user.user)"
-            matTooltip="Remove user from project"
-            class="!mx-0 !px-0 text-sm"
-          >
-            <mat-icon>delete</mat-icon>
-          </button>
-
-          <button
-            mat-icon-button
-            color="primary"
-            *ngIf="'user' === user.role"
-            (click)="upgradeUserToProjectManager(user.user)"
-            matTooltip="Upgrade user to project manager"
-            class="!mx-0 !px-0 text-sm"
-          >
-            <mat-icon>arrow_upward</mat-icon>
-          </button>
-          <button
-            mat-icon-button
-            color="primary"
-            *ngIf="'manager' === user.role"
-            (click)="downgradeUserToUserRole(user.user)"
-            matTooltip="Downgrade user to simple user"
-            class="!mx-0 !px-0 text-sm"
-          >
-            <mat-icon>arrow_downward</mat-icon>
-          </button>
-          <div *ngIf="'manager' !== user.role">
-            <button
-              mat-icon-button
-              color="primary"
-              *ngIf="'read' === user.permission"
-              (click)="setUserPermission(user.user, 'write')"
-              matTooltip="Set permission of user to read/write"
-              class="!mx-0 !px-0 text-sm"
-            >
-              <mat-icon>folder_shared</mat-icon>
-            </button>
-            <button
-              mat-icon-button
-              color="primary"
-              *ngIf="
-                'write' === user.permission && user.role !== 'administrator'
-              "
-              (click)="setUserPermission(user.user, 'read')"
-              matTooltip="Set permission of user to read only"
-              class="!mx-0 !px-0 text-sm"
-            >
-              <mat-icon>folder_open</mat-icon>
-            </button>
+            <div>
+              <div class="break-all text-[17.5px]">{{ user.user.name }}</div>
+              <div class="text-[14px] text-gray-500">
+                {{ advanced_roles[user.role] }},
+                {{ permissions[user.permission] }}
+              </div>
+            </div>
+          </a>
+          <div class="ml-1 mr-0 flex items-center">
+            @if (user.role === "user") {
+              @if (user.permission === "read") {
+                <button
+                  mat-icon-button
+                  color="primary"
+                  (click)="setUserPermission(user.user, 'write')"
+                  matTooltip="Set permission of user to read/write"
+                  class="!mx-0 !px-0 text-sm"
+                >
+                  <mat-icon>folder_shared</mat-icon>
+                </button>
+              } @else {
+                <button
+                  mat-icon-button
+                  color="primary"
+                  (click)="setUserPermission(user.user, 'read')"
+                  matTooltip="Set permission of user to read only"
+                  class="!mx-0 !px-0 text-sm"
+                >
+                  <mat-icon>folder_open</mat-icon>
+                </button>
+              }
+            }
+            @if (user.role === "user") {
+              <button
+                mat-icon-button
+                color="primary"
+                (click)="upgradeUserToProjectManager(user.user)"
+                matTooltip="Upgrade user to project manager"
+                class="!mx-0 !px-0 text-sm"
+              >
+                <mat-icon>arrow_upward</mat-icon>
+              </button>
+            } @else if (user.role === "manager") {
+              <button
+                mat-icon-button
+                color="primary"
+                (click)="downgradeUserToUserRole(user.user)"
+                matTooltip="Downgrade user to simple user"
+                class="!mx-0 !px-0 text-sm"
+              >
+                <mat-icon>arrow_downward</mat-icon>
+              </button>
+            }
+            @if (user.role !== "administrator") {
+              <button
+                mat-icon-button
+                color="warn"
+                (click)="removeUserFromProject(user.user)"
+                matTooltip="Remove user from project"
+                class="!mx-0 !px-0 text-sm"
+              >
+                <mat-icon>delete</mat-icon>
+              </button>
+            }
           </div>
         </div>
-      </div>
-      <div *ngIf="(projectUserService.projectUsers$ | async) === undefined">
+      }
+      @if ((projectUserService.projectUsers$ | async) === undefined) {
         <ngx-skeleton-loader
           appearance="circle"
           [theme]="{
@@ -137,7 +144,7 @@
             border: '1px solid white',
           }"
         ></ngx-skeleton-loader>
-      </div>
-    </div>
+      }
+    }
   </div>
 </div>

--- a/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.ts
+++ b/frontend/src/app/projects/project-detail/project-users/project-user-settings.component.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
@@ -25,14 +25,15 @@ import {
   InputDialogResult,
 } from 'src/app/helpers/input-dialog/input-dialog.component';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
-import { Project, User } from 'src/app/openapi';
-import { AddUserToProjectDialogComponent } from 'src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.component';
-import { ProjectAuditLogComponent } from 'src/app/projects/project-detail/project-users/project-audit-log/project-audit-log.component';
 import {
+  Project,
   ProjectUser,
   ProjectUserPermission,
-  ProjectUserService,
-} from 'src/app/projects/project-detail/project-users/service/project-user.service';
+  User,
+} from 'src/app/openapi';
+import { AddUserToProjectDialogComponent } from 'src/app/projects/project-detail/project-users/add-user-to-project/add-user-to-project.component';
+import { ProjectAuditLogComponent } from 'src/app/projects/project-detail/project-users/project-audit-log/project-audit-log.component';
+import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
 import { UserWrapperService } from 'src/app/services/user/user.service';
 import { ProjectWrapperService } from '../../service/project.service';
 
@@ -42,7 +43,6 @@ import { ProjectWrapperService } from '../../service/project.service';
   templateUrl: './project-user-settings.component.html',
   standalone: true,
   imports: [
-    NgIf,
     MatButton,
     MatIcon,
     MatDivider,
@@ -51,7 +51,6 @@ import { ProjectWrapperService } from '../../service/project.service';
     MatInput,
     FormsModule,
     MatSuffix,
-    NgFor,
     RouterLink,
     MatIconButton,
     MatTooltip,
@@ -79,6 +78,14 @@ export class ProjectUserSettingsComponent implements OnInit {
       .subscribe((project) => {
         this.project = project;
       });
+  }
+
+  get permissions() {
+    return ProjectUserService.PERMISSIONS;
+  }
+
+  get advanced_roles() {
+    return ProjectUserService.ADVANCED_ROLES;
   }
 
   removeUserFromProject(user: User): void {
@@ -166,7 +173,7 @@ export class ProjectUserSettingsComponent implements OnInit {
             next: () =>
               this.toastService.showSuccess(
                 `User modified`,
-                `User '${user.name}' is no longer project lead in the project '${projectName}'`,
+                `User '${user.name}' is no longer project administrator in the project '${projectName}'`,
               ),
           });
       }
@@ -217,15 +224,12 @@ export class ProjectUserSettingsComponent implements OnInit {
     if (projectUsers === undefined || projectUsers === null) {
       return undefined;
     }
+
     return projectUsers?.filter(
       (pUser) =>
         pUser.role == role &&
         pUser.user.name.toLowerCase().includes(this.search.toLowerCase()),
     );
-  }
-
-  capitalizeFirstLetter(role: string) {
-    return role.charAt(0).toUpperCase() + role.slice(1);
   }
 
   openAddUserDialog() {
@@ -244,7 +248,11 @@ export class ProjectUserSettingsComponent implements OnInit {
     });
   }
 
-  hasRoute(route: string) {
+  hasRoute(route: string): boolean {
     return this.router.url.includes(route);
+  }
+
+  isInProjectCreation(): boolean {
+    return this.hasRoute('projects/create');
   }
 }

--- a/frontend/src/app/projects/project-detail/project-users/project-user-settings.stories.ts
+++ b/frontend/src/app/projects/project-detail/project-users/project-user-settings.stories.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
+import { MockProjectUserService } from 'src/storybook/project-users';
+import { mockUser } from 'src/storybook/user';
+import { ProjectUserSettingsComponent } from './project-user-settings.component';
+
+const meta: Meta<ProjectUserSettingsComponent> = {
+  title: 'Project Components / Project Users',
+  component: ProjectUserSettingsComponent,
+};
+
+export default meta;
+type Story = StoryObj<ProjectUserSettingsComponent>;
+
+export const Loading: Story = {
+  args: {},
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: ProjectUserService,
+          useFactory: () =>
+            new MockProjectUserService('user', undefined, [
+              {
+                role: 'administrator',
+                permission: 'write',
+                user: { ...mockUser, name: 'administrator1' },
+              },
+              {
+                role: 'administrator',
+                permission: 'write',
+                user: { ...mockUser, name: 'administrator2' },
+              },
+              {
+                role: 'user',
+                permission: 'write',
+                user: { ...mockUser, name: 'projectuser1' },
+              },
+              {
+                role: 'user',
+                permission: 'read',
+                user: { ...mockUser, name: 'projectuser2' },
+              },
+              {
+                role: 'manager',
+                permission: 'write',
+                user: { ...mockUser, name: 'projectadmin1' },
+              },
+            ]),
+        },
+      ],
+    }),
+  ],
+};

--- a/frontend/src/app/projects/project-overview/project-overview.component.html
+++ b/frontend/src/app/projects/project-overview/project-overview.component.html
@@ -64,7 +64,7 @@
                 }}
               </div>
               <div>
-                {{ project.users.leads }} project lead(s),
+                {{ project.users.leads }} project admin(s),
                 {{ project.users.contributors }} contributor(s),
                 {{ project.users.subscribers }}
                 subscriber(s)

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-session/create-readonly-session/create-readonly-session.component.html
@@ -3,8 +3,8 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 <div class="wrapper flex flex-col">
-  <h2 id="title" class="text-xl font-medium">Read-only Sessions</h2>
-  <div id="readonly-card" class="collab-card m-[10px] grow p-[16px]">
+  <h2 id="title" class="mb-2 text-xl font-medium">Read-only Sessions</h2>
+  <div id="readonly-card" class="collab-card grow p-[16px]">
     <div class="flex h-full flex-col justify-between gap-2">
       <p class="text-sm">
         Start a read-only session. Select the tool and the version. We'll show

--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-readonly-session/create-readonly-session-dialog.component.html
@@ -51,8 +51,8 @@
       <hr class="m-2" />
     } @empty {
       <div class="my-1 border p-2 text-sm shadow">
-        No models have read-only session support. Please contact your
-        administrator or project lead.
+        No models have read-only session support. Please contact your global
+        administrator or project administrator.
       </div>
     }
 

--- a/frontend/src/app/settings/core/user-settings/user-settings.component.html
+++ b/frontend/src/app/settings/core/user-settings/user-settings.component.html
@@ -30,7 +30,7 @@
             <div class="ml-2">
               <div mat-line>{{ user.name }}</div>
               <div mat-line class="text-gray-500">
-                {{ projectUserService.ADVANCED_ROLES[user.role] }}
+                {{ advanced_roles[user.role] }}
               </div>
             </div>
           </a>
@@ -60,7 +60,7 @@
             <div class="ml-2">
               <div mat-line>{{ user.name }}</div>
               <div mat-line class="text-gray-500">
-                {{ projectUserService.ADVANCED_ROLES[user.role] }}
+                {{ advanced_roles[user.role] }}
               </div>
             </div>
           </a>

--- a/frontend/src/app/settings/core/user-settings/user-settings.component.ts
+++ b/frontend/src/app/settings/core/user-settings/user-settings.component.ts
@@ -95,6 +95,10 @@ export class UserSettingsComponent implements OnInit {
     return this.createUserFormGroup.controls.idpIdentifier;
   }
 
+  get advanced_roles() {
+    return ProjectUserService.ADVANCED_ROLES;
+  }
+
   userNameAlreadyExistsValidator(): ValidatorFn {
     return (control: AbstractControl): ValidationErrors | null => {
       if (this.users.find((user) => user.name == control.value)) {

--- a/frontend/src/storybook/decorators.ts
+++ b/frontend/src/storybook/decorators.ts
@@ -5,5 +5,6 @@
 import { componentWrapperDecorator } from '@storybook/angular';
 
 export const dialogWrapper = componentWrapperDecorator(
-  (story) => `<div class="rounded-md border shadow">${story}</div>`,
+  (story) =>
+    `<div class="rounded-md border shadow bg-white w-fit">${story}</div>`,
 );

--- a/frontend/src/storybook/project-users.ts
+++ b/frontend/src/storybook/project-users.ts
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { BehaviorSubject } from 'rxjs';
+import {
+  ProjectUser,
+  ProjectUserPermission,
+  ProjectUserRole,
+} from 'src/app/openapi';
+import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
+
+export class MockProjectUserService implements Partial<ProjectUserService> {
+  role: ProjectUserRole;
+  permission: ProjectUserPermission | undefined;
+
+  private _projectUsers = new BehaviorSubject<ProjectUser[] | undefined>(
+    undefined,
+  );
+  public readonly projectUsers$ = this._projectUsers.asObservable();
+
+  constructor(
+    role: ProjectUserRole,
+    permission: ProjectUserPermission | undefined = undefined,
+    projectUsers: ProjectUser[] | undefined = undefined,
+  ) {
+    this.role = role;
+    this.permission = permission;
+    this._projectUsers.next(projectUsers);
+  }
+
+  verifyRole(requiredRole: ProjectUserRole): boolean {
+    const roles = ['user', 'manager', 'administrator'];
+    return roles.indexOf(requiredRole) <= roles.indexOf(this.role);
+  }
+
+  verifyPermission(requiredPermission: string): boolean {
+    if (this.permission === undefined) return false;
+    const permissions = ['read', 'write'];
+    return (
+      permissions.indexOf(requiredPermission) <=
+      permissions.indexOf(this.permission)
+    );
+  }
+}


### PR DESCRIPTION
Use the following names consistently across frontend and documentation:
- Project Administrator
- Project User
- Global Administrator

In addition, a few stories were added and parts of the frontend were rebased to comply with our code style.