### PR TITLE
build: Fail `helm upgrade` if secrets are not set in `values.yaml`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -112,6 +112,9 @@ jobs:
           --set mocks.oauth=True \
           --set development=True \
           --set general.port=8080 \
+          --set database.backend.internal.password="secret" \
+          --set database.guacamole.internal.password="secret" \
+          --set valkey.password="secret" \
           --set backend.authentication.oauth.endpoints.wellKnown="http://test-oauth-mock:8080/default/.well-known/openid-configuration" \
           ./helm
       - name: Wait for all containers to be ready

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ helm-deploy:
 		--set cluster.ingressClassName=traefik \
 		--set cluster.ingressNamespace=kube-system \
 		--set backend.k8sSessionNamespace="$(SESSION_NAMESPACE)" \
+		--set loki.gateway.basicAuth.password="localLokiPassword" \
+		--set grafana.adminPassword="admin" \
+		--set database.backend.internal.password="secret" \
+		--set database.guacamole.internal.password="secret" \
+		--set valkey.password="secret" \
 		$(RELEASE) $$HELM_PACKAGE_DIR/collab-manager-*.tgz
 	rm -rf "$$HELM_PACKAGE_DIR"
 	$(MAKE) provision-guacamole wait

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ https://github.com/DSD-DBS/capella-collab-manager/assets/23395732/01c5dc34-7792-
 
 ### Running Locally with k3d
 
