### PR TITLE
ci: Temporarily set fastapi to `<0.112.4` due to incompatility

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "alembic==1.13.2",
   "appdirs",
   "cachetools",
-  "fastapi>=0.101.0",
+  "fastapi>=0.101.0,<0.112.4",
   "kubernetes",
   "psycopg2-binary>2.9.7",
   "pydantic>=2.0.0",


### PR DESCRIPTION
The fastapi-pagination package is not compatible with the latest version of fastapi:
https://github.com/uriyyo/fastapi-pagination/issues/1273