### PR TITLE
ci: Use ruff to replace black, pyupgrade, and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,12 @@ default_install_hook_types: [commit-msg, pre-commit]
 default_stages: [pre-commit, pre-merge-commit]
 minimum_pre_commit_version: 3.2.0
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.2
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
   - repo: https://github.com/gitleaks/gitleaks.git
     rev: v8.20.1
     hooks:
@@ -39,24 +45,6 @@ repos:
       - id: codespell
         exclude: 'frontend/package-lock.json'
         args: ['-L', 'AKS']
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
-    hooks:
-      - id: black
-        files: '^backend/'
-        args:
-          - '--config'
-          - 'backend/pyproject.toml'
-        types: [python]
-      - id: black
-        types: [python]
-        exclude: '^backend/'
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        entry: bash -c "cd backend && isort ."
-        types: [python]
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.3
     hooks:
@@ -217,8 +205,3 @@ repos:
         stages: [commit-msg]
         additional_dependencies:
           - '@commitlint/config-conventional'
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
-    hooks:
-      - id: pyupgrade
-        args: ['--py311-plus']

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -50,12 +50,18 @@ sqlalchemy.url =
 # post_write_hooks defines scripts or Python functions that are run
 # on newly generated revision scripts.  See the documentation for further
 # detail and examples
+hooks = ruff, ruff_format
 
-# format using "black" - use the console_scripts runner, against the "black" entrypoint
-# hooks = black
-# black.type = console_scripts
-# black.entrypoint = black
-# black.options = -l 79 REVISION_SCRIPT_FILENAME
+# lint with attempts to fix using "ruff"
+ruff.type = exec
+ruff.executable = %(here)s/.venv/bin/ruff
+ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# format using "ruff" - use the exec runner, execute a binary
+ruff_format.type = exec
+ruff_format.executable = %(here)s/.venv/bin/ruff
+ruff_format.options = format REVISION_SCRIPT_FILENAME
+
 
 # Logging configuration
 [loggers]

