### PR TITLE
fix: Use T4C repository in multiple projects / models

### DIFF
--- a/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/repositories/crud.py
@@ -105,6 +105,7 @@ def _get_user_write_t4c_repositories(
             == projects_users_models.ProjectUserPermission.WRITE
         )
         .where(projects_users_models.ProjectUserAssociation.user == user)
+        .distinct()
     )
 
     return db.execute(stmt).scalars().all()
@@ -123,6 +124,7 @@ def _get_admin_t4c_repositories(
         )
         .join(toolmodels_models.DatabaseToolModel.project)
         .where(projects_models.DatabaseProject.is_archived.is_(False))
+        .distinct()
     )
 
     return db.execute(stmt).scalars().all()


### PR DESCRIPTION
When a single T4C repository was used in multiple different toolmodels, the repository was injected twice into the session in the T4C session hook.

This led to errors in the dropdown menu of the T4C connection in Capella sessions.