### PR TITLE
chore: Change idle time unavailable message if metrics not found

### DIFF
--- a/backend/capellacollab/sessions/injection.py
+++ b/backend/capellacollab/sessions/injection.py
@@ -48,6 +48,6 @@ def get_idle_state(sid: str) -> sessions_models2.IdleState:
 
         return sessions_models2.IdleState(
             available=False,
-            unavailable_reason="Unknown session",
+            unavailable_reason="No metrics found for session",
             terminate_after_minutes=config.sessions.timeout,
         )

--- a/backend/tests/sessions/test_session_injection.py
+++ b/backend/tests/sessions/test_session_injection.py
@@ -43,7 +43,7 @@ def test_get_idle_status_unknown_session():
 
         assert injection.get_idle_state("test") == models2_sessions.IdleState(
             available=False,
-            unavailable_reason="Unknown session",
+            unavailable_reason="No metrics found for session",
             terminate_after_minutes=90,
         )
 


### PR DESCRIPTION
"Unknown session" could be interpreted as "The session doesn't exist", but that is not true. The session exists and only the metrics are not available.