### PR TITLE
fix: Increase connection pool to 20 concurrent database connections

### DIFF
--- a/backend/capellacollab/core/database/__init__.py
+++ b/backend/capellacollab/core/database/__init__.py
@@ -15,6 +15,8 @@ from capellacollab.config import config
 engine = sa.create_engine(
     config.database.url,
     connect_args={"connect_timeout": 5, "options": "-c timezone=utc"},
+    pool_size=20,
+    pool_timeout=5,
 )
 SessionLocal = orm.sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
Due to the asynchronous nature of FastAPI and the number of requests, it can happen that we have to handle more than the default of 5 requests at the same time.

In addition, reduce the pool timeout to 5. The goal is to fail requests if they can't get a database session within 5 seconds instead of spawning a queue with wait times of 30 seconds, which can lead to a blocking backend.


Resolves #1914