### PR TITLE
chore: Limit version of `aiohttp`

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "python-slugify[unidecode]",
   "starlette-prometheus",
   "fastapi-pagination>=0.12.27",
-  "aiohttp",
+  "aiohttp<3.11.0",
   "argon2-cffi",
   "typer",
   "lxml",


### PR DESCRIPTION
`aiohttp` released a version that breaks aioresponses. Until the coresponding PR is merged on their side, stick to aiohttp < 3.11.0

More information: https://github.com/pnuckowski/aioresponses/issues/263