### PR TITLE
ci: Downgrade to reg-actions v2

### DIFF
--- a/.github/workflows/storybook-diff.yml
+++ b/.github/workflows/storybook-diff.yml
@@ -20,7 +20,7 @@ jobs:
           npx storycap http://localhost:6006 --serverCmd "npx -p @angular/cli
           ng run capellacollab:storybook" --flat
         working-directory: ./frontend
-      - uses: reg-viz/reg-actions@v3
+      - uses: reg-viz/reg-actions@v2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           image-directory-path: './frontend/__screenshots__'


### PR DESCRIPTION
There is another error with v2 (`Error: Cannot copy __reg__/0_diff/General components_404 (Not Found)_Not Found_desktop.png: the file doesn't exist`), but at least the report in generated in the artifacts and can be downloaded. 
Check this issue for more information about the v3 issue: https://github.com/reg-viz/reg-actions/issues/178