### PR TITLE
build: Downgrade pnpm

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,5 +109,5 @@
     }
   },
   "type": "module",
-  "packageManager": "pnpm@10.2.1"
+  "packageManager": "pnpm@9.15.5"
 }


### PR DESCRIPTION
This reverts parts of commit 4f9979a8864e81e77f24e6063f5407594262cede.
Puppeteer doesn't work with pnpm 10.