### PR TITLE
feat: Add metrics about the SQLAlchemy database pool

### DIFF
--- a/backend/capellacollab/core/database/metrics.py
+++ b/backend/capellacollab/core/database/metrics.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import typing as t
+
+import prometheus_client
+import prometheus_client.core
+from prometheus_client import registry as prometheus_registry
+
+from . import engine
+
+
+class DatabasePoolSizeCollector(prometheus_registry.Collector):
+    def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
+        metric = prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_pool_size",
+            "SQLAlchemy database connection pool size",
+        )
+
+        metric.add_metric([], engine.pool.size())  # type: ignore[attr-defined]
+
+        yield metric
+
+
+class DatabaseConnectionsInPoolCollector(prometheus_registry.Collector):
+    def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
+        metric = prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_connections_in_pool",
+            "Available database connections in the SQLAlchemy pool",
+        )
+
+        metric.add_metric([], engine.pool.checkedin())  # type: ignore[attr-defined]
+
+        yield metric
+
+
+class DatabaseOverflowCollector(prometheus_registry.Collector):
+    def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
+        metric = prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_pool_overflow",
+            "Overflow of the SQLAlchemy database connection pool",
+        )
+
+        metric.add_metric([], engine.pool.overflow())  # type: ignore[attr-defined]
+
+        yield metric
+
+
+class DatabaseCheckedOutConnectionsCollector(prometheus_registry.Collector):
+    def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
+        metric = prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_checked_out_connections",
+            "Checked out SQLAlchemy database connections",
+        )
+
+        metric.add_metric([], engine.pool.checkedout())  # type: ignore[attr-defined]
+
+        yield metric
+
+
+def register() -> None:
+    prometheus_client.REGISTRY.register(DatabasePoolSizeCollector())
+    prometheus_client.REGISTRY.register(DatabaseConnectionsInPoolCollector())
+    prometheus_client.REGISTRY.register(DatabaseOverflowCollector())
+    prometheus_client.REGISTRY.register(
+        DatabaseCheckedOutConnectionsCollector()
+    )

--- a/backend/capellacollab/metrics.py
+++ b/backend/capellacollab/metrics.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import typing as t
+
+import capellacollab.sessions.metrics as sessions_metrics
+import capellacollab.settings.modelsources.t4c.license_server.metrics as t4c_metrics
+from capellacollab.core.database import metrics as database_metrics
+from capellacollab.feedback import metrics as feedback_metrics
+
+metrics_registration: list[t.Callable] = [
+    sessions_metrics.register,
+    t4c_metrics.register,
+    feedback_metrics.register,
+    database_metrics.register,
+]

--- a/backend/tests/core/test_database_metrics.py
+++ b/backend/tests/core/test_database_metrics.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from capellacollab.core.database import metrics as database_metrics
+
+
+def test_sqlalchemy_pool_size_metric():
+    data = list(database_metrics.DatabasePoolSizeCollector().collect())
+
+    assert data[0].samples[0].value == 20
+
+
+def test_sqlalchemy_connections_in_pool_metric():
+    data = list(
+        database_metrics.DatabaseConnectionsInPoolCollector().collect()
+    )
+
+    assert data[0].samples[0].value == 0
+
+
+def test_sqlalchemy_pool_overflow_metric():
+    data = list(database_metrics.DatabaseOverflowCollector().collect())
+
+    assert data[0].samples[0].value == -20
+
+
+def test_sqlalchemy_checked_out_connections_metric():
+    data = list(
+        database_metrics.DatabaseCheckedOutConnectionsCollector().collect()
+    )
+
+    assert data[0].samples[0].value == 0


### PR DESCRIPTION
Adds the following to the `/metrics` endpoint: 

```
# HELP sqlalchemy_pool_size SQLAlchemy database connection pool size
# TYPE sqlalchemy_pool_size gauge
sqlalchemy_pool_size 20.0
# HELP sqlalchemy_connections_in_pool Available database connections in the SQLAlchemy pool
# TYPE sqlalchemy_connections_in_pool gauge
sqlalchemy_connections_in_pool 1.0
# HELP sqlalchemy_pool_overflow Overflow of the SQLAlchemy database connection pool
# TYPE sqlalchemy_pool_overflow gauge
sqlalchemy_pool_overflow -19.0
# HELP sqlalchemy_checked_out_connections Checked out SQLAlchemy database connections
# TYPE sqlalchemy_checked_out_connections gauge
sqlalchemy_checked_out_connections 0.0
```