### PR TITLE
fix: Destroy session history subscription

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/create-sessions/create-session-history/create-session-history.component.ts
@@ -72,7 +72,7 @@ export class CreateSessionHistoryComponent implements OnInit, OnDestroy {
   loadLastSessions() {
     this.toolService._tools.pipe(filter(Boolean), take(1)).subscribe(() => {
       this.sessionHistoryService.sessionHistory
-        .pipe(filter(Boolean))
+        .pipe(filter(Boolean), take(1))
         .subscribe((sessions) => {
           this.resolvedHistory = [];
           this.sessionsToBeLoaded = sessions.length;


### PR DESCRIPTION
This ensures that the session history subscription is destroyed immediately after the first value is emitted. This ensures that the subscription is not executed multiple times when you leave and return to the session page.