### PR TITLE
feat: Rework Monaco editor integration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,9 @@
         "marked-highlight": "^2.2.1",
         "marked-mangle": "^1.1.10",
         "monaco-editor": "^0.52.2",
+        "monaco-yaml": "^5.2.3",
         "ngx-markdown": "^19.0.0",
+        "ngx-monaco-editor-v2": "^19.0.2",
         "ngx-skeleton-loader": "^9.0.0",
         "ngx-toastr": "^19.0.0",
         "npm": "^11.0.0",
@@ -41,6 +43,7 @@
         "storycap": "^5.0.1",
         "tslib": "^2.8.1",
         "uuid": "^11.0.5",
+        "vscode-uri": "^3.0.8",
         "yaml": "^2.7.0",
         "zone.js": "^0.15.0"
       },
@@ -84,6 +87,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
         "typescript-eslint": "8.21.0",
+        "vite-plugin-static-copy": "^2.2.0",
         "vite-tsconfig-paths": "^5.1.4"
       }
     },
@@ -19857,7 +19861,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -21595,6 +21598,78 @@
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "license": "MIT"
     },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
+      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0",
+        "vscode-uri": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-marker-data-provider": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.4.tgz",
+      "integrity": "sha512-4DsPgsAqpTyUDs3humXRBPUJoihTv+L6v9aupQWD80X2YXaCXUd11mWYeSCYHuPgdUmjFaNWCEOjQ6ewf/QA1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.0.tgz",
+      "integrity": "sha512-aWK7SN9hAqNYi0WosPoMjenMeXJjwCxDibOqWffyQ/qXdzB/86xshGQobRferfmNz7BSNQ8GB0MD0oby9/5fTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-worker-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
+      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.3.0.tgz",
+      "integrity": "sha512-BxRgK21kBMx5JpP+LAXsME4TTCtkIDiOJkvuCH2XOdxwKYIYahDWA29OoavbmzsuYDFbEeSTnqsYjLQtdis2CQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "path-browserify": "^1.0.0",
+        "prettier": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -21798,6 +21873,20 @@
         "marked": "^15.0.0",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
+      }
+    },
+    "node_modules/ngx-monaco-editor-v2": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/ngx-monaco-editor-v2/-/ngx-monaco-editor-v2-19.0.2.tgz",
+      "integrity": "sha512-hkPiCnLU0vdIF2DW7Ko/EHoGCtLxuN85eygKuk3fXL2GRbEIl5VcbUXmRX9ItfLOI1F5QcH80HhavY5r0gNfEw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^19.0.4",
+        "@angular/core": "^19.0.4",
+        "monaco-editor": "^0.52.2"
       }
     },
     "node_modules/ngx-skeleton-loader": {
@@ -26490,7 +26579,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-data-parser": {
@@ -27662,7 +27750,6 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -33394,6 +33481,104 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.2.0.tgz",
+      "integrity": "sha512-ytMrKdR9iWEYHbUxs6x53m+MRl4SJsOSoMu1U1+Pfg0DjPeMlsRVx3RR5jvoonineDquIue83Oq69JvNsFSU5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite-plugin-static-copy/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
@@ -33989,6 +34174,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/vscode-languageserver": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
@@ -34002,47 +34196,33 @@
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
-    "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+    "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
       "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "vscode-jsonrpc": "8.2.0",
         "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
       "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,9 @@
     "marked-highlight": "^2.2.1",
     "marked-mangle": "^1.1.10",
     "monaco-editor": "^0.52.2",
+    "monaco-yaml": "^5.2.3",
     "ngx-markdown": "^19.0.0",
+    "ngx-monaco-editor-v2": "^19.0.2",
     "ngx-skeleton-loader": "^9.0.0",
     "ngx-toastr": "^19.0.0",
     "npm": "^11.0.0",
@@ -48,6 +50,7 @@
     "storycap": "^5.0.1",
     "tslib": "^2.8.1",
     "uuid": "^11.0.5",
+    "vscode-uri": "^3.0.8",
     "yaml": "^2.7.0",
     "zone.js": "^0.15.0"
   },
@@ -91,6 +94,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",
     "typescript-eslint": "8.21.0",
