### PR TITLE
fix: Convert Prometheus floating point numbers correctly to int

### DIFF
--- a/backend/capellacollab/sessions/injection.py
+++ b/backend/capellacollab/sessions/injection.py
@@ -36,7 +36,7 @@ def get_idle_state(sid: str) -> sessions_models2.IdleState:
 
     if len(response.json()["data"]["result"]) > 0:
         idle_for_minutes = int(
-            response.json()["data"]["result"][0]["value"][1]
+            float(response.json()["data"]["result"][0]["value"][1])
         )
         return sessions_models2.IdleState(
             available=True,


### PR DESCRIPTION
Prometheus returns floats as strings, e.g., `"16.5"` is a valid idletime. This breaks the `int()` parsing since it can't handle floats as strings.