### PR TITLE
feat: Let session proxy handle timeouts

### DIFF
--- a/helm/templates/routing/routing.ingress.yaml
+++ b/helm/templates/routing/routing.ingress.yaml
@@ -11,11 +11,8 @@ metadata:
     nginx.ingress.kubernetes.io/fastcgi_buffer_size: 16k
     nginx.ingress.kubernetes.io/fastcgi_buffers: 16 16k
     nginx.ingress.kubernetes.io/fastcgi_busy_buffers_size: 16k
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
-    nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     {{- if eq .Values.cluster.kind "OpenShift" }}
     route.openshift.io/insecureEdgeTerminationPolicy: Redirect
     route.openshift.io/termination: edge
@@ -74,13 +71,6 @@ spec:
                 name: {{ .Release.Name }}-grafana-nginx
                 port:
                   name: grafui
-          - path: /session
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Release.Name }}-session-nginx
-                port:
-                  name: http
           {{ if .Values.mocks.oauth }}
           - path: /default
             pathType: Prefix

--- a/helm/templates/routing/sessions.ingress.yaml
+++ b/helm/templates/routing/sessions.ingress.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-nginx-sessions
+  labels:
+    id: {{ .Release.Name }}-nginx-sessions
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '70'
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '70'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '70'
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    {{- if eq .Values.cluster.kind "OpenShift" }}
+    route.openshift.io/insecureEdgeTerminationPolicy: Redirect
+    route.openshift.io/termination: edge
+    haproxy.router.openshift.io/timeout: 70s
+    {{ end }}
+spec:
+  ingressClassName: {{ .Values.cluster.ingressClassName }}
+  rules:
+    - http:
+        paths:
+          - path: /session
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-session-nginx
+                port:
+                  name: http
+      {{ if not .Values.general.wildcardHost }}
+      host: {{ .Values.general.host }}
+      {{ end }}


### PR DESCRIPTION
The default timeout for nginx is 60 seconds and for haproxy it's 30 seconds. Our session proxy should terminate requests after 60 seconds with a custom error page, but the Ingress nginx / HAProxy was faster.

This sets the timeout to 70s, independently from nginx / HAProxy.