### PR TITLE
fix: Allow longer feedback and warn users if their feedback is too long

### DIFF
--- a/backend/capellacollab/feedback/models.py
+++ b/backend/capellacollab/feedback/models.py
@@ -65,7 +65,7 @@ class Feedback(core_pydantic.BaseModel):
         description="The rating of the feedback"
     )
     feedback_text: str | None = pydantic.Field(
-        description="The feedback text", max_length=255
+        description="The feedback text", max_length=500
     )
     share_contact: bool = pydantic.Field(
         description="Whether the user wants to share their contact information"

--- a/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.html
+++ b/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.html
@@ -60,6 +60,11 @@
           formControlName="feedbackText"
           data-testid="feedback-text"
         ></textarea>
+        @if (feedbackForm.controls.feedbackText.hasError("maxlength")) {
+          <mat-error>
+            Your feedback can't be longer than 500 characters.
+          </mat-error>
+        }
         <mat-hint
           >Try to be specific. What happened? What were you doing?</mat-hint
         >

--- a/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.ts
+++ b/frontend/src/app/sessions/feedback/feedback-dialog/feedback-dialog.component.ts
@@ -64,7 +64,9 @@ export class FeedbackDialogComponent {
       undefined,
       Validators.required,
     ),
-    feedbackText: new FormControl<string>(''),
+    feedbackText: new FormControl<string>('', {
+      validators: [Validators.maxLength(500)],
+    }),
     shareContact: new FormControl<boolean>(true),
   });
 


### PR DESCRIPTION
The previous limit of 255 was a bit too short, so raise it to 500. Add a client-side warning about the feedback being too long instead of making users run into a server-side error.