### PR TITLE
ci: Change `pnpm` to `npm` in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: 'weekly'
   # Frontend
-  - package-ecosystem: 'pnpm'
+  - package-ecosystem: 'npm'
     directory: '/frontend'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Even though we use `pnpm`, the value has to be `npm` as per docs