### PR TITLE
feat: Redirect to open page after login again

### DIFF
--- a/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
+++ b/frontend/src/app/general/auth/auth-guard/auth-guard.service.ts
@@ -20,7 +20,8 @@ export const authGuard: CanActivateFn = (
     return true;
   } else {
     // Needs window.location, since Router.url isn't updated yet
-    authService.login(window.location.pathname);
+    authService.redirectURL = window.location.pathname;
+    authService.login();
     return false;
   }
 };

--- a/frontend/src/app/general/auth/auth-redirect/auth-redirect.component.ts
+++ b/frontend/src/app/general/auth/auth-redirect/auth-redirect.component.ts
@@ -28,7 +28,10 @@ export class AuthRedirectComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((params) => {
+      const redirectTo = sessionStorage.getItem(params.state);
+
       if (params.error) {
+        this.authService.redirectURL = redirectTo ?? undefined;
         const redirect_url =
           '/auth?' +
           Object.keys(params)
@@ -43,7 +46,6 @@ export class AuthRedirectComponent implements OnInit {
         return;
       }
 
-      const redirectTo = sessionStorage.getItem(params.state);
       const nonce = sessionStorage.getItem(
         this.authService.SESSION_STORAGE_NONCE_KEY,
       );
@@ -52,12 +54,14 @@ export class AuthRedirectComponent implements OnInit {
       );
 
       if (nonce === null || codeVerifier === null) {
+        this.authService.redirectURL = redirectTo ?? undefined;
         this.toastService.showError(
           'Missing nonce or code verifier value',
           'The nonce or code verifier value is missing in the session storage. If you initiated the login yourself, please retry, and if the error persists or you did not initiate the login, please contact your system administrator',
         );
         this.redirectToLogin();
       } else if (redirectTo === null) {
+        this.authService.redirectURL = redirectTo ?? undefined;
         this.toastService.showError(
           'State mismatch error',
           'The state returned by the authentication server does not match the local state. If you initiated the login yourself, please retry, and if the error persists or you did not initiate the login, please contact your system administrator.',
@@ -83,7 +87,10 @@ export class AuthRedirectComponent implements OnInit {
               this.feedbackService.triggerFeedbackPrompt();
               this.router.navigateByUrl(redirectTo);
             },
-            error: () => this.redirectToLogin(),
+            error: () => {
+              this.authService.redirectURL = redirectTo ?? undefined;
+              this.redirectToLogin();
+            },
           });
       }
     });

--- a/frontend/src/app/general/auth/auth/auth.component.html
+++ b/frontend/src/app/general/auth/auth/auth.component.html
@@ -42,7 +42,7 @@
         mat-flat-button
         color="primary"
         class="mt-2 !h-[50px]"
-        (click)="login()"
+        (click)="authService.login()"
       >
         Login with
         {{ (metadataService.backendMetadata | async)?.authentication_provider }}

--- a/frontend/src/app/general/auth/auth/auth.component.ts
+++ b/frontend/src/app/general/auth/auth/auth.component.ts
@@ -48,16 +48,12 @@ export class AuthComponent implements OnInit {
     this.route.queryParams.subscribe((params) => {
       this.params = params;
       if (params.reason && params.reason === 'session-expired') {
-        this.login();
+        this.authService.login();
       }
     });
   }
 
   getDocsURL(): string {
     return environment.docs_url + '/';
-  }
-
-  login(): void {
-    this.authService.login('/');
   }
 }

--- a/frontend/src/app/general/auth/http-interceptor/auth.interceptor.ts
+++ b/frontend/src/app/general/auth/http-interceptor/auth.interceptor.ts
@@ -42,6 +42,7 @@ export class AuthInterceptor implements HttpInterceptor {
     next: HttpHandler,
   ) {
     if (err.status === 401) {
+      this.authService.redirectURL = this.router.url;
       localStorage.setItem(this.authService.LOGGED_IN_KEY, 'false');
       if (err.error.detail.err_code == 'TOKEN_SIGNATURE_EXPIRED') {
         return this.authenticationService.refreshIdentityToken().pipe(

--- a/frontend/src/app/services/auth/auth.service.ts
+++ b/frontend/src/app/services/auth/auth.service.ts
@@ -13,6 +13,8 @@ export class AuthenticationWrapperService {
   SESSION_STORAGE_CODE_VERIFIER_KEY = 'CCM_CODE_VERIFIER';
   LOGGED_IN_KEY = 'CCM_LOGGED_IN';
 
+  redirectURL: string | undefined = undefined;
+
   constructor(private authenticationService: AuthenticationService) {}
 
   isLoggedIn(): boolean {
@@ -20,9 +22,9 @@ export class AuthenticationWrapperService {
     return loggedIn !== null && loggedIn === 'true';
   }
 
-  login(redirectTo: string) {
+  login() {
     this.authenticationService.getAuthorizationUrl().subscribe((res) => {
-      sessionStorage.setItem(res.state, redirectTo);
+      sessionStorage.setItem(res.state, this.redirectURL ?? '/');
       sessionStorage.setItem(this.SESSION_STORAGE_NONCE_KEY, res.nonce);
       sessionStorage.setItem(
         this.SESSION_STORAGE_CODE_VERIFIER_KEY,


### PR DESCRIPTION
On initial login, the URL was already preserved.
When the login was triggered by an expired token while working in the application, the user was always redirect to the start page after login.

To prevent interruption of workflows, the user is redirected to the original page again.