### PR TITLE
feat: Add `preparation_state` to feedback email

### DIFF
--- a/backend/capellacollab/feedback/models.py
+++ b/backend/capellacollab/feedback/models.py
@@ -57,7 +57,12 @@ class AnonymizedSession(core_pydantic.BaseModel):
 
     version: tools_models.MinimalToolVersionWithTool
 
-    state: str = pydantic.Field(default="UNKNOWN")
+    preparation_state: sessions_models.SessionPreparationState = (
+        pydantic.Field(default=sessions_models.SessionPreparationState.UNKNOWN)
+    )
+    state: sessions_models.SessionState = pydantic.Field(
+        default=sessions_models.SessionState.UNKNOWN
+    )
     warnings: list[core_models.Message] = pydantic.Field(default=[])
 
     connection_method: (

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -96,7 +96,7 @@ def test_send_feedback_with_session(
                             "name": "6.1.0",
                             "tool": {"id": 1, "name": "Capella"},
                         },
-                        "state": "Started",
+                        "state": "Running",
                         "warnings": [],
                         "connection_method": {
                             "id": "xpra",

--- a/frontend/src/app/openapi/model/anonymized-session.ts
+++ b/frontend/src/app/openapi/model/anonymized-session.ts
@@ -10,9 +10,11 @@
  */
 
 import { MinimalToolSessionConnectionMethod } from './minimal-tool-session-connection-method';
+import { SessionState } from './session-state';
 import { SessionType } from './session-type';
 import { Message } from './message';
 import { MinimalToolVersionWithTool } from './minimal-tool-version-with-tool';
+import { SessionPreparationState } from './session-preparation-state';
 
 
 export interface AnonymizedSession { 
@@ -20,7 +22,8 @@ export interface AnonymizedSession {
     type: SessionType;
     created_at: string;
     version: MinimalToolVersionWithTool;
-    state?: string;
+    preparation_state?: SessionPreparationState;
+    state?: SessionState;
     warnings?: Array<Message>;
     connection_method?: MinimalToolSessionConnectionMethod | null;
 }

--- a/frontend/src/app/sessions/session/session-viewer.stories.ts
+++ b/frontend/src/app/sessions/session/session-viewer.stories.ts
@@ -5,6 +5,7 @@
 import { SafeResourceUrl } from '@angular/platform-browser';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { BehaviorSubject } from 'rxjs';
+import { SessionPreparationState, SessionState } from 'src/app/openapi';
 import {
   SessionViewerService,
   ViewerSession,
@@ -116,13 +117,13 @@ export const TwoSessionsTilingPending: Story = {
         mockSessionServiceProvider([
           {
             ...mockPersistentViewerSession,
-            preparation_state: 'Pending',
-            state: 'Pending',
+            preparation_state: SessionPreparationState.Pending,
+            state: SessionState.Pending,
           },
           {
             ...mockReadOnlyViewerSession,
-            preparation_state: 'Completed',
-            state: 'Failed',
+            preparation_state: SessionPreparationState.Completed,
+            state: SessionState.Failed,
           },
         ]),
       ],
@@ -140,8 +141,8 @@ export const OneSessionTilingPending: Story = {
         mockSessionServiceProvider([
           {
             ...mockPersistentViewerSession,
-            preparation_state: 'Completed',
-            state: 'Pending',
+            preparation_state: SessionPreparationState.Completed,
+            state: SessionState.Pending,
           },
         ]),
       ],


### PR DESCRIPTION
The preparation state was not part of the email, only the state.