--- a/backend/capellacollab/alembic/versions/014438261702_add_provisioning_feature.py
+++ b/backend/capellacollab/alembic/versions/014438261702_add_provisioning_feature.py
@@ -8,6 +8,7 @@ Revises: 320c5b39c509
 Create Date: 2024-10-11 17:34:05.210906
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/028c72ddfd20_add_idp_identifier_and_email_column.py
+++ b/backend/capellacollab/alembic/versions/028c72ddfd20_add_idp_identifier_and_email_column.py
@@ -8,6 +8,7 @@ Revises: a1e59021e0d0
 Create Date: 2024-07-22 14:49:47.575605
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/0e2028f83156_add_user_determined_display_order_to_.py
+++ b/backend/capellacollab/alembic/versions/0e2028f83156_add_user_determined_display_order_to_.py
@@ -8,6 +8,7 @@ Revises: ac0e6e0f77ee
 Create Date: 2023-11-12 14:47:12.295103
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/0ef0826d54e7_create_pure_variant_table.py
+++ b/backend/capellacollab/alembic/versions/0ef0826d54e7_create_pure_variant_table.py
@@ -8,6 +8,7 @@ Revises: 2df2e0fd7774
 Create Date: 2022-11-18 11:40:46.395645
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/16398dfaeef7_replace_project_name_with_id_for_.py
+++ b/backend/capellacollab/alembic/versions/16398dfaeef7_replace_project_name_with_id_for_.py
@@ -8,6 +8,7 @@ Revises: 7617cde6fbb1
 Create Date: 2022-11-25 13:02:19.197569
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/1a4208c18909_make_tool_name_required.py
+++ b/backend/capellacollab/alembic/versions/1a4208c18909_make_tool_name_required.py
@@ -8,6 +8,7 @@ Revises: d8cf851562cd
 Create Date: 2023-09-19 11:25:16.343948
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/2df2e0fd7774_add_user_events.py
+++ b/backend/capellacollab/alembic/versions/2df2e0fd7774_add_user_events.py
@@ -8,6 +8,7 @@ Revises: 16398dfaeef7
 Create Date: 2022-12-28 16:56:43.714914
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/2f8449c217fa_add_project_tools_table.py
+++ b/backend/capellacollab/alembic/versions/2f8449c217fa_add_project_tools_table.py
@@ -8,6 +8,7 @@ Revises: 014438261702
 Create Date: 2024-10-29 14:11:47.774679
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/320c5b39c509_add_beta_tester.py
+++ b/backend/capellacollab/alembic/versions/320c5b39c509_add_beta_tester.py
@@ -8,6 +8,7 @@ Revises: 3818a5009130
 Create Date: 2024-11-04 12:31:17.024627
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/3442c1b545e3_add_http_port_to_t4c_instance.py
+++ b/backend/capellacollab/alembic/versions/3442c1b545e3_add_http_port_to_t4c_instance.py
@@ -8,6 +8,7 @@ Revises: c6d27bd8cf6e
 Create Date: 2023-06-26 17:04:34.613373
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/3818a5009130_split_t4c_instances_and_license_servers.py
+++ b/backend/capellacollab/alembic/versions/3818a5009130_split_t4c_instances_and_license_servers.py
@@ -8,6 +8,7 @@ Revises: 7cf3357ddd7b
 Create Date: 2024-10-01 15:46:26.054936
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/3ec39e345cc9_cut_tool_names_that_are_too_long.py
+++ b/backend/capellacollab/alembic/versions/3ec39e345cc9_cut_tool_names_that_are_too_long.py
@@ -8,6 +8,7 @@ Revises: c973be2e2ac7
 Create Date: 2024-02-23 08:53:31.142987
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/3fa75ddfdde8_use_user_id_as_foreign_key_instead_of_.py
+++ b/backend/capellacollab/alembic/versions/3fa75ddfdde8_use_user_id_as_foreign_key_instead_of_.py
@@ -8,6 +8,7 @@ Revises: 3fe3ed1167fb
 Create Date: 2022-10-17 14:08:01.431956
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/49f51db92903_add_session_sharing.py
+++ b/backend/capellacollab/alembic/versions/49f51db92903_add_session_sharing.py
@@ -8,6 +8,7 @@ Revises: aa88e6d1333b
 Create Date: 2024-05-29 14:25:34.801756
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/4c58f4db4f54_replace_tool_specific_session_.py
+++ b/backend/capellacollab/alembic/versions/4c58f4db4f54_replace_tool_specific_session_.py
@@ -8,6 +8,7 @@ Revises: 97c7acd616fc
 Create Date: 2023-08-07 20:09:26.524318
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/4cf566b4f986_add_project_scope_to_session_table.py
+++ b/backend/capellacollab/alembic/versions/4cf566b4f986_add_project_scope_to_session_table.py
@@ -8,6 +8,7 @@ Revises: 2f8449c217fa
 Create Date: 2024-12-02 14:40:15.815359
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/4df9c82766e2_add_model_restrictions_table.py
+++ b/backend/capellacollab/alembic/versions/4df9c82766e2_add_model_restrictions_table.py
@@ -8,6 +8,7 @@ Revises: ca2346be296b
 Create Date: 2022-12-21 12:01:00.653463
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/4f273887f742_set_nullable_to_false_for_run_nightly_.py
+++ b/backend/capellacollab/alembic/versions/4f273887f742_set_nullable_to_false_for_run_nightly_.py
@@ -8,6 +8,7 @@ Revises: df07aad6525d
 Create Date: 2022-11-08 16:36:18.621808
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/5717cf6b004d_add_api_url_to_git_instances.py
+++ b/backend/capellacollab/alembic/versions/5717cf6b004d_add_api_url_to_git_instances.py
@@ -8,6 +8,7 @@ Revises: 4df9c82766e2
 Create Date: 2023-02-02 09:05:00.727519
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/598efe35c2de_add_t4c_password_to_sessions_table.py
+++ b/backend/capellacollab/alembic/versions/598efe35c2de_add_t4c_password_to_sessions_table.py
@@ -8,6 +8,7 @@ Revises: 9a1e6729858b
 Create Date: 2022-11-09 16:50:52.026374
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/5a6b36abdf25_add_t4c_repositories_table.py
+++ b/backend/capellacollab/alembic/versions/5a6b36abdf25_add_t4c_repositories_table.py
@@ -9,6 +9,7 @@ Revises: cf93aadf77d6
 Create Date: 2022-10-06 15:06:40.370022
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/5ca7037ef183_project_type.py
+++ b/backend/capellacollab/alembic/versions/5ca7037ef183_project_type.py
@@ -8,6 +8,7 @@ Revises: 0e2028f83156
 Create Date: 2023-10-24 14:21:07.128985
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/61d36288afe9_define_jupyter_as_integration.py
+++ b/backend/capellacollab/alembic/versions/61d36288afe9_define_jupyter_as_integration.py
@@ -8,6 +8,7 @@ Revises: f3d2dedd7906
 Create Date: 2023-02-09 11:57:07.345877
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/6c4ff61acc8e_add_resources_to_tools.py
+++ b/backend/capellacollab/alembic/versions/6c4ff61acc8e_add_resources_to_tools.py
@@ -8,6 +8,7 @@ Revises: 3ec39e345cc9
 Create Date: 2024-02-15 14:21:18.085411
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/6c5d1334d606_remove_scope_from_notices.py
+++ b/backend/capellacollab/alembic/versions/6c5d1334d606_remove_scope_from_notices.py
@@ -8,6 +8,7 @@ Revises: 740f45fd20e8
 Create Date: 2022-10-14 08:17:28.933231
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/703517ca79bc_add_config_dockerimages_table.py
+++ b/backend/capellacollab/alembic/versions/703517ca79bc_add_config_dockerimages_table.py
@@ -9,6 +9,7 @@ Revises: 951433f1f092
 Create Date: 2022-05-27 12:27:22.682178
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/740f45fd20e8_remove_table_for_docker_images.py
+++ b/backend/capellacollab/alembic/versions/740f45fd20e8_remove_table_for_docker_images.py
@@ -8,6 +8,7 @@ Revises: 3fe3ed1167fb
 Create Date: 2022-10-14 08:16:20.665269
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/7617cde6fbb1_link_sessions_to_projects.py
+++ b/backend/capellacollab/alembic/versions/7617cde6fbb1_link_sessions_to_projects.py
@@ -8,6 +8,7 @@ Revises: ab01ad045341
 Create Date: 2022-11-10 13:13:25.041000
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/7683b08b00ba_add_environment_and_connection_info_to_.py
+++ b/backend/capellacollab/alembic/versions/7683b08b00ba_add_environment_and_connection_info_to_.py
@@ -8,6 +8,7 @@ Revises: 6c4ff61acc8e
 Create Date: 2024-02-20 09:24:05.465477
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/7cf3357ddd7b_add_feedback_table.py
+++ b/backend/capellacollab/alembic/versions/7cf3357ddd7b_add_feedback_table.py
@@ -8,6 +8,7 @@ Revises: abddaf015966
 Create Date: 2024-09-30 19:47:36.253187
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/86ab7d4d1684_add_configuration_table.py
+++ b/backend/capellacollab/alembic/versions/86ab7d4d1684_add_configuration_table.py
@@ -8,6 +8,7 @@ Revises: f55b41e32223
 Create Date: 2023-10-27 14:54:40.452599
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/8eceebe9b3ea_rename_tpye_id_to_nature_id.py
+++ b/backend/capellacollab/alembic/versions/8eceebe9b3ea_rename_tpye_id_to_nature_id.py
@@ -8,6 +8,7 @@ Revises: e7a140389e22
 Create Date: 2022-10-28 14:22:52.516394
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/backend/capellacollab/alembic/versions/90abdec3827e_project_visibility.py
+++ b/backend/capellacollab/alembic/versions/90abdec3827e_project_visibility.py
@@ -8,6 +8,7 @@ Revises: 3442c1b545e3
 Create Date: 2023-07-10 09:24:26.635483
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/951433f1f092_move_models_to_own_table.py
+++ b/backend/capellacollab/alembic/versions/951433f1f092_move_models_to_own_table.py
@@ -10,7 +10,6 @@ Create Date: 2022-05-16 12:49:07.592601
 
 """
 
-
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/97c7acd616fc_add_configuration_to_toolmodels.py
+++ b/backend/capellacollab/alembic/versions/97c7acd616fc_add_configuration_to_toolmodels.py
@@ -8,6 +8,7 @@ Revises: d0cbf2813066
 Create Date: 2023-08-04 12:05:53.846434
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/9960cd073b98_remove_outdated_model_type.py
+++ b/backend/capellacollab/alembic/versions/9960cd073b98_remove_outdated_model_type.py
@@ -8,6 +8,7 @@ Revises: cf93aadf77d6
 Create Date: 2022-10-06 08:52:02.263343
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/9a1e6729858b_introduce_protocol_on_instance.py
+++ b/backend/capellacollab/alembic/versions/9a1e6729858b_introduce_protocol_on_instance.py
@@ -8,6 +8,7 @@ Revises: e7a140389e22
 Create Date: 2022-11-08 10:06:04.740051
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/a1e59021e0d0_add_workspaces_table.py
+++ b/backend/capellacollab/alembic/versions/a1e59021e0d0_add_workspaces_table.py
@@ -8,6 +8,7 @@ Revises: 49f51db92903
 Create Date: 2024-07-17 09:19:57.903328
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/a81a79a7eaac_remove_jenkins_support.py
+++ b/backend/capellacollab/alembic/versions/a81a79a7eaac_remove_jenkins_support.py
@@ -8,6 +8,7 @@ Revises: a6aedef45374
 Create Date: 2022-10-07 10:29:25.859413
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/aa88e6d1333b_remove_versions_without_tool.py
+++ b/backend/capellacollab/alembic/versions/aa88e6d1333b_remove_versions_without_tool.py
@@ -8,6 +8,7 @@ Revises: e06d616469ec
 Create Date: 2024-04-25 10:48:56.205850
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
+++ b/backend/capellacollab/alembic/versions/ab01ad045341_add_readonly_docker_image.py
@@ -8,6 +8,7 @@ Revises: b14f7a53b9e2
 Create Date: 2022-10-13 10:51:57.631309
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/abddaf015966_add_repository_id_to_git_model_and_remove_unused_name.py
+++ b/backend/capellacollab/alembic/versions/abddaf015966_add_repository_id_to_git_model_and_remove_unused_name.py
@@ -8,6 +8,7 @@ Revises: 028c72ddfd20
 Create Date: 2024-08-12 11:43:34.158404
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/ac0e6e0f77ee_add_project_archive_flag.py
+++ b/backend/capellacollab/alembic/versions/ac0e6e0f77ee_add_project_archive_flag.py
@@ -8,6 +8,7 @@ Revises: f7bf9456cfc9
 Create Date: 2023-09-25 16:08:07.115693
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/b036c613afc7_update_indexes_for_models.py
+++ b/backend/capellacollab/alembic/versions/b036c613afc7_update_indexes_for_models.py
@@ -8,6 +8,7 @@ Revises: a81a79a7eaac
 Create Date: 2022-10-07 11:10:08.420400
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/backend/capellacollab/alembic/versions/b14f7a53b9e2_add_tool_and_version_to_sessions_table.py
+++ b/backend/capellacollab/alembic/versions/b14f7a53b9e2_add_tool_and_version_to_sessions_table.py
@@ -8,6 +8,7 @@ Revises: 598efe35c2de
 Create Date: 2022-11-10 08:19:53.488507
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/c3320b81a372_add_docker_image_backup_template_to_.py
+++ b/backend/capellacollab/alembic/versions/c3320b81a372_add_docker_image_backup_template_to_.py
@@ -8,6 +8,7 @@ Revises: 4f273887f742
 Create Date: 2022-11-09 15:00:59.177753
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/c6d27bd8cf6e_add_run_layer_for_pipelines.py
+++ b/backend/capellacollab/alembic/versions/c6d27bd8cf6e_add_run_layer_for_pipelines.py
@@ -8,6 +8,7 @@ Revises: d1414756738a
 Create Date: 2023-06-22 09:12:10.587478
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/c926d3e402a8_merge_branches_permissions_and_.py
+++ b/backend/capellacollab/alembic/versions/c926d3e402a8_merge_branches_permissions_and_.py
@@ -8,6 +8,7 @@ Revises: 1b4c1dc944d6, 52aec4f341a5
 Create Date: 2021-08-30 12:27:00.888738
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/c973be2e2ac7_migrate_tools_to_json_configuration.py
+++ b/backend/capellacollab/alembic/versions/c973be2e2ac7_migrate_tools_to_json_configuration.py
@@ -8,6 +8,7 @@ Revises: 86ab7d4d1684
 Create Date: 2024-01-31 17:40:31.743565
 
 """
