### PR TITLE
fix: Make sure gzip is applied to js files

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,7 +17,7 @@ http {
     access_log /var/log/nginx/nginx-frontend.log;
 
     gzip on;
-    gzip_types text/plain text/css application/json text/xml application/xml text/javascript;
+    gzip_types text/plain text/css application/json text/xml application/xml application/javascript text/javascript;
     gzip_min_length 256;
     gzip_comp_level 5;
     gzip_vary on;


### PR DESCRIPTION
We removed the application/javascript filetype because it's considered legacy. Unfortunately, nginx uses it to decide if it should compress .js files so they weren't being compressed.