### PR TITLE
ci: Build storybook for diffing

### DIFF
--- a/.github/workflows/storybook-diff.yml
+++ b/.github/workflows/storybook-diff.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Install dependencies
         run: npm install storycap puppeteer http-server
         working-directory: ./frontend
+      - name: Build Storybook
+        run: npm run build-storybook
+        working-directory: ./frontend
       - name: Capture screenshots
         run:
-          npx storycap http://localhost:6006 --serverCmd "npx -p @angular/cli
-          ng run capellacollab:storybook" --flat
+          npx storycap --serverCmd "npx http-server storybook-static -p 9001" http://localhost:9001
         working-directory: ./frontend
       - uses: reg-viz/reg-actions@v2
         with:

--- a/.github/workflows/storybook-publish.yml
+++ b/.github/workflows/storybook-publish.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
         working-directory: ./frontend
       - name: Build Storybook
-        run: npx -p @angular/cli ng run capellacollab:build-storybook
+        run: npm run build-storybook
         working-directory: ./frontend
       - name: Run Chromatic
         id: chromatic

--- a/frontend/src/app/general/404/404.stories.ts
+++ b/frontend/src/app/general/404/404.stories.ts
@@ -6,7 +6,7 @@ import { Meta, StoryObj } from '@storybook/angular';
 import { PageNotFoundComponent } from './404.component';
 
 const meta: Meta<PageNotFoundComponent> = {
-  title: 'General components/404 (Not Found)',
+  title: 'General Components/404 (Not Found)',
   component: PageNotFoundComponent,
 };
 


### PR DESCRIPTION
We've had issues with storybook diff captures timing out due to the long startup time of storybook. By building storybook first, then running storycap on the static build output, we can avoid these timeouts.