### PR TITLE
fix: Improve regex for API changelog generation

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -87,7 +87,7 @@ jobs:
             docker run --rm -v /tmp:/tmp:ro tufin/oasdiff changelog \
               --format markup \
               /tmp/openapi.json /tmp/openapi2.json \
-              | sed 's/\/anyOf\[subschema #[0-9]\+\(: [a-zA-Z]\+\)\?\]//g'
+              | sed 's/#\([0-9]\+\)/\1/g'
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
       - name: Find existing comment on PR


### PR DESCRIPTION
A hashtag following a number is detected as reference to an issue in GitHub. This breaks the API changelog comment and the regex replaced those references.