+    "vite-plugin-static-copy": "^2.2.0",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "overrides": {

--- a/frontend/src/app/helpers/editor/editor.component.html
+++ b/frontend/src/app/helpers/editor/editor.component.html
@@ -3,7 +3,13 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<div #editorRef [style.height]="height"></div>
+<ngx-monaco-editor
+  [style.height]="height()"
+  [options]="options"
+  [(ngModel)]="code"
+  [model]="editorModel()"
+  (onInit)="onInit($event)"
+></ngx-monaco-editor>
 
 <span class="size-0 text-xs text-gray-600">
   <em>Hint: You can also save the content by pressing 'CTRL' + 'S'</em>

--- a/frontend/src/app/settings/core/configuration-settings/configuration-settings.component.html
+++ b/frontend/src/app/settings/core/configuration-settings/configuration-settings.component.html
@@ -3,7 +3,12 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
-<app-editor height="70vh" #editor (submitted)="submitValue($event)" />
+<app-editor
+  height="70vh"
+  #editor
+  (submitted)="submitValue($event)"
+  type="globalconfig"
+/>
 <div class="m-2 flex gap-2">
   <button mat-stroked-button (click)="editor.submitValue()" color="primary">
     <span>Save</span>

--- a/frontend/src/app/settings/core/configuration-settings/configuration-settings.component.ts
+++ b/frontend/src/app/settings/core/configuration-settings/configuration-settings.component.ts
@@ -31,7 +31,7 @@ export class ConfigurationSettingsComponent implements OnInit {
 
   fetchConfiguration() {
     this.configurationSettingsService.getConfiguration().subscribe((data) => {
-      this.editor!.value = data;
+      this.editor!.setValue(data);
     });
   }
 

--- a/frontend/src/app/settings/core/tools-settings/create-tool/create-tool.component.html
+++ b/frontend/src/app/settings/core/tools-settings/create-tool/create-tool.component.html
@@ -8,7 +8,12 @@
 >
   <div>
     <h2 class="text-lg font-medium">Common</h2>
-    <app-editor height="500px" (submitted)="submitValue($event)" #editor />
+    <app-editor
+      height="500px"
+      (submitted)="submitValue($event)"
+      #editor
+      type="tool"
+    />
   </div>
   <div class="mt-2 flex flex-wrap justify-between gap-2">
     <button mat-stroked-button (click)="editor.resetValue()">

--- a/frontend/src/app/settings/core/tools-settings/create-tool/create-tool.component.ts
+++ b/frontend/src/app/settings/core/tools-settings/create-tool/create-tool.component.ts
@@ -26,7 +26,7 @@ export class CreateToolComponent {
     private route: ActivatedRoute,
   ) {
     this.toolsService.getDefaultTool().subscribe((tool) => {
-      this.editor!.value = tool;
+      this.editor!.setValue(tool);
     });
   }
 

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-details.component.html
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-details.component.html
@@ -13,7 +13,12 @@
           hyperlink="create_tool"
         ></app-api-documentation>
       </div>
-      <app-editor height="500px" (submitted)="submitValue($event)" #editor />
+      <app-editor
+        height="500px"
+        (submitted)="submitValue($event)"
+        #editor
+        type="tool"
+      />
     </div>
     <div class="mt-2 flex flex-wrap justify-between gap-2">
       <button mat-stroked-button (click)="deleteTool()" color="warn">

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-details.component.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-details.component.ts
@@ -58,7 +58,7 @@ export class ToolDetailsComponent {
         next: (tool) => {
           this.breadcrumbsService.updatePlaceholder({ tool });
           this.selectedTool = tool;
-          this.editor!.value = this.selectedTool;
+          this.editor!.setValue(this.selectedTool);
         },
       });
   }
@@ -73,7 +73,7 @@ export class ToolDetailsComponent {
             'Tool updated',
             `The configuration of the tool '${tool.name}' has been updated successfully.`,
           );
-          this.editor!.value = tool;
+          this.editor!.setValue(tool);
           this.breadcrumbsService.updatePlaceholder({ tool });
         }),
       )

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-nature/tool-nature.component.html
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-nature/tool-nature.component.html
@@ -21,6 +21,7 @@
         context="new"
         height="calc(500px - 48px)"
         (submitted)="submittedNewToolNature($event)"
+        type="toolnature"
       />
       <div class="mt-2 flex flex-wrap justify-between gap-2">
         <div class="w-[100px]"></div>
@@ -46,6 +47,7 @@
           [context]="nature.id.toString()"
           height="calc(500px - 48px)"
           [value]="nature"
