### PR TITLE
fix: No longer block uploads of larger files in Ingress nginx

### DIFF
--- a/helm/templates/routing/routing.ingress.yaml
+++ b/helm/templates/routing/routing.ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/fastcgi_busy_buffers_size: 16k
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+    nginx.ingress.kubernetes.io/proxy-body-size: "30m"
     {{- if eq .Values.cluster.kind "OpenShift" }}
     route.openshift.io/insecureEdgeTerminationPolicy: Redirect
     route.openshift.io/termination: edge


### PR DESCRIPTION
If nginx was used as Ingress, the default max body size of 1MB was applied. This has blocked uploads of files > 1MB.