### PR TITLE
test: Add delay to let mat-error animation complete

### DIFF
--- a/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.stories.ts
+++ b/frontend/src/app/projects/models/model-source/git/manage-git-model/manage-git-model.stories.ts
@@ -44,7 +44,11 @@ export default meta;
 type Story = StoryObj<ManageGitModelComponent>;
 
 export const InvalidURL: Story = {
-  args: {},
+  parameters: {
+    screenshot: {
+      delay: 300,
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const absoluteURL = canvas.getByTestId('absolute-url');

--- a/frontend/src/app/settings/modelsources/git-settings/add-git-instance/add-git-instance.component.html
+++ b/frontend/src/app/settings/modelsources/git-settings/add-git-instance/add-git-instance.component.html
@@ -39,7 +39,12 @@
     @if (gitInstancesForm.controls.type.value !== "General") {
       <mat-form-field class="form-field-default" appearance="fill">
         <mat-label>API Base URL</mat-label>
-        <input matInput formControlName="api_url" data-testid="api_url" />
+        <input
+          matInput
+          spellcheck="false"
+          formControlName="api_url"
+          data-testid="api_url"
+        />
         @if (gitInstancesForm.controls.url.errors?.urlSchemeError) {
           <mat-error> API URLs have to start with 'http(s)://' </mat-error>
         }


### PR DESCRIPTION
The mat-error animation didn't complete for an invalid input of the ManageGitModelComponent.