### PR TITLE
feat: Add internal endpoints for sessions and expose backend

### DIFF
--- a/backend/capellacollab/configuration/app/models.py
+++ b/backend/capellacollab/configuration/app/models.py
@@ -191,6 +191,16 @@ class K8sConfig(BaseConfig):
         description="The name of the IngressClass to use.",
         examples=["traefik", "nginx"],
     )
+    management_portal_namespace: str = pydantic.Field(
+        default="collab-manager",
+        description="The namespace where the management portal is deployed in.",
+        examples=["collab-manager"],
+    )
+    release_name: str = pydantic.Field(
+        default="dev",
+        description="The release name of the Helm chart",
+        examples=["dev", "prod", "test123"],
+    )
 
 
 class GeneralConfig(BaseConfig):

--- a/backend/capellacollab/sessions/models.py
+++ b/backend/capellacollab/sessions/models.py
@@ -42,6 +42,7 @@ class SessionEnvironment(t.TypedDict):
     CAPELLACOLLAB_SESSION_TOKEN: str
     CAPELLACOLLAB_SESSION_ID: str
     CAPELLACOLLAB_SESSION_REQUESTER_USERNAME: str
+    CAPELLACOLLAB_SESSION_REQUESTER_USER_ID: int
     CAPELLACOLLAB_SESSION_CONNECTION_METHOD_TYPE: str
     CAPELLACOLLAB_SESSION_CONTAINER_PORT: str
 
@@ -51,6 +52,7 @@ class SessionEnvironment(t.TypedDict):
     CAPELLACOLLAB_SESSIONS_BASE_PATH: str
 
     CAPELLACOLLAB_ORIGIN_BASE_URL: str
+    CAPELLACOLLAB_API_BASE_URL: str
 
 
 class SessionProvisioningRequest(core_pydantic.BaseModel):
@@ -130,6 +132,12 @@ class Session(core_pydantic.BaseModel):
 
     connection_method_id: str
     connection_method: tools_models.ToolSessionConnectionMethod | None = None
+
+    @pydantic.computed_field  # type: ignore[misc]
+    @property
+    def internal_endpoint(self) -> str:
+        """Internal DNS endpoint of the session for inter-session communication."""
+        return f"{self.id}.{config.k8s.namespace}.svc.cluster.local"
 
     shared_with: list[SessionSharing] = pydantic.Field(default=[])
 

--- a/backend/capellacollab/sessions/util.py
+++ b/backend/capellacollab/sessions/util.py
@@ -67,6 +67,7 @@ def get_environment(
         ),
         "CAPELLACOLLAB_SESSION_ID": session_id,
         "CAPELLACOLLAB_SESSION_REQUESTER_USERNAME": user.name,
+        "CAPELLACOLLAB_SESSION_REQUESTER_USER_ID": user.id,
         "CAPELLACOLLAB_SESSIONS_BASE_PATH": f"/session/{session_id}",
         "CAPELLACOLLAB_SESSION_CONNECTION_METHOD_TYPE": connection_method.type,
         "CAPELLACOLLAB_ORIGIN_BASE_URL": f"{config.general.scheme}://{config.general.host}:{config.general.port}",
@@ -74,6 +75,7 @@ def get_environment(
         "CAPELLACOLLAB_SESSIONS_HOST": config.general.host,
         "CAPELLACOLLAB_SESSIONS_PORT": str(config.general.port),
         "CAPELLACOLLAB_SESSION_CONTAINER_PORT": str(container_port),
+        "CAPELLACOLLAB_API_BASE_URL": f"http://{config.k8s.release_name}-backend.{config.k8s.management_portal_namespace}.svc.cluster.local/api",
     }
 
 

--- a/docs/docs/admin/tools/configuration.md
+++ b/docs/docs/admin/tools/configuration.md
@@ -91,6 +91,11 @@ variables can be used by the tool:
         <td>The username of the user who has requested the session.</td>
     </tr>
     <tr>
