### PR TITLE
fix: Replace 'default' with 'regular' image in alebmic migration

### DIFF
--- a/backend/capellacollab/alembic/versions/320c5b39c509_add_beta_tester.py
+++ b/backend/capellacollab/alembic/versions/320c5b39c509_add_beta_tester.py
@@ -48,7 +48,7 @@ def upgrade():
     for row in results:
         config = row["config"]
         config["sessions"]["persistent"]["image"] = {
-            "default": config["sessions"]["persistent"]["image"],
+            "regular": config["sessions"]["persistent"]["image"],
             "beta": None,
         }
 


### PR DESCRIPTION
The migration was wrong, leading to an invalid configuration.