### PR TITLE
refactor: Use Zod for Session History

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,7 @@
         "tslib": "^2.8.1",
         "uuid": "^11.0.5",
         "yaml": "^2.7.0",
+        "zod": "^3.24.1",
         "zone.js": "^0.15.0"
       },
       "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "tslib": "^2.8.1",
     "uuid": "^11.0.5",
     "yaml": "^2.7.0",
+    "zod": "^3.24.1",
     "zone.js": "^0.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use Zod for validating the session history from localStorage. This is simpler and less error-prone than doing it manually, and also prepares us for implementing more features built on storing data in localStorage (like favorites).