### PR TITLE
docs: Remove references to nightly run at 3am UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ In addition, we have integrated commercial products:
   - Automatic repository monitoring
   - UI to create and delete models
   - Automatic license injection into sessions.
-  - Nightly synchronization from TeamForCapella repositories to Git
-    repositories
+  - Synchronization from TeamForCapella repositories to Git repositories
   - Automatic access management via session tokens.
 
 - [pure::variants](https://www.pure-systems.com/purevariants)

--- a/docs/docs/admin/installation.md
+++ b/docs/docs/admin/installation.md
@@ -124,9 +124,9 @@ overview reasons, they are separated:
     and you won't need to touch it. In the session namespace, the following
     services run:
     -   Storage for persistent workspaces
-    -   Storage for Juypter file-shares
-    -   Pipeline jobs for nightly TeamForCapella to Git synchronisation
-    -   Session containers (Capella, Papyrus, Juypter, pure::variants)
+    -   Storage for Jupyter file-shares
+    -   Pipeline jobs for TeamForCapella to Git synchronization
+    -   Session containers (Capella, Papyrus, Jupyter, pure::variants)
 
 ---
 

--- a/docs/docs/admin/teamforcapella/migration.md
+++ b/docs/docs/admin/teamforcapella/migration.md
@@ -24,8 +24,7 @@
     previously imported project!
 1.  Terminate the session.
 1.  Remove existing TeamForCapella to Git backup pipelines in the Collaboration
-    Manager:
-    [Remove a (nightly) backup](../../user/projects/models/backups/remove.md)
+    Manager: [Remove a backup](../../user/projects/models/backups/remove.md)
 1.  Add a new repository in the TeamForCapella server with the new Capella
     version via the Capella Collaboration Manager:
     [Add a new TeamForCapella repository](./repository-management/index.md#add-a-new-teamforcapella-repository)

--- a/docs/docs/user/projects/models/backups/remove.md
+++ b/docs/docs/user/projects/models/backups/remove.md
@@ -3,7 +3,7 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-# Remove a (Nightly) Backup
+# Remove a Backup
 
 !!! warning
 

--- a/docs/docs/user/projects/models/backups/setup.md
+++ b/docs/docs/user/projects/models/backups/setup.md
@@ -12,12 +12,13 @@
 
 !!! danger
 
-    Models are not automatically backed up! Please make sure to set up a nightly
+    Models are not automatically backed up! Please make sure to set up a regular
     backup for important content.
 
 It's possible to create a backup from any TeamForCapella repository to any Git
 repository in a project. Pipelines can be triggered manually and can be
-executed nightly at 3 am UTC.
+executed on schedule. By default the schedule is set to run every night at 3am
+UTC, but can be configured in the configuration.
 
 1.  Navigate to `Projects`
 1.  Select the relevant project

--- a/docs/docs/user/tools/capella/t4c-git-compare.md
+++ b/docs/docs/user/tools/capella/t4c-git-compare.md
@@ -46,12 +46,12 @@
   <tr>
     <td><b>Potential of data loss</b></td>
     <td>Changes are backed up after each push (more regularly).</td>
-    <td>Changes are backed up on a nightly basis.</td>
+    <td>Changes are backed up on schedule, usually once a day.</td>
   </tr>
   <tr>
     <td><b>Automation</b></td>
     <td>Possible via CI/CD in the Git repository.</td>
-    <td>Possible via TeamForCapella &rarr; Git synchronisation (runs on a nightly basis).</td>
+    <td>Possible via TeamForCapella &rarr; Git synchronization (runs on schedule, usually once a day).</td>
   </tr>
   <tr markdown="span">
     <td><b>Change control</b></td>
@@ -61,7 +61,7 @@
   <tr>
     <td><b>Release tagging</b></td>
     <td>Directly possible via tags in Git.</td>
-    <td>Possible via TeamForCapella &rarr; Git synchronisation (Releases are stored as tags in the Git repository).</td>
+    <td>Possible via TeamForCapella &rarr; Git synchronization (Releases are stored as tags in the Git repository).</td>
   </tr>
 </table>
 
@@ -103,7 +103,7 @@
     modeling process that would stop a person from making changes that are not
     allowed. Yet there are a few ways around that limitation. For teams with
     basic or no experience in modeling and git this is probably the best way to
-    start co-woking. Git is still used for nightly backup of the model and
+    start co-woking. Git is still used for regular backups of the model and
     release-tagging.
 
     !!! info "TeamForCapella license required"

--- a/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
+++ b/frontend/src/app/projects/models/backup-settings/create-backup/create-backup.component.html
@@ -79,8 +79,7 @@
         </div>
       </div>
       <form class="mt-5" formGroupName="configuration">
-        <mat-checkbox formControlName="runNightly"
-          >Run nightly (at 3 am)</mat-checkbox
+        <mat-checkbox formControlName="runNightly">Run on schedule</mat-checkbox
         ><br />
       </form>
     </form>

--- a/frontend/src/app/projects/models/backup-settings/job-run-overview/job-run-overview.component.html
+++ b/frontend/src/app/projects/models/backup-settings/job-run-overview/job-run-overview.component.html
@@ -4,8 +4,8 @@
  -->
 
 <div>
-  Please note: Nightly runs are currently not listed. Please ask your
-  administrator for the status of nightly runs. <br />
+  Please note: Automatically scheduled runs are currently not listed. Please ask
+  your administrator for the status of those runs. <br />
 
   <table>
     <thead>

--- a/frontend/src/app/projects/models/backup-settings/trigger-pipeline/trigger-pipeline.component.html
+++ b/frontend/src/app/projects/models/backup-settings/trigger-pipeline/trigger-pipeline.component.html
@@ -28,7 +28,7 @@
             <br />
             <span>
               @if (pipeline.run_nightly) {
-                Runs nightly at 3am or on manual trigger.
+                Runs on schedule or on manual trigger.
               } @else {
                 Runs on manual trigger.
               }


### PR DESCRIPTION
The timezone and cron schedule are configurable.
Remove all hardcoded references to the old time.

Thanks @ewuerger for reporting.