### PR TITLE
feat: Add "Session container not found" sessions tatus

### DIFF
--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -186,9 +186,12 @@ class KubernetesOperator:
     def get_session_state(self, _id: str) -> str:
         return self._get_pod_state(label_selector=f"app={_id}")
 
-    def _get_pod_state(self, label_selector: str):
+    def _get_pod_state(self, label_selector: str) -> str:
         try:
-            pod = self.get_pods(label_selector=label_selector)[0]
+            pods = self.get_pods(label_selector=label_selector)
+            if not pods:
+                return "NOT_FOUND"
+            pod = pods[0]
             pod_name = pod.metadata.name
 
             log.debug("Received k8s pod: %s", pod_name)

--- a/frontend/src/app/sessions/service/session.service.ts
+++ b/frontend/src/app/sessions/service/session.service.ts
@@ -199,6 +199,11 @@ export class SessionService {
         success = true;
         icon = 'check';
         break;
+      case 'NOT_FOUND':
+        text = 'Session container not found';
+        css = 'error';
+        icon = 'error';
+        break;
       case 'unknown':
       case 'Unknown':
         text = 'Unknown State';


### PR DESCRIPTION
Previously, it did only fall back to "Unknown" state. This commit adds explicit handling for it.