+
 import typing as t
 
 import sqlalchemy as sa

--- a/backend/capellacollab/alembic/versions/c9f30ccd4650_add_basic_auth_token.py
+++ b/backend/capellacollab/alembic/versions/c9f30ccd4650_add_basic_auth_token.py
@@ -8,6 +8,7 @@ Revises: 1a4208c18909
 Create Date: 2023-09-06 14:42:53.016924
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/ca2346be296b_add_tool_integrations_table.py
+++ b/backend/capellacollab/alembic/versions/ca2346be296b_add_tool_integrations_table.py
@@ -8,6 +8,7 @@ Revises: 0ef0826d54e7
 Create Date: 2022-12-19 17:05:07.009764
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/cf93aadf77d6_add_t4c_instances.py
+++ b/backend/capellacollab/alembic/versions/cf93aadf77d6_add_t4c_instances.py
@@ -8,6 +8,7 @@ Revises: d64fc5a97252
 Create Date: 2022-09-29 11:52:20.442558
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/d0cbf2813066_add_end_time_for_pipeline_run.py
+++ b/backend/capellacollab/alembic/versions/d0cbf2813066_add_end_time_for_pipeline_run.py
@@ -8,6 +8,7 @@ Revises: 90abdec3827e
 Create Date: 2023-07-26 18:16:55.723944
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/d1414756738a_migrate_to_sql_alchemy_2_0.py
+++ b/backend/capellacollab/alembic/versions/d1414756738a_migrate_to_sql_alchemy_2_0.py
@@ -8,6 +8,7 @@ Revises: 61d36288afe9
 Create Date: 2023-05-23 14:18:35.476683
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/d8cf851562cd_add_missing_empty_model_restrictions.py
+++ b/backend/capellacollab/alembic/versions/d8cf851562cd_add_missing_empty_model_restrictions.py
@@ -8,6 +8,7 @@ Revises: 4c58f4db4f54
 Create Date: 2023-08-21 15:45:27.243037
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/df07aad6525d_add_run_nighly_and_include_commit_.py
+++ b/backend/capellacollab/alembic/versions/df07aad6525d_add_run_nighly_and_include_commit_.py
@@ -8,6 +8,7 @@ Revises: fcf5d69d7bbc
 Create Date: 2022-11-07 14:42:40.129037
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/e06d616469ec_add_eclipse_projects_to_load_.py
+++ b/backend/capellacollab/alembic/versions/e06d616469ec_add_eclipse_projects_to_load_.py
@@ -8,6 +8,7 @@ Revises: 7683b08b00ba
 Create Date: 2024-04-16 15:32:33.123817
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/e7a140389e22_update_databaset4cmodel_table.py
+++ b/backend/capellacollab/alembic/versions/e7a140389e22_update_databaset4cmodel_table.py
@@ -8,6 +8,7 @@ Revises: 5a6b36abdf25
 Create Date: 2022-10-12 14:43:58.270916
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/f3d2dedd7906_add_jupyter_token_column.py
+++ b/backend/capellacollab/alembic/versions/f3d2dedd7906_add_jupyter_token_column.py
@@ -8,6 +8,7 @@ Revises: 4df9c82766e2
 Create Date: 2023-02-03 14:31:55.776520
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/f55b41e32223_make_instance_name_unique.py
+++ b/backend/capellacollab/alembic/versions/f55b41e32223_make_instance_name_unique.py
@@ -8,6 +8,7 @@ Revises: 5ca7037ef183
 Create Date: 2023-12-12 18:01:35.967370
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/f7bf9456cfc9_add_archive_flag.py
+++ b/backend/capellacollab/alembic/versions/f7bf9456cfc9_add_archive_flag.py
@@ -8,6 +8,7 @@ Revises: c9f30ccd4650
 Create Date: 2023-08-28 08:57:22.931913
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/f7c1a89af5d7_rename_git_settings_table_to_git_.py
+++ b/backend/capellacollab/alembic/versions/f7c1a89af5d7_rename_git_settings_table_to_git_.py
@@ -8,6 +8,7 @@ Revises: 5717cf6b004d
 Create Date: 2023-02-10 09:32:05.903031
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/backend/capellacollab/alembic/versions/fcf5d69d7bbc_add_backups_table.py
+++ b/backend/capellacollab/alembic/versions/fcf5d69d7bbc_add_backups_table.py
@@ -8,6 +8,7 @@ Revises: e7a140389e22
 Create Date: 2022-11-07 13:33:24.231968
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/alembic/versions/fdff657f3cc1_add_ocd_port_to_t4c_instance.py
+++ b/backend/capellacollab/alembic/versions/fdff657f3cc1_add_ocd_port_to_t4c_instance.py
@@ -8,6 +8,7 @@ Revises: 8eceebe9b3ea
 Create Date: 2022-11-03 10:19:48.397946
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/backend/capellacollab/cli/ws.py
+++ b/backend/capellacollab/cli/ws.py
@@ -236,10 +236,10 @@ def restore(
     volume_name: str,
     tarfile: t.Annotated[pathlib.Path, typer.Argument(exists=True)],
     namespace: t.Annotated[str, NamespaceOption],
-    sidecar_path: t.Union[pathlib.Path, None] = None,
+    sidecar_path: pathlib.Path | None = None,
     access_mode: str = "ReadWriteMany",
     storage_class_name: str = "persistent-sessions-csi",
-    user_id: t.Union[str, None] = None,
+    user_id: str | None = None,
 ):
     """Restore a backup to a Kubernetes Persistent Volume.
 

--- a/backend/capellacollab/configuration/models.py
+++ b/backend/capellacollab/configuration/models.py
@@ -270,7 +270,7 @@ class GlobalConfiguration(ConfigurationBase):
 
 
 # All subclasses of ConfigurationBase are automatically registered using this dict.
-NAME_TO_MODEL_TYPE_MAPPING: dict[str, t.Type[ConfigurationBase]] = {
+NAME_TO_MODEL_TYPE_MAPPING: dict[str, type[ConfigurationBase]] = {
     model()._name: model for model in ConfigurationBase.__subclasses__()
 }
 

--- a/backend/capellacollab/core/authentication/basic_auth.py
+++ b/backend/capellacollab/core/authentication/basic_auth.py
@@ -21,9 +21,9 @@ class HTTPBasicAuth(security.HTTPBasic):
         super().__init__(auto_error=True)
 
     async def __call__(self, request: fastapi.Request) -> str:  # type: ignore
-        credentials: security.HTTPBasicCredentials | None = (
-            await super().__call__(request)
-        )
+        credentials: (
+            security.HTTPBasicCredentials | None
+        ) = await super().__call__(request)
         if not credentials:
             raise exceptions.UnauthenticatedError()
         with database.SessionLocal() as session:

--- a/backend/capellacollab/core/database/decorator.py
+++ b/backend/capellacollab/core/database/decorator.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import typing as t
-
 import pydantic
 from sqlalchemy import types
 from sqlalchemy.dialects import postgresql
@@ -26,7 +24,7 @@ class PydanticDecorator(types.TypeDecorator):
 
     cache_ok = True
 
-    def __init__(self, pydantic_model: t.Type[pydantic.BaseModel]):
+    def __init__(self, pydantic_model: type[pydantic.BaseModel]):
         super().__init__()
         self.pydantic_model = pydantic_model
 

--- a/backend/capellacollab/core/database/migration.py
+++ b/backend/capellacollab/core/database/migration.py
@@ -6,9 +6,8 @@ import logging
 import os
 import pathlib
 
-from alembic import command
+from alembic import command, migration
 from alembic import config as alembic_config
-from alembic import migration
 from sqlalchemy import orm
 
 from capellacollab import core

--- a/backend/capellacollab/core/responses.py
+++ b/backend/capellacollab/core/responses.py
@@ -18,7 +18,7 @@ from .authentication import exceptions as authentication_exceptions
 
 
 def _construct_union(types: list[type[pydantic.BaseModel]]):
-    return t.Union[tuple(types)]
+    return t.Union[tuple(types)]  # noqa: UP007
 
 
 def _create_pydantic_error_model(exc: exceptions.BaseError):

--- a/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
+++ b/backend/capellacollab/projects/toolmodels/backups/runs/routes.py
@@ -155,9 +155,9 @@ def _determine_end_time_from_pipeline_run(
 def _transform_unix_nanoseconds_to_human_readable_format(
     nanoseconds: int,
 ) -> str:
-    return datetime.datetime.fromtimestamp(
-        int(nanoseconds) / 10**9
-    ).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.datetime.fromtimestamp(int(nanoseconds) / 10**9).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
 
 
 @router.get(
@@ -190,9 +190,9 @@ def get_logs(
 
     logs = "\n".join(
         [
-            datetime.datetime.fromtimestamp(
-                int(logline[0]) / 10**9
-            ).strftime("%Y-%m-%d %H:%M:%S")
+            datetime.datetime.fromtimestamp(int(logline[0]) / 10**9).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             + ": "
             + logline[1]
             for logentry in logs

--- a/backend/capellacollab/projects/toolmodels/diagrams/routes.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/routes.py
@@ -42,13 +42,15 @@ async def get_diagram_metadata(
     logger: logging.LoggerAdapter = fastapi.Depends(log.get_request_logger),
 ):
     try:
-        job_id, last_updated, diagram_metadata_entries = (
-            await handler.get_file_or_artifact(
-                trusted_file_path="diagram_cache/index.json",
-                logger=logger,
-                job_name="update_capella_diagram_cache",
-                file_revision=f"diagram-cache/{handler.revision}",
-            )
+        (
+            job_id,
+            last_updated,
+            diagram_metadata_entries,
+        ) = await handler.get_file_or_artifact(
+            trusted_file_path="diagram_cache/index.json",
+            logger=logger,
+            job_name="update_capella_diagram_cache",
+            file_revision=f"diagram-cache/{handler.revision}",
         )
     except requests.HTTPError:
         logger.info(

--- a/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
+++ b/backend/capellacollab/projects/toolmodels/restrictions/injectables.py
@@ -15,5 +15,7 @@ def get_model_restrictions(
     ),
 ) -> models.DatabaseToolModelRestrictions | None:
     restrictions = model.restrictions
-    assert restrictions  # restrictions are only None for a short time during creation
+    assert (
+        restrictions
+    )  # restrictions are only None for a short time during creation
     return restrictions

--- a/backend/capellacollab/sessions/operators/k8s.py
+++ b/backend/capellacollab/sessions/operators/k8s.py
@@ -153,7 +153,9 @@ class KubernetesOperator:
     def get_job_by_name(self, name: str) -> client.V1Job:
         return self.v1_batch.read_namespaced_job(name, namespace=namespace)
 
-    def get_session_state(self, session_id: str) -> tuple[
+    def get_session_state(
+        self, session_id: str
+    ) -> tuple[
         sessions_models.SessionPreparationState,
         sessions_models.SessionState,
     ]:

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -11,10 +11,9 @@ import jwt
 from fastapi import status
 from sqlalchemy import orm
 
-from capellacollab.core import database
+from capellacollab.core import database, responses
 from capellacollab.core import logging as log
 from capellacollab.core import models as core_models
-from capellacollab.core import responses
 from capellacollab.core.authentication import exceptions as auth_exceptions
 from capellacollab.core.authentication import injectables as auth_injectables
 from capellacollab.projects import injectables as projects_injectables
@@ -321,9 +320,8 @@ def share_session(
     user_to_share_with = users_crud.get_user_by_name(db, body.username)
     if not user_to_share_with:
         raise users_exceptions.UserNotFoundError(username=body.username)
-    if (
-        session.owner == user_to_share_with
-        or util.is_session_shared_with_user(session, user_to_share_with)
+    if session.owner == user_to_share_with or util.is_session_shared_with_user(
+        session, user_to_share_with
     ):
         raise exceptions.SessionAlreadySharedError(user_to_share_with.name)
 

--- a/backend/capellacollab/tools/routes.py
+++ b/backend/capellacollab/tools/routes.py
@@ -327,7 +327,6 @@ def delete_tool_nature(
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
 ):
-
     raise_when_tool_nature_dependency_exist(db, nature)
     crud.delete_nature(db, nature)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,10 +54,9 @@ Homepage = "https://github.com/DSD-DBS/capella-collab-manager"
 
 [project.optional-dependencies]
 dev = [
-  "black",
+  "ruff",
   "capellambse",
   "deepdiff",
-  "isort",
   "mypy",
   "pylint",
   "pylint-pytest",
@@ -75,10 +74,6 @@ dev = [
   "pytest-asyncio",
 ]
 
-[tool.black]
-line-length = 79
-target-version = ["py311"]
-
 [tool.coverage.run]
 source = ["capellacollab"]
 branch = true
@@ -93,10 +88,6 @@ exclude_also = [
   '@t\.overload',
 ]
 skip_covered = true
-
-[tool.isort]
-profile = 'black'
-line_length = 79
 
 [tool.mypy]
 check_untyped_defs = true
@@ -136,22 +127,6 @@ module = [
   "valkey.*",
 ]
 ignore_missing_imports = true
-
-[tool.pydocstyle]
-convention = "numpy"
-add-select = [
-  "D212", # Multi-line docstring summary should start at the first line
-  "D402", # First line should not be the function’s “signature”
-  "D417", # Missing argument descriptions in the docstring
-]
-add-ignore = [
-  "D201", # No blank lines allowed before function docstring  # auto-formatting
-  "D202", # No blank lines allowed after function docstring  # auto-formatting
-  "D203", # 1 blank line required before class docstring  # auto-formatting
-  "D204", # 1 blank line required after class docstring  # auto-formatting
-  "D211", # No blank lines allowed before class docstring  # auto-formatting
-  "D213", # Multi-line docstring summary should start at the second line
-]
 
 [tool.pylint]
 bad-functions = ["print"]
@@ -244,6 +219,13 @@ addopts = """
 """
 testpaths = ["tests"]
 xfail_strict = true
+
+[tool.ruff]
+line-length = 79
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["I", "UP"]
 
 [tool.setuptools]
 platforms = ["any"]

--- a/backend/tests/cli/test_cli.py
+++ b/backend/tests/cli/test_cli.py
@@ -13,7 +13,6 @@ def fixture_cli_runner() -> testing.CliRunner:
 
 
 def test_cli_help(cli_runner: testing.CliRunner):
-
     result = cli_runner.invoke(cli.app, ["--help"])
     assert result.exit_code == 0
 

--- a/backend/tests/cli/test_workspace_backup.py
+++ b/backend/tests/cli/test_workspace_backup.py
@@ -74,9 +74,9 @@ def test_workspace_volumes(
 
     monkeypatch.setattr(
         "kubernetes.client.CoreV1Api.list_namespaced_persistent_volume_claim",
-        lambda self, namespace, watch: kubernetes.client.V1PersistentVolumeClaimList(
-            items=pvcs
-        ),
+        lambda self,
+        namespace,
+        watch: kubernetes.client.V1PersistentVolumeClaimList(items=pvcs),
     )
 
     volumes(namespace="default")
@@ -113,7 +113,9 @@ def test_backup_workspace(
     monkeypatch.setattr(
         kubernetes.client.CoreV1Api,
         "read_namespaced_persistent_volume_claim",
-        lambda self, name, namespace: kubernetes.client.V1PersistentVolumeClaim(
+        lambda self,
+        name,
+        namespace: kubernetes.client.V1PersistentVolumeClaim(
             spec=kubernetes.client.V1PersistentVolumeClaimSpec(
                 resources=kubernetes.client.V1ResourceRequirements(
                     requests={"storage": "1Gi"},

--- a/backend/tests/config/test_app_configuration.py
+++ b/backend/tests/config/test_app_configuration.py
@@ -48,14 +48,13 @@ class MockLocation:
 
 @pytest.fixture(name="mock_locations")
 def fixture_mock_locations() -> tuple[MockLocation, MockLocation]:
-
     mock_location_1 = MockLocation()
     mock_location_2 = MockLocation()
     return mock_location_1, mock_location_2
 
 
 def test_loader_does_config_exist_true(
-    mock_locations: tuple[MockLocation, MockLocation]
+    mock_locations: tuple[MockLocation, MockLocation],
 ):
     """Test that does_config_exist returns True when a config file exists in one of the provided locations."""
 
@@ -68,7 +67,7 @@ def test_loader_does_config_exist_true(
 
 
 def test_loader_does_config_exist_false(
-    mock_locations: tuple[MockLocation, MockLocation]
+    mock_locations: tuple[MockLocation, MockLocation],
 ):
     """Test that does_config_exist returns False when a config file does not exist in one of the provided locations."""
 
@@ -94,7 +93,7 @@ def test_load_yaml_exists(mock_locations: tuple[MockLocation, MockLocation]):
 
 
 def test_load_yaml_not_exists(
-    mock_locations: tuple[MockLocation, MockLocation]
+    mock_locations: tuple[MockLocation, MockLocation],
 ):
     """Test that load_yaml raises an exception when no config file is found in provided locations."""
 

--- a/backend/tests/sessions/hooks/conftest.py
+++ b/backend/tests/sessions/hooks/conftest.py
@@ -66,7 +66,6 @@ def fixture_session_connection_hook_request(
     session: sessions_models.DatabaseSession,
     logger: logging.LoggerAdapter,
 ) -> hooks_interface.SessionConnectionHookRequest:
-
     return hooks_interface.SessionConnectionHookRequest(
         db=db,
         db_session=session,

--- a/backend/tests/sessions/hooks/test_jupyter_hook.py
+++ b/backend/tests/sessions/hooks/test_jupyter_hook.py
@@ -17,7 +17,6 @@ def test_jupyter_successful_volume_mount(
     jupyter_tool: tools_models.DatabaseTool,
     configuration_hook_request: hooks_interface.ConfigurationHookRequest,
 ):
-
     class MockOperator:
         # pylint: disable=unused-argument
         def persistent_volume_exists(self, name: str) -> bool:

--- a/backend/tests/sessions/hooks/test_persistent_workspace.py
+++ b/backend/tests/sessions/hooks/test_persistent_workspace.py
@@ -19,9 +19,7 @@ from capellacollab.users.workspaces import models as users_workspaces_models
 def test_persistent_workspace_mounting_not_allowed(
     configuration_hook_request: hooks_interface.ConfigurationHookRequest,
 ):
-    configuration_hook_request.tool.config.persistent_workspaces.mounting_enabled = (
-        False
-    )
+    configuration_hook_request.tool.config.persistent_workspaces.mounting_enabled = False
 
     with pytest.raises(sessions_exceptions.WorkspaceMountingNotAllowedError):
         persistent_workspace.PersistentWorkspaceHook().configuration_hook(

--- a/backend/tests/sessions/k8s_operator/test_session_state.py
+++ b/backend/tests/sessions/k8s_operator/test_session_state.py
@@ -224,7 +224,7 @@ def fixture_pod(
 def test_session_state(
     expected: tuple[
         sessions_models.SessionPreparationState, sessions_models.SessionState
-    ]
+    ],
 ):
     assert operators.get_operator().get_session_state("test") == expected
 

--- a/backend/tests/sessions/test_session_environment.py
+++ b/backend/tests/sessions/test_session_environment.py
@@ -199,7 +199,6 @@ def test_environment_resolution_before_stage(logger: logging.LoggerAdapter):
 
 
 def test_environment_resolution_wrong_stage(logger: logging.LoggerAdapter):
-
     environment = {"TEST": [{"test": "test2"}]}
     rules = {
         "TEST2": tools_models.ToolSessionEnvironment(

--- a/backend/tests/settings/pure_variants/test_pure_variants_license_routes.py
+++ b/backend/tests/settings/pure_variants/test_pure_variants_license_routes.py
@@ -90,7 +90,9 @@ class FakeKubernetesSecretClient:
         return secret
 
     def delete_namespaced_secret(
-        self, name: str, namespace: str  # pylint: disable=unused-argument
+        self,
+        name: str,  # pylint: disable=unused-argument
+        namespace: str,  # pylint: disable=unused-argument
     ):
         self.deleted_secrets_counter += 1
         return kubernetes_client.V1Status()

--- a/backend/tests/settings/test_git_instances.py
+++ b/backend/tests/settings/test_git_instances.py
@@ -101,7 +101,6 @@ def test_delete_git_instance(
 def test_fetch_revisions(
     client: testclient.TestClient,
 ):
-
     response = client.post(
         "/api/v1/settings/modelsources/git/revisions",
         json={

--- a/backend/tests/tools/fixtures.py
+++ b/backend/tests/tools/fixtures.py
@@ -41,7 +41,8 @@ def fixture_tool_nature(
     nature = tools_crud.create_nature(db, tool, "test")
 
     def get_existing_tool_nature(
-        *args, **kwargs  # pylint: disable=unused-argument
+        *args,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> tools_models.DatabaseNature:
         return nature
 

--- a/docs/docs/development/backend/code-style.md
+++ b/docs/docs/development/backend/code-style.md
@@ -22,9 +22,9 @@ Python code. The key differences are:
 - **Linting**: Use [pylint] for static code analysis, and [mypy] for static
   type checking.
 
-- **Formatting**: Use [black] as code auto-formatter. The maximum line length
-  is 79, as per [PEP-8]. This setting should be automatically picked up from
-  the `pyproject.toml` file. The reason for the shorter line length is that it
+- **Formatting**: Use [ruff] as code auto-formatter. The maximum line length is
+  79, as per [PEP-8]. This setting should be automatically picked up from the
+  `pyproject.toml` file. The reason for the shorter line length is that it
   avoids wrapping and overflows in side-by-side split views (e.g. diffs) if
   there's also information displayed to the side of it (e.g. a tree view of the
   modified files).
@@ -36,9 +36,6 @@ Python code. The key differences are:
     requirement to break up long strings into smaller parts. Additionally,
     never break up strings that are presented to the user in e.g. log messages,
     as that makes it significantly harder to grep for them.
-
-    Use [isort] for automatic sorting of imports. Its settings should
-    automatically be picked up from the `pyproject.toml` file as well.
 
 - **Typing**: We do not make an exception for `typing` imports. Instead of
   writing `from typing import SomeName`, use `import typing as t` and access
@@ -56,9 +53,9 @@ Python code. The key differences are:
       `t.Optional[...]` and always explicitly annotate where `None` is
       possible.
 
-- **Python style rules**: For conflicting parts, the [black] code style wins.
-  If you have set up `black` correctly, you don't need to worry about this
-  though :)
+- **Python style rules**: For conflicting parts, the [ruff] code style wins. If
+  you have set up `ruff` correctly, you don't need to worry about this though
+  :)
 - When working with `dict`s, consider using `t.TypedDict` instead of a more
   generic `dict[str, float|int|str]`-like annotation where possible, as the
   latter is much less precise (often requiring additional `assert`s or
@@ -113,6 +110,4 @@ Python code. The key differences are:
 [pep-604]: https://www.python.org/dev/peps/pep-0604/
 [mypy]: https://github.com/python/mypy
 [pylint]: https://github.com/PyCQA/pylint
-[isort]: https://github.com/PyCQA/isort
-[black]:
-    https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html
+[ruff]: https://docs.astral.sh/ruff/


### PR DESCRIPTION
For now, replace black, pyupgrade, and isort with ruff.
In the future, we can also replace pylint with ruff.
Pydocstyle was configured but not actually being run, so it has been removed from the config. It can also be re-added and replaced with ruff in the future.