+        <td>`CAPELLACOLLAB_SESSION_REQUESTER_USER_ID`</td>
+        <td>`123`</td>
+        <td>The ID of the user who has requested the session.</td>
+    </tr>
+    <tr>
         <td>`CAPELLACOLLAB_SESSION_CONTAINER_PORT`</td>
         <td>`8080`</td>
         <td>
@@ -165,6 +170,13 @@ variables can be used by the tool:
         <td>
             The origin host of the Collaboration Manager.
             The tool has to set the `Content-Security-Policy` header to `frame-ancestors self {CAPELLACOLLAB_ORIGIN_HOST}`. Otherwise, the session viewer can't be used with the tool!
+        </td>
+    </tr>
+    <tr>
+        <td>`CAPELLACOLLAB_API_BASE_URL`</td>
+        <td>`http://dev-backend.collab-manager.svc.cluster.local:/api`</td>
+        <td>
+            The API URL of the Collaboration Manager. The URL is only available from the session itself.
         </td>
     </tr>
     <tr>

--- a/frontend/src/app/openapi/model/session.ts
+++ b/frontend/src/app/openapi/model/session.ts
@@ -35,6 +35,10 @@ export interface Session {
     connection_method: ToolSessionConnectionMethod | null;
     shared_with: Array<SessionSharing>;
     project: SimpleProject | null;
+    /**
+     * Internal DNS endpoint of the session for inter-session communication.
+     */
+    readonly internal_endpoint: string;
 }
 export namespace Session {
 }

--- a/frontend/src/storybook/session.ts
+++ b/frontend/src/storybook/session.ts
@@ -32,6 +32,8 @@ export const mockPersistentSession: Readonly<Session> = {
   state: SessionState.Running,
   owner: mockUser,
   connection_method: { ...mockHttpConnectionMethod, name: 'Xpra' },
+  internal_endpoint:
+    'vfurvsrldxfwwsqdiqvnufonh.collab-sessions.svc.cluster.local',
   warnings: [],
   connection_method_id: 'default',
   shared_with: [],

--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -11,6 +11,9 @@ docker:
 
 k8s:
   namespace: {{ .Values.backend.k8sSessionNamespace }}
+  managementPortalNamespace: {{ .Release.Namespace }}
+  releaseName: {{ .Release.Name }}
+
   {{- if .Values.cluster.namespaces.sessions.ingressClassName }}
   ingressClassName: {{ .Values.cluster.namespaces.sessions.ingressClassName }}
   {{- end }}

--- a/helm/templates/backend/backend.networkpolicy.yaml
+++ b/helm/templates/backend/backend.networkpolicy.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-{{- .Values.backend.k8sSessionNamespace -}}-to-backend
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      id: {{ .Release.Name }}-deployment-backend
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.backend.k8sSessionNamespace }}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
The internal endpoints can be received via the API for inter-session communication.

A new network route is available between sessions and the backend. This enables sessions to use the backend API.

Two new pre-defined variables were added:
- `CAPELLACOLLAB_API_BASE_URL`
- `CAPELLACOLLAB_SESSION_REQUESTER_USER_ID`

This enables sessions to talk to other sessions more easily. For example, this is a small script to send a request to another session. The personal access token has to be replaced manually (until #1774 is implemeted). 

```py
import os
import requests

backend_url = os.getenv("CAPELLACOLLAB_API_BASE_URL")
user_id = os.getenv("CAPELLACOLLAB_SESSION_REQUESTER_USER_ID")
username = os.getenv("CAPELLACOLLAB_SESSION_REQUESTER_USERNAME")

response = requests.get(f"{backend_url}/v1/users/{user_id}/sessions", auth=(username, "ENTER_YOUR_PAT_HERE"))

internal_endpoint = response.json()[0]["internal_endpoint"]
requests.get(f"http://{internal_endpoint}").content
```