### PR TITLE
build: Fix a bug that Storybook couldn't recognize npm

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -20,10 +20,10 @@ test:
 	fi
 
 storybook:
-	ng run capellacollab:storybook
+	npm run storybook
 
 build-storybook:
-	ng run capellacollab:build-storybook
+	npm run build-storybook
 
 snapshots:
 	rm -rf __screenshots__


### PR DESCRIPTION
When I don't invoke the Storybook command via npm, it fails with: 

```
An unhandled exception occurred: Unable to find a usable package manager within NPM, PNPM, Yarn and Yarn 2
```