### PR TITLE
fix: Enable view encapsulation for notice component

### DIFF
--- a/frontend/src/app/general/notice/notice.component.ts
+++ b/frontend/src/app/general/notice/notice.component.ts
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { AsyncPipe, NgClass } from '@angular/common';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 import { NoticeWrapperService } from 'src/app/general/notice/notice.service';
 
 @Component({
   selector: 'app-notice',
   templateUrl: './notice.component.html',
   styleUrls: ['./notice.component.css'],
-  encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [NgClass, AsyncPipe],
 })


### PR DESCRIPTION
The warning class of the notice component interfered with the session iframe, resulting in black text in the status message of the session.