### PR TITLE
build(dev): Run frontend on `localhost` instead of `127.0.0.1`

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -43,7 +43,7 @@ logging.basicConfig(
 
 ALLOW_ORIGINS = (
     [f"{config.general.scheme}//{config.general.host}:{config.general.port}"]
-    + ["http://localhost:4200"]
+    + ["http://localhost:4200", "http://127.0.0.1:4200"]
     if core.DEVELOPMENT_MODE
     else []
 )

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -3,7 +3,7 @@
 
 export NG_FORCE_TTY=false
 
-HOST ?= 127.0.0.1
+HOST ?= localhost
 
 .ONESHELL:
 


### PR DESCRIPTION
The redirectURI and CORS policy would have to be modified otherwise.