### PR TITLE
chore: Improve error message for failed pipeline operation

### DIFF
--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -358,7 +358,7 @@ def create_t4c_instance_and_repositories(db):
     assert tool
 
     version = tools_crud.get_version_by_tool_id_version_name(
-        db, tool.id, "5.2.0"
+        db, tool.id, "6.0.0"
     )
     assert version
 

--- a/backend/capellacollab/projects/toolmodels/backups/exceptions.py
+++ b/backend/capellacollab/projects/toolmodels/backups/exceptions.py
@@ -18,7 +18,7 @@ class PipelineOperationFailedT4CServerUnreachable(core_exceptions.BaseError):
         self.operation = operation
         super().__init__(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            title=f"The '{operation.value}' operation on the pipeline failed",
+            title=f"Couldn't {operation.value} pipeline",
             reason=(
                 f"We're not able to connect to the TeamForCapella server and therefore cannot {operation.value} the pipeline. "
                 "Please try again later or contact your administrator."


### PR DESCRIPTION
In addtion, set the default T4C Server Version to 6.0.0.