+The following instructions are not suitable for a production deployment, but
+can be used to try out the features of the Collaboration Manager locally. You
+can find the installation guide for a production deployment in the
+[general documentation](https://dsd-dbs.github.io/capella-collab-manager/admin/installation/).
+
 #### Prerequisites
 
 To deploy the application you need:
@@ -181,11 +186,6 @@ Once the cluster is installed and all services are running
 (`kubectl get pods`), you can get started. Follow our
 [Getting started guide](https://dsd-dbs.github.io/capella-collab-manager/admin/getting_started/getting_started/)
 and be up and running in a few minutes.
-
-### Deployment
-
-You can find the installation guide for a production deployment in the
-[general documentation](https://dsd-dbs.github.io/capella-collab-manager/admin/installation/).
 
 ## How it Works
 

--- a/backend/capellacollab/config/models.py
+++ b/backend/capellacollab/config/models.py
@@ -108,27 +108,40 @@ class K8sPromtailConfig(BaseConfig):
         description="Whether to enable Loki monitoring.",
         examples=[True],
     )
-    loki_url: str = pydantic.Field(
+    loki_url: str | None = pydantic.Field(
         default="http://localhost:30001/loki/api/v1/push",
         alias="lokiURL",
         description="The URL of the Loki instance to which to push logs.",
         examples=["http://localhost:30001/loki/api/v1/push"],
     )
-    loki_username: str = pydantic.Field(
+    loki_username: str | None = pydantic.Field(
         default="localLokiUser",
         description="The username for the Loki instance.",
         examples=["localLokiUser"],
     )
-    loki_password: str = pydantic.Field(
+    loki_password: str | None = pydantic.Field(
         default="localLokiPassword",
         description="The password for the Loki instance.",
         examples=["localLokiPassword"],
     )
-    server_port: int = pydantic.Field(
+    server_port: int | None = pydantic.Field(
         default=3101,
         description="The port of the promtail server.",
         examples=[3101],
     )
+
+    @pydantic.model_validator(mode="after")
+    def check_fields_are_set_if_enabled(self) -> t.Self:
+        if self.loki_enabled and not (
+            self.loki_url
+            and self.loki_username
+            and self.loki_password
+            and self.server_port
+        ):
+            raise ValueError(
+                "Loki monitoring is enabled, but not all required fields are set."
+            )
+        return self
 
 
 class K8sConfig(BaseConfig):

--- a/backend/capellacollab/core/logging/loki.py
+++ b/backend/capellacollab/core/logging/loki.py
@@ -34,7 +34,11 @@ def check_loki_enabled():
         raise exceptions.GrafanaLokiDisabled()
 
 
-def push_logs_to_loki(entries: list[LogEntry], labels):
+def push_logs_to_loki(entries: list[LogEntry], labels) -> None:
+    if PROMTAIL_CONFIGURATION.loki_enabled is False:
+        return None
+    assert PROMTAIL_CONFIGURATION.loki_url
+
     # Convert the streams and labels into the Loki log format
     log_data = json.dumps(
         {
@@ -70,12 +74,18 @@ def push_logs_to_loki(entries: list[LogEntry], labels):
         logging.exception("Error pushing logs to Grafana Loki", exc_info=True)
         logging.info("Response from Loki API: %s", e.response.content.decode())
 
+    return None
+
 
 def fetch_logs_from_loki(
     query,
     start_time: datetime.datetime,
     end_time: datetime.datetime,
 ):
+    if PROMTAIL_CONFIGURATION.loki_enabled is False:
+        return None
+    assert PROMTAIL_CONFIGURATION.loki_url
+
     # Prepare the query parameters
     params = {
         "query": query,

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -828,7 +828,13 @@ class KubernetesOperator:
         session_type: str,
         tool_name: str,
         version_name: str,
-    ) -> client.V1ConfigMap:
+    ) -> client.V1ConfigMap | None:
+        """Create the configuration for promtail.
+
+        Do not call if loki is disabled!
+        """
+
+        assert cfg.promtail.loki_url
         config_map: client.V1ConfigMap = client.V1ConfigMap(
             kind="ConfigMap",
             api_version="v1",

--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -24,8 +24,8 @@ k8s:
   promtail:
     lokiEnabled: {{ .Values.loki.enabled }}
     lokiURL: http://loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local/loki/api/v1
-    lokiUsername: {{ .Values.definitions.loki.username }}
-    lokiPassword: {{ .Values.definitions.loki.password }}
+    lokiUsername: {{ .Values.loki.gateway.basicAuth.username }}
+    lokiPassword: {{ .Values.loki.gateway.basicAuth.password }}
     serverPort: 3101
 
 general:

--- a/helm/templates/backend/postgres.deployment.yaml
+++ b/helm/templates/backend/postgres.deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - name: POSTGRES_DB
               value: backend
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.database.backend.internal.password }}
+              value: {{ .Values.database.backend.internal.password | required ".Values.database.backend.internal.password is required. Please generate a random password and set it in the values.yaml." }}
             - name: POSTGRES_USER
               value: backend
           ports:

--- a/helm/templates/grafana/grafana.configmap.yaml
+++ b/helm/templates/grafana/grafana.configmap.yaml
@@ -13,8 +13,7 @@ data:
   grafana.ini: |
     [security]
     admin_user = {{ .Values.grafana.adminUser }}
-    admin_password = {{ .Values.grafana.adminPassword }}
-
+    admin_password = {{ .Values.grafana.adminPassword | required ".Values.grafana.adminPassword is required. Please generate a random password and set it in the values.yaml." }}
     [paths]
     data = /var/lib/grafana/
     logs = /var/log/grafana
@@ -64,9 +63,9 @@ data:
         orgId: 1
         url: http://loki-gateway.{{ .Release.Namespace }}.svc.cluster.local
         basicAuth: true
-        basicAuthUser: {{ .Values.definitions.loki.username }}
+        basicAuthUser: {{ .Values.loki.gateway.basicAuth.username }}
         secureJsonData:
-          basicAuthPassword: {{ .Values.definitions.loki.password }}
+          basicAuthPassword: {{ .Values.loki.gateway.basicAuth.password | required ".Values.loki.gateway.basicAuth.password is required. Please generate a random password and set it in the values.yaml." }}
         version: 1
         editable: false
       {{ end }}

--- a/helm/templates/guacamole/postgres.deployment.yaml
+++ b/helm/templates/guacamole/postgres.deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: POSTGRES_DB
               value: guacamole
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.database.guacamole.internal.password }}
+              value: {{ .Values.database.guacamole.internal.password | required ".Values.database.guacamole.internal.password is required. Please generate a random password and set it in the values.yaml." }}
             - name: POSTGRES_USER
               value: guacamole
             - name: POSTGRES_HOST_AUTH_METHOD

--- a/helm/templates/promtail/_promtail.tpl
+++ b/helm/templates/promtail/_promtail.tpl
@@ -5,8 +5,8 @@
 clients:
   - url: http://loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local/loki/api/v1/push
     basic_auth:
-      username: {{ .Values.definitions.loki.username }}
-      password: {{ .Values.definitions.loki.password }}
+      username: {{ .Values.loki.gateway.basicAuth.username }}
+      password: {{ .Values.loki.gateway.basicAuth.password }}
 server:
   http_listen_port: 3101
 {{- end }}

--- a/helm/templates/valkey/valkey.secret.yaml
+++ b/helm/templates/valkey/valkey.secret.yaml
@@ -10,4 +10,4 @@ metadata:
 type: Opaque
 stringData:
   valkey.conf: |
-    requirepass {{ .Values.valkey.password }}
+    requirepass {{ .Values.valkey.password | required ".Values.valkey.password is required. Please generate a random password and set it in the values.yaml." }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -100,7 +100,7 @@ database:
       ###### IF database.guacamole.deploy == True ######
 
       # Admin password of the database
-      password: secret
+      password: null
 
     external:
       ###### IF database.guacamole.deploy == False ######
@@ -135,7 +135,7 @@ database:
       ###### IF database.backend.deploy == True ######
 
       # Admin password of the database
-      password: secret
+      password: null
 
     external:
       ###### IF database.backend.deploy == False ######
@@ -144,7 +144,7 @@ database:
       uri: postgresql://user:password@url:port/db_name
 
 valkey:
-  password: secret
+  password: null
 
 backend:
   authentication:
@@ -258,16 +258,10 @@ promtail:
   storageAccessMode: ReadWriteOnce
   storageClassName: local-path
 
-definitions:
-  loki:
-    # Default username & password for Loki
-    username: &lokiUsername localLokiUser
-    password: &lokiPassword localLokiPassword
-
 # Default passwords for Grafana
 grafana:
   adminUser: admin
-  adminPassword: admin
+  adminPassword: null
 
 # https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
 loki:
@@ -284,8 +278,8 @@ loki:
   gateway:
     basicAuth:
       enabled: True
-      username: *lokiUsername
-      password: *lokiPassword
+      username: localLokiUser
+      password: null
     resources: &resourcesLoki
       limits:
         cpu: '1'


### PR DESCRIPTION
To avoid unintential default secrets in production, passwords default to null now. `helm upgrade` will fail if the secrets are not set.