### PR TITLE
feat: Make nginx error pages more user-friendly

### DIFF
--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -406,13 +406,13 @@ def get_session_connection_information(
 )
 def validate_session_token(
     session_id: str,
-    ccm_session_token: t.Annotated[str, fastapi.Cookie()],
+    ccm_session_token: t.Annotated[str | None, fastapi.Cookie()] = None,
     db: orm.Session = fastapi.Depends(database.get_db),
 ):
     """Validate that the passed session token is valid for the given session."""
     session = crud.get_session_by_id(db, session_id)
 
-    if session is None:
+    if not session or not ccm_session_token:
         return fastapi.Response(status_code=status.HTTP_401_UNAUTHORIZED)
 
     if hmac.compare_digest(

--- a/backend/tests/sessions/test_session_routes.py
+++ b/backend/tests/sessions/test_session_routes.py
@@ -193,6 +193,17 @@ def test_validate_session_token_with_invalid_session(
     assert response.status_code == 401
 
 
+def test_validate_session_token_without_token_cookie(
+    client: testclient.TestClient,
+    session: sessions_models.DatabaseSession,
+):
+    """Test that an request without cookie is declined during validation"""
+
+    response = client.post(f"/api/v1/sessions/{session.id}/tokens/validate")
+
+    assert response.status_code == 401
+
+
 def test_validate_session_token_with_invalid_token(
     client: testclient.TestClient,
     session: sessions_models.DatabaseSession,

--- a/frontend/src/app/openapi/api/sessions.service.ts
+++ b/frontend/src/app/openapi/api/sessions.service.ts
@@ -839,15 +839,12 @@ export class SessionsService {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public validateSessionToken(sessionId: string, ccmSessionToken: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any>;
-    public validateSessionToken(sessionId: string, ccmSessionToken: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<any>>;
-    public validateSessionToken(sessionId: string, ccmSessionToken: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<any>>;
-    public validateSessionToken(sessionId: string, ccmSessionToken: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public validateSessionToken(sessionId: string, ccmSessionToken?: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any>;
+    public validateSessionToken(sessionId: string, ccmSessionToken?: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<any>>;
+    public validateSessionToken(sessionId: string, ccmSessionToken?: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<any>>;
+    public validateSessionToken(sessionId: string, ccmSessionToken?: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
         if (sessionId === null || sessionId === undefined) {
             throw new Error('Required parameter sessionId was null or undefined when calling validateSessionToken.');
-        }
-        if (ccmSessionToken === null || ccmSessionToken === undefined) {
-            throw new Error('Required parameter ccmSessionToken was null or undefined when calling validateSessionToken.');
         }
 
         let localVarHeaders = this.defaultHeaders;

--- a/helm/templates/sessions/sessions.configmap.yaml
+++ b/helm/templates/sessions/sessions.configmap.yaml
@@ -27,6 +27,7 @@ data:
 
             root /usr/share/nginx/html;
             error_page 502 /502.html;
+            error_page 504 /502.html;
             error_page 401 /401.html;
 
             resolver {{ .Values.cluster.dns.service }}.{{ .Values.cluster.dns.namespace }}.svc.cluster.local;
@@ -56,7 +57,7 @@ data:
                 proxy_pass_request_body off;
                 proxy_pass_request_headers off;
                 proxy_set_header Cookie $http_cookie;
-                proxy_pass http://{{ .Release.Name }}-backend.{{ .Release.Namespace }}.svc.cluster.local:80/api/v1/sessions/$ccm_session_id/tokens/validate?token=$cookie_session_token;
+                proxy_pass http://{{ .Release.Name }}-backend.{{ .Release.Namespace }}.svc.cluster.local:80/api/v1/sessions/$ccm_session_id/tokens/validate;
             }
         }
     }
@@ -66,20 +67,73 @@ data:
       <head>
         <style>
           body {
-            font-family: Arial, sans-serif;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+              Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',
+              sans-serif;
+            display: grid;
+            place-items: center;
+            background-color: #000;
+            color: white;
+            margin: 0;
+            height: 100vh;
+          }
+
+          .container {
+            text-align: center;
+            max-width: 400px;
+            background-color: #1e1e1e;
+            padding: 20px;
+            border-radius: 4px;
+            width: 100%;
+            box-sizing: border-box;
+          }
+
+          div {
+            margin: 10px 0;
           }
         </style>
-      </head>
-      <body>
-        <h2>Session is not reachable - 502 Bad Gateway</h2>
+        <script>
+          let counter = 5
 
-        <div>Please wait a few seconds and try to reconnect.</div>
-        <div>
-          If it doesn't work, check the status of the session in the Capella
-          Collaboration Manager.
-        </div>
-        <div>
-          If this error is persistent, please contact your system administrator.
+          function startCountdown() {
+            const countdownElement = document.getElementById('countdown')
+
+            function updateCountdown() {
+              countdownElement.textContent = counter
+              if (counter > 0) {
+                counter--
+              } else {
+                location.reload()
+              }
+            }
+
+            updateCountdown()
+            setInterval(updateCountdown, 1000)
+          }
+        </script>
+      </head>
+      <body onload="startCountdown()">
+        <div class="container">
+          <h2 style="color: #63ca63; margin-top: 2px">
+            Session is starting up...
+          </h2>
+          <div style="text-align: center">
+            <div>
+              It might take some time until the session is started up. <br />
+              The page will try to connect to the session automatically.
+            </div>
+            <div>
+              If it doesn't work, check the status of the session in the Capella
+              Collaboration Manager.
+            </div>
+            <div>
+              If this page does not disappear after a few minutes and you expect
+              your session to run, please contact your system administrator.
+            </div>
+            <div style="font-style: italic">
+              Refreshing in <span id="countdown">5</span> seconds...
+            </div>
+          </div>
         </div>
       </body>
     </html>
@@ -89,21 +143,53 @@ data:
       <head>
         <style>
           body {
-            font-family: Arial, sans-serif;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+              Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',
+              sans-serif;
+            display: grid;
+            place-items: center;
+            background-color: #000;
+            color: white;
+            margin: 0;
+            height: 100vh;
+          }
+
+          .container {
+            text-align: center;
+            max-width: 400px;
+            background-color: #1e1e1e;
+            padding: 20px;
+            border-radius: 4px;
+            width: 100%;
+            box-sizing: border-box;
+          }
+
+          div {
+            margin: 10px 0;
           }
         </style>
       </head>
-      <body>
-        <h2>Not authenticated against session - 401 Authorization Required</h2>
+      <body onload="startCountdown()">
+        <div class="container">
+          <h2 style="margin-top: 2px">Not authenticated <br />against session</h2>
+          <div style="text-align: center">
+            <div>
+              The message can occur for various reasons:
 
-        <div>
-          The error can occur for various reasons:
-          <ul>
-            <li>The session has been terminated in the Capella Collaboration Manager.</li>
-            <li>You've tried to connect to a session directly. You have to connect via the Capella Collaboration Manager.</li>
-        </div>
-        <div>
-          If you think this error shouldn't appear, please contact your system administrator.
+              <div>The session has been terminated</div>
+
+              OR
+
+              <div>
+                You've tried to connect to a session directly. You have to connect
+                via the Capella Collaboration Manager
+              </div>
+            </div>
+            <div>
+              If you think this message shouldn't appear, please contact your
+              system administrator.
+            </div>
+          </div>
         </div>
       </body>
     </html>


### PR DESCRIPTION
The new 401 error page: 

![image](https://github.com/user-attachments/assets/4476dfbb-748c-4343-b636-b5a2579fe67b)

The new 502 error page: 

![image](https://github.com/user-attachments/assets/1b4cd6ba-4892-4d75-a53e-d2b3d8db33ee)

This also fixes a bug that an "500 - Internal server error" page was displayed when the user tried to access a session without session token.