### PR TITLE
feat(grafana): Show all active sessions by default, disable filters

### DIFF
--- a/helm/config/grafana/dashboards/active-sessions.json
+++ b/helm/config/grafana/dashboards/active-sessions.json
@@ -38,6 +38,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -52,6 +53,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "stepBefore",
             "lineWidth": 1,
             "pointSize": 5,
@@ -178,6 +180,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": true,
@@ -193,6 +196,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "stepBefore",
             "lineStyle": {
               "fill": "solid"
@@ -331,14 +335,17 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.0.1",
+      "pluginVersion": "11.1.0",
       "targets": [
         {
           "datasource": {
@@ -367,6 +374,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -381,6 +389,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -456,14 +465,15 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",
@@ -471,7 +481,7 @@
         },
         "definition": "up{job=\"sessions\"}",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "Tool and Version",
         "multi": true,
         "name": "tool_version_id",
@@ -488,7 +498,9 @@
       },
       {
         "current": {
-          "selected": true
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",
@@ -497,7 +509,7 @@
         "definition": "up{job=\"sessions\", tool_version_id=~\"$tool_version_id\"}",
         "description": "",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "Connection Method",
         "multi": true,
         "name": "connection_method_id",
@@ -514,7 +526,9 @@
       },
       {
         "current": {
-          "selected": true
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",
@@ -522,7 +536,7 @@
         },
         "definition": "label_values(up{job=\"sessions\", tool_version_id=~\"$tool_version_id\"},session_type)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "Session Type",
         "multi": true,
         "name": "session_type",
@@ -547,6 +561,6 @@
   "timezone": "",
   "title": "Active sessions",
   "uid": "0kK_I7T4k",
-  "version": 4,
+  "version": 11,
   "weekStart": ""
 }


### PR DESCRIPTION
By default, it did only choose one tool version, one connection method and one session type. Instead, add an "All" option and set it as default to display the page without filters when loading initially. 