+          type="toolnature"
         />
         <div class="mt-2 flex flex-wrap justify-between gap-2">
           <button

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-nature/tool-nature.component.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-nature/tool-nature.component.ts
@@ -51,7 +51,7 @@ export class ToolNatureComponent {
       this.toolsService
         .getDefaultToolNature(this._tool!.id)
         .subscribe((nature) => {
-          this.getEditorForContext('new')!.value = nature;
+          this.getEditorForContext('new')!.setValue(nature);
         });
       this.toolsService
         .getToolNatures(this._tool.id)
@@ -73,7 +73,7 @@ export class ToolNatureComponent {
   ) {}
 
   getEditorForContext(context: string) {
-    return this.editorRefs?.find((editor) => editor.context === context);
+    return this.editorRefs?.find((editor) => editor.context() === context);
   }
 
   resetValue(context: string) {
@@ -98,7 +98,9 @@ export class ToolNatureComponent {
         );
 
         this.toolNatures![natureIdx!] = toolNature;
-        this.getEditorForContext(toolNature.id.toString())!.value = toolNature;
+        this.getEditorForContext(toolNature.id.toString())!.setValue(
+          toolNature,
+        );
       });
   }
 

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-version/tool-version.component.html
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-version/tool-version.component.html
@@ -20,6 +20,7 @@
         #editorRef
         context="new"
         height="calc(500px - 48px)"
+        type="toolversion"
         (submitted)="submittedNewToolVersion($event)"
       />
       <div class="mt-2 flex flex-wrap justify-between gap-2">
@@ -46,6 +47,7 @@
           [context]="version.id.toString()"
           height="calc(500px - 48px)"
           [value]="version"
+          type="toolversion"
         />
         <div class="mt-2 flex flex-wrap justify-between gap-2">
           <button

--- a/frontend/src/app/settings/core/tools-settings/tool-details/tool-version/tool-version.component.ts
+++ b/frontend/src/app/settings/core/tools-settings/tool-details/tool-version/tool-version.component.ts
@@ -52,7 +52,7 @@ export class ToolVersionComponent {
       this.toolsService
         .getDefaultToolVersion(this._tool!.id)
         .subscribe((version) => {
-          this.getEditorForContext('new')!.value = version;
+          this.getEditorForContext('new')!.setValue(version);
         });
       this.toolsService
         .getToolVersions(this._tool.id)
@@ -75,7 +75,7 @@ export class ToolVersionComponent {
   ) {}
 
   getEditorForContext(context: string) {
-    return this.editorRefs?.find((editor) => editor.context === context);
+    return this.editorRefs?.find((editor) => editor.context() === context);
   }
 
   resetValue(context: string) {
@@ -100,8 +100,9 @@ export class ToolVersionComponent {
         );
 
         this.toolVersions![versionIdx!] = toolVersion;
-        this.getEditorForContext(toolVersion.id.toString())!.value =
-          toolVersion;
+        this.getEditorForContext(toolVersion.id.toString())!.setValue(
+          toolVersion,
+        );
       });
   }
 

--- a/frontend/src/app/yaml.worker.js
+++ b/frontend/src/app/yaml.worker.js
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "monaco-yaml/yaml.worker.js";

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -11,7 +11,6 @@
 @import "@fontsource/roboto/700.css";
 @import "@fontsource/material-symbols-outlined/400.css";
 @import "@angular/material/prebuilt-themes/indigo-pink.css";
-@import "monaco-editor/min/vs/editor/editor.main.css";
 @import "./../node_modules/ngx-toastr/toastr.css";
 
 @tailwind base;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@
  */
 import analog from '@analogjs/platform';
 import { defineConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
@@ -23,6 +24,14 @@ export default defineConfig(() => {
         prerender: {
           routes: [],
         },
+      }),
+      viteStaticCopy({
+        targets: [
+          {
+            src: 'node_modules/monaco-editor/**/*',
+            dest: 'assets/monaco',
+          },
+        ],
       }),
       viteTsConfigPaths(),
     ],


### PR DESCRIPTION
Until now, we were importing Monaco directly which massively increased our bundle size. By moving to
 ngx-monaco-editor-v2, Monaco is loaded on-demand. Also add support for monaco-yaml, which provides
 Intellisense for our yaml configs using OpenAPI schemas. This is also our first component using
 signals.

 Closes #2089