### PR TITLE
feat: Trigger feedback dialog after login

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { NgIf, NgClass, AsyncPipe } from '@angular/common';
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
 import {
   MatSidenav,
   MatDrawerContainer,
@@ -18,7 +18,6 @@ import { HeaderComponent } from './general/header/header.component';
 import { NavBarMenuComponent } from './general/nav-bar-menu/nav-bar-menu.component';
 import { NoticeComponent } from './general/notice/notice.component';
 import { PageLayoutService } from './page-layout/page-layout.service';
-import { AuthenticationWrapperService } from './services/auth/auth.service';
 import { FeedbackWrapperService } from './sessions/feedback/feedback.service';
 import { FullscreenService } from './sessions/service/fullscreen.service';
 
@@ -41,30 +40,17 @@ import { FullscreenService } from './sessions/service/fullscreen.service';
     AsyncPipe,
   ],
 })
-export class AppComponent implements OnInit, AfterViewInit {
+export class AppComponent implements AfterViewInit {
   constructor(
     public pageLayoutService: PageLayoutService,
     public fullscreenService: FullscreenService,
     private navBarService: NavBarService,
     private feedbackService: FeedbackWrapperService,
-    private authService: AuthenticationWrapperService,
   ) {
     slugify.extend({ '.': '-' });
   }
 
   @ViewChild('sidenav') private sidenav?: MatSidenav;
-
-  async ngOnInit() {
-    this.feedbackService.loadFeedbackConfig().subscribe(() => {
-      if (
-        this.feedbackService.shouldShowIntervalPrompt() &&
-        this.authService.isLoggedIn()
-      ) {
-        this.feedbackService.showDialog([], 'On interval');
-        this.feedbackService.saveFeedbackPromptDate();
-      }
-    });
-  }
 
   ngAfterViewInit(): void {
     this.navBarService.sidenav = this.sidenav;

--- a/frontend/src/app/general/auth/auth-redirect/auth-redirect.component.ts
+++ b/frontend/src/app/general/auth/auth-redirect/auth-redirect.component.ts
@@ -8,6 +8,7 @@ import { ToastService } from 'src/app/helpers/toast/toast.service';
 import { AuthenticationService } from 'src/app/openapi';
 import { AuthenticationWrapperService } from 'src/app/services/auth/auth.service';
 import { OwnUserWrapperService } from 'src/app/services/user/user.service';
+import { FeedbackWrapperService } from 'src/app/sessions/feedback/feedback.service';
 
 @Component({
   selector: 'app-auth-redirect',
@@ -22,6 +23,7 @@ export class AuthRedirectComponent implements OnInit {
     private authenticationService: AuthenticationService,
     private userService: OwnUserWrapperService,
     private router: Router,
+    private feedbackService: FeedbackWrapperService,
   ) {}
 
   ngOnInit(): void {
@@ -78,6 +80,7 @@ export class AuthRedirectComponent implements OnInit {
             next: () => {
               localStorage.setItem(this.authService.LOGGED_IN_KEY, 'true');
               this.userService.updateOwnUser();
+              this.feedbackService.triggerFeedbackPrompt();
               this.router.navigateByUrl(redirectTo);
             },
             error: () => this.redirectToLogin(),

--- a/frontend/src/app/sessions/feedback/feedback.service.ts
+++ b/frontend/src/app/sessions/feedback/feedback.service.ts
@@ -5,6 +5,7 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { AuthenticationWrapperService } from 'src/app/services/auth/auth.service';
 import {
   FeedbackConfigurationOutput,
   FeedbackService as OpenAPIFeedbackService,
@@ -19,8 +20,9 @@ export class FeedbackWrapperService {
   constructor(
     private feedbackService: OpenAPIFeedbackService,
     public dialog: MatDialog,
+    private authService: AuthenticationWrapperService,
   ) {
-    this.loadFeedbackConfig().subscribe();
+    this.loadFeedbackConfig().subscribe(() => this.triggerFeedbackPrompt());
   }
 
   private _feedbackConfig = new BehaviorSubject<
@@ -33,6 +35,13 @@ export class FeedbackWrapperService {
     return this.feedbackService
       .getFeedbackConfiguration()
       .pipe(tap((feedbackConf) => this._feedbackConfig.next(feedbackConf)));
+  }
+
+  triggerFeedbackPrompt(): void {
+    if (this.shouldShowIntervalPrompt() && this.authService.isLoggedIn()) {
+      this.showDialog([], 'On interval');
+      this.saveFeedbackPromptDate();
+    }
   }
 
   public showDialog(sessions: Session[], trigger: string) {


### PR DESCRIPTION
As a result of https://github.com/DSD-DBS/capella-collab-manager/pull/1828, the feedback interval doesn't trigger the dialog anymore after login, only after refresh if logged in. This can be an issue for users which don't use the CCM often since they have to login each time. This PR makes sure that the dialog is also triggered after login.

Also fixes another bug that the request to the backend was triggered twice.