### PR TITLE
fix: Minor frontend fixes for T4C instance components

### DIFF
--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -378,6 +378,7 @@ def create_t4c_instance_and_repositories(db):
         host="localhost",
         port=2036,
         cdo_port=12036,
+        http_port=8080,
         license_server=default_license_server,
         rest_api="http://localhost:8081/api/v1.0",
         username="admin",

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.html
@@ -151,10 +151,10 @@
         </mat-form-field>
       </fieldset>
       <mat-form-field subscriptSizing="dynamic" appearance="fill">
-        <mat-label>Experimental REST API</mat-label>
+        <mat-label>REST API</mat-label>
         <input matInput formControlName="rest_api" />
         @if (form.controls.rest_api.errors?.required) {
-          <mat-error>The REST server URL is required.</mat-error>
+          <mat-error>The REST API server URL is required.</mat-error>
         } @else if (form.controls.rest_api.errors?.pattern) {
           <mat-error>The URL should start with "http(s)://"</mat-error>
         }
@@ -207,7 +207,12 @@
           (t4cInstanceWrapperService.t4cInstance$ | async) !== undefined
         ) {
           @if (!isArchived) {
-            <button mat-flat-button color="primary" (click)="enableEditing()">
+            <button
+              mat-flat-button
+              color="primary"
+              (click)="enableEditing()"
+              data-testid="edit-button"
+            >
               Edit
             </button>
           } @else {

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.component.ts
@@ -139,6 +139,8 @@ export class EditT4CInstanceComponent implements OnInit, OnDestroy {
         const t4cInstance = {
           ...initialT4CInstance,
           password: '***********',
+          version_id: initialT4CInstance.version.id,
+          license_server_id: initialT4CInstance.license_server.id,
         };
         this.isArchived = t4cInstance.is_archived;
         this.form.patchValue(t4cInstance);

--- a/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.stories.ts
+++ b/frontend/src/app/settings/modelsources/t4c-settings/edit-t4c-instance/edit-t4c-instance.stories.ts
@@ -2,11 +2,17 @@
  * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { ActivatedRoute } from '@angular/router';
 import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { userEvent, within } from '@storybook/test';
 import { T4CInstanceWrapperService } from 'src/app/services/settings/t4c-instance.service';
+import { T4CLicenseServerWrapperService } from 'src/app/services/settings/t4c-license-server.service';
+import { MockActivedRoute } from 'src/storybook/routes';
 import {
   MockT4CInstanceWrapperService,
+  MockT4CLicenseServerWrapperService,
   mockT4CInstance,
+  mockT4CLicenseServer,
 } from 'src/storybook/t4c';
 import { mockToolVersion } from 'src/storybook/tool';
 import { EditT4CInstanceComponent } from './edit-t4c-instance.component';
@@ -14,6 +20,22 @@ import { EditT4CInstanceComponent } from './edit-t4c-instance.component';
 const meta: Meta<EditT4CInstanceComponent> = {
   title: 'Settings Components/Modelsources/T4C/Server Instance',
   component: EditT4CInstanceComponent,
+  args: {
+    capellaVersions: [mockToolVersion],
+  },
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: T4CLicenseServerWrapperService,
+          useFactory: () =>
+            new MockT4CLicenseServerWrapperService(mockT4CLicenseServer, [
+              mockT4CLicenseServer,
+            ]),
+        },
+      ],
+    }),
+  ],
 };
 
 export default meta;
@@ -26,7 +48,6 @@ export const AddInstance: Story = {
 export const ExistingInstance: Story = {
   args: {
     existing: true,
-    capellaVersions: [mockToolVersion],
   },
   decorators: [
     moduleMetadata({
@@ -37,6 +58,13 @@ export const ExistingInstance: Story = {
             new MockT4CInstanceWrapperService(mockT4CInstance, [
               mockT4CInstance,
             ]),
+        },
+        {
+          provide: ActivatedRoute,
+          useFactory: () =>
+            new MockActivedRoute({
+              instance: -1,
+            }),
         },
       ],
     }),
@@ -44,10 +72,37 @@ export const ExistingInstance: Story = {
 };
 
 export const EditExistingInstance: Story = {
+  args: {},
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: T4CInstanceWrapperService,
+          useFactory: () =>
+            new MockT4CInstanceWrapperService(mockT4CInstance, [
+              mockT4CInstance,
+            ]),
+        },
+        {
+          provide: ActivatedRoute,
+          useFactory: () =>
+            new MockActivedRoute({
+              instance: -1,
+            }),
+        },
+      ],
+    }),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const editButton = canvas.getByTestId('edit-button');
+    await userEvent.click(editButton);
+  },
+};
+
+export const ArchivedInstance: Story = {
   args: {
-    existing: true,
-    editing: true,
-    capellaVersions: [mockToolVersion],
+    isArchived: true,
   },
   decorators: [
     moduleMetadata({
@@ -59,26 +114,12 @@ export const EditExistingInstance: Story = {
               mockT4CInstance,
             ]),
         },
-      ],
-    }),
-  ],
-};
-
-export const ArchivedInstance: Story = {
-  args: {
-    existing: true,
-    isArchived: true,
-    capellaVersions: [mockToolVersion],
-  },
-  decorators: [
-    moduleMetadata({
-      providers: [
         {
-          provide: T4CInstanceWrapperService,
+          provide: ActivatedRoute,
           useFactory: () =>
-            new MockT4CInstanceWrapperService(mockT4CInstance, [
-              mockT4CInstance,
-            ]),
+            new MockActivedRoute({
+              instance: -1,
+            }),
         },
       ],
     }),


### PR DESCRIPTION
- Capella version and license server are now set properly while editing.
- Some stories have been improved.
- The REST API is not experimental anymore; the corresponding text has been removed.