### PR TITLE
feat: Update feedback dialog to encourage actionable feedback

### DIFF
--- a/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.html
+++ b/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.html
@@ -60,12 +60,16 @@
           formControlName="feedbackText"
           data-testid="feedback-text"
         ></textarea>
-        <mat-hint>Try to be as specific as possible.</mat-hint>
+        <mat-hint
+          >Try to be specific. What happened? What were you doing?</mat-hint
+        >
       </mat-form-field>
     }
 
     <mat-checkbox formControlName="shareContact">
-      <span data-testid="share-user-information"> Share user information </span>
+      <span data-testid="share-user-information">
+        Let us reach out if we need more details
+      </span>
     </mat-checkbox>
 
     <div class="ml-2 flex max-w-80 flex-col gap-2 text-xs text-gray-500">

--- a/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.ts
+++ b/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.ts
@@ -65,7 +65,7 @@ export class FeedbackDialogComponent {
       Validators.required,
     ),
     feedbackText: new FormControl<string>(''),
-    shareContact: new FormControl<boolean>(false),
+    shareContact: new FormControl<boolean>(true),
   });
 
   constructor(


### PR DESCRIPTION
Until now, the defaults encouraged anonymous feedback. Unfortunately, this meant that a lot of feedback was lacking the detail to be actionable for us. By changing the texts in the dialog and making user information sharing opt-out, we can hopefully act on feedback more effectively.