### PR TITLE
feat: Fix loading of project users on project change

### DIFF
--- a/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
+++ b/frontend/src/app/projects/project-detail/project-users/service/project-user.service.ts
@@ -125,15 +125,16 @@ export class ProjectUserService {
     this._projectUsers.next(undefined);
     combineLatest([
       this.projectWrapperService.project$.pipe(filter(Boolean)),
-      this.projectUser$.pipe(
+      this.projectUser$,
+    ])
+      .pipe(
+        filter(Boolean),
         filter(
-          (projectUser) =>
+          ([_, projectUser]) =>
             projectUser?.role === 'manager' ||
             projectUser?.role === 'administrator',
         ),
-      ),
-    ])
-      .pipe(filter(Boolean))
+      )
       .subscribe(([project, _]) => {
         this.loadProjectUsers(project.slug);
       });


### PR DESCRIPTION
When changing the project from a project with project admin privileges to a project without project admin permissions, it still tried to load the project users, which led to an error.