### PR TITLE
chore: Add small margin to main page on small screens

### DIFF
--- a/frontend/src/app/sessions/sessions.component.html
+++ b/frontend/src/app/sessions/sessions.component.html
@@ -3,15 +3,17 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div class="mb-12 hidden tall:block"><app-welcome /></div>
+<div class="mb-10 hidden tall:block"><app-welcome /></div>
 
-<app-user-sessions-wrapper>
-  <div class="flex flex-wrap justify-around gap-4">
-    <app-create-persistent-session
-      class="w-[360px] sm:w-[450px]"
-    ></app-create-persistent-session>
-    <app-active-sessions
-      class="mt-[10px] w-[360px] sm:mt-0 sm:w-[450px]"
-    ></app-active-sessions>
-  </div>
-</app-user-sessions-wrapper>
+<div class="mt-2">
+  <app-user-sessions-wrapper>
+    <div class="flex flex-wrap justify-around gap-4">
+      <app-create-persistent-session
+        class="w-[360px] sm:w-[450px]"
+      ></app-create-persistent-session>
+      <app-active-sessions
+        class="mt-[10px] w-[360px] sm:mt-0 sm:w-[450px]"
+      ></app-active-sessions>
+    </div>
+  </app-user-sessions-wrapper>
+</div>


### PR DESCRIPTION
The margin was on the welcome-card before. Since the welcome card is hidden on small screens, the margin wasn't applied on those screens.