### PR TITLE
build: Expose development environment on localhost only

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,6 +7,8 @@ DB_USER = dev
 DB_NAME = dev
 VENV = .venv
 
+HOST ?= 127.0.0.1
+
 DATABASE_LOAD_FILE ?= ../local/load.sql
 DATABASE_SAVE_DIR ?= ../local
 
@@ -36,7 +38,7 @@ app:
 		source $(VENV)/Scripts/activate;
 	fi
 	export OAUTHLIB_INSECURE_TRANSPORT=1;
-	uvicorn --host 0.0.0.0 --reload --reload-dir $$(pwd) --reload-include "*.py" --reload-include "*.yaml" --reload-include "*.yml" capellacollab.__main__:app
+	uvicorn --host $(HOST) --reload --reload-dir $$(pwd) --reload-include "*.py" --reload-include "*.yaml" --reload-include "*.yml" capellacollab.__main__:app
 
 coverage:
 	pytest \

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -3,10 +3,12 @@
 
 export NG_FORCE_TTY=false
 
+HOST ?= 127.0.0.1
+
 .ONESHELL:
 
 dev:
-	ng serve --host 0.0.0.0 --open
+	ng serve --host $(HOST) --open
 
 test:
 	if [ $(shell which chromium) ]; \


### PR DESCRIPTION
The host can be still set via the `HOST` environment variable. If you want to expose it to all hosts, set `HOST` to `0.0.0.0`