### PR TITLE
fix: Don't show seconds for estimated session termination

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/session-card/session-card.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/session-card/session-card.component.html
@@ -71,6 +71,7 @@
           This session will automatically terminate
           <app-relative-time
             [date]="addMinutes(Date.now(), remainingMinutes)"
+            dateFormat="PPp"
           />
           if you do not interact with it.
         </div>


### PR DESCRIPTION
The shown seconds were not accurate.
Show minutes instead.