### PR TITLE
fix: Disable "Connect to session" button when missing session info

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.component.html
@@ -37,8 +37,15 @@
   <div class="mb-1 text-base font-bold">Connect to the session</div>
   Please click on this button to connect to the server: <br />
   <div class="mt-2">
-    <button mat-flat-button color="primary" (click)="redirectToSession()">
-      Connect to Session
+    <button
+      mat-flat-button
+      color="primary"
+      (click)="redirectToSession()"
+      [disabled]="!connectionInfo"
+    >
+      {{
+        connectionInfo ? "Connect to Session" : "Loading Session Information..."
+      }}
     </button>
   </div>
 </div>

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.component.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.component.ts
@@ -46,13 +46,7 @@ export class ConnectionDialogComponent {
   }
 
   redirectToSession(): void {
-    if (!this.connectionInfo) {
-      this.toastService.showError(
-        'Session connection information is not available yet.',
-        'Try again later.',
-      );
-      return;
-    }
+    if (!this.connectionInfo) return;
     this.sessionService.setConnectionInformation(this.connectionInfo);
     if (this.connectionInfo.redirect_url) {
       window.open(this.connectionInfo.redirect_url);

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/connection-dialog/connection-dialog.stories.ts
@@ -31,7 +31,13 @@ export default meta;
 type Story = StoryObj<ConnectionDialogComponent>;
 
 export const WithoutTeamForCapella: Story = {
-  args: {},
+  args: {
+    connectionInfo: {
+      local_storage: {},
+      t4c_token: '',
+      redirect_url: 'https://example.com',
+    },
+  },
   decorators: [
     moduleMetadata({
       providers: [
@@ -47,6 +53,7 @@ export const WithoutTeamForCapella: Story = {
         },
       ],
     }),
+    dialogWrapper,
   ],
 };
 
@@ -95,4 +102,8 @@ export const WithoutSessionToken: Story = {
       redirect_url: 'https://example.com',
     },
   },
+};
+
+export const LoadingSessionInfo: Story = {
+  args: {},
 };


### PR DESCRIPTION
Disables the "Connect to session" button inside the connection dialog if the session's connection info is not available. The logic to show a toast when there is no session information is removed, as there is no situation where it could be triggered.

Closes #1785