### PR TITLE
build: Use `uv` for Python installation in backend Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,44 +1,51 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE=python:3.12-slim-bookworm
+ARG BASE_IMAGE=debian:bookworm-slim
 FROM $BASE_IMAGE
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 ENV SHELL=/bin/bash
 
+EXPOSE 8000
+
 USER root
 
-RUN apt-get update && \
-    apt-get upgrade --yes && \
-    apt-get install --yes \
-    ca-certificates \
-    git-lfs \
-    libpq-dev \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+ENV UV_UNMANAGED_INSTALL=/usr/bin/
+ENV UV_PYTHON_INSTALL_DIR=/etc/python
 
-EXPOSE 8000
-COPY . /tmp/backend
-COPY .git_archival.txt /tmp/.git_archival.txt
+RUN apt-get update\
+    && apt-get upgrade --yes \
+    && apt-get install --yes \
+    ca-certificates \
+    curl \
+    git \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && sh /uv-installer.sh && rm /uv-installer.sh
+
+ENV PATH="/usr/bin/:$PATH"
+WORKDIR /opt/backend
+
+RUN uv python install 3.12 --preview \
+    && ln -s /etc/python/*/bin/python /usr/bin/python \
+    && ln -s /etc/python/*/bin/python /usr/bin/python3 \
+    && uv venv
+
+COPY . /opt/backend
+COPY .git_archival.txt /opt/.git_archival.txt
 COPY startup.sh /opt/.startup.sh
 
-# Activate venv
-RUN ln -s "$(which python3.12)" /usr/bin/python && \
-    ln -sf "$(which python3.12)" /usr/bin/python3 && \
-    python -m venv /opt/.venv
-ENV _OLD_VIRTUAL_PATH="$PATH"
-ENV VIRTUAL_ENV=/opt/.venv
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-WORKDIR /tmp/backend
-RUN pip install . && chmod +x "$VIRTUAL_ENV/lib/python3.12/site-packages/capellacollab/settings/modelsources/git/askpass.py"
-
-RUN mkdir -p /var/log/backend && \
-    chmod -R 777 /var/log/backend
+RUN uv pip install . && chmod +x ".venv/lib/python3.12/site-packages/capellacollab/settings/modelsources/git/askpass.py" \
+    && mkdir -p /var/log/backend \
+    && chmod -R 777 /var/log/backend \
+    && chmod 777 /opt/.startup.sh \
+    && chmod -R 777 /opt/backend
 
 # Mount a config.yaml into this directory
 VOLUME [ "/etc/capellacollab" ]
 
-RUN chmod 777 /opt/.startup.sh
-CMD ["/opt/.startup.sh"]
+USER 1001
+
+ENTRYPOINT ["/opt/.startup.sh"]

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -7,4 +7,4 @@ set -e
 # When running inside the cluster, the k8s service host should not use the proxy
 export no_proxy=$no_proxy,$KUBERNETES_SERVICE_HOST,$no_proxy_additional,svc.cluster.local
 export NO_PROXY=$NO_PROXY,$KUBERNETES_SERVICE_HOST,$no_proxy_additional,svc.cluster.local
-uvicorn capellacollab.__main__:app --host 0.0.0.0 --forwarded-allow-ips '*'
+/opt/backend/.venv/bin/uvicorn capellacollab.__main__:app --host 0.0.0.0 --forwarded-allow-ips '*'


### PR DESCRIPTION
Use `uv` for the Python installation in the backend Docker image. This restores compatibility with the debian:bookworm-slim image, which was used in the Gitlab CI template.