### PR TITLE
fix: Disable Feedback Prompt when logged out, Change order of buttons

### DIFF
--- a/backend/capellacollab/feedback/models.py
+++ b/backend/capellacollab/feedback/models.py
@@ -13,9 +13,9 @@ from capellacollab.tools import models as tools_models
 
 
 class FeedbackRating(str, enum.Enum):
-    GOOD = "good"
-    OKAY = "okay"
     BAD = "bad"
+    OKAY = "okay"
+    GOOD = "good"
 
 
 class AnonymizedSession(core_pydantic.BaseModel):

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -18,6 +18,7 @@ import { HeaderComponent } from './general/header/header.component';
 import { NavBarMenuComponent } from './general/nav-bar-menu/nav-bar-menu.component';
 import { NoticeComponent } from './general/notice/notice.component';
 import { PageLayoutService } from './page-layout/page-layout.service';
+import { AuthenticationWrapperService } from './services/auth/auth.service';
 import { FeedbackWrapperService } from './sessions/feedback/feedback.service';
 import { FullscreenService } from './sessions/service/fullscreen.service';
 
@@ -46,6 +47,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     public fullscreenService: FullscreenService,
     private navBarService: NavBarService,
     private feedbackService: FeedbackWrapperService,
+    private authService: AuthenticationWrapperService,
   ) {
     slugify.extend({ '.': '-' });
   }
@@ -54,7 +56,10 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   async ngOnInit() {
     this.feedbackService.loadFeedbackConfig().subscribe(() => {
-      if (this.feedbackService.shouldShowIntervalPrompt()) {
+      if (
+        this.feedbackService.shouldShowIntervalPrompt() &&
+        this.authService.isLoggedIn()
+      ) {
         this.feedbackService.showDialog([], 'On interval');
         this.feedbackService.saveFeedbackPromptDate();
       }

--- a/frontend/src/app/openapi/model/feedback-rating.ts
+++ b/frontend/src/app/openapi/model/feedback-rating.ts
@@ -11,11 +11,11 @@
 
 
 
-export type FeedbackRating = 'good' | 'okay' | 'bad';
+export type FeedbackRating = 'bad' | 'okay' | 'good';
 
 export const FeedbackRating = {
-    Good: 'good' as FeedbackRating,
+    Bad: 'bad' as FeedbackRating,
     Okay: 'okay' as FeedbackRating,
-    Bad: 'bad' as FeedbackRating
+    Good: 'good' as FeedbackRating
 };
 


### PR DESCRIPTION
Fix a bug where the interval feedback prompt would be shown, even when the user is not logged in. Restore the original order of the feedback buttons by changing the server-side enum.