### PR TITLE
feat: Set Cache-Control header on static assets

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -21,6 +21,11 @@ http {
         server_name _;
         root /usr/share/nginx/html;
         index index.html;
+
+        location /assets/ {
+            add_header Cache-Control "public, max-age=31536000, immutable";
+        }
+
         location / {
             try_files $uri $uri/ /index.html;
         }


### PR DESCRIPTION
Assets inside the /assets/ folder are immutable, so they can be cached by browsers forever to increase performance.

Closes #2141