### PR TITLE
fix: Add uniqueness constraint for project users

### DIFF
--- a/backend/capellacollab/alembic/versions/16a64401737c_add_uniqueness_constraint_for_project_.py
+++ b/backend/capellacollab/alembic/versions/16a64401737c_add_uniqueness_constraint_for_project_.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add uniqueness constraint for project users
+
+Revision ID: 16a64401737c
+Revises: 8731ac0b284e
+Create Date: 2025-02-10 16:19:52.570927
+
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+LOGGER = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = "16a64401737c"
+down_revision = "8731ac0b284e"
+branch_labels = None
+depends_on = None
+
+t_project_user_association = sa.Table(
+    "project_user_association",
+    sa.MetaData(),
+    sa.Column("user_id", sa.Integer),
+    sa.Column("project_id", sa.Integer),
+    sa.Column("role", sa.String),
+    sa.Column("permission", sa.String),
+)
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    constraint = insp.get_pk_constraint("project_user_association")
+
+    if (
+        constraint["name"]
+        and "project_user_association_pkey" == constraint["name"]
+    ):
+        # The database looks correct, nothing to do
+        return
+
+    project_user_combinations = []
+    users_to_create = {}
+
+    for project_user in (
+        bind.execute(sa.select(t_project_user_association)).mappings().all()
+    ):
+        project_user_tuple = (
+            project_user["user_id"],
+            project_user["project_id"],
+        )
+        if project_user_tuple in project_user_combinations:
+            # User is part of the project multiple times
+
+            LOGGER.info("Found duplicated user %s", project_user_tuple)
+
+            bind.execute(
+                sa.delete(t_project_user_association)
+                .where(
+                    t_project_user_association.c.user_id
+                    == project_user["user_id"]
+                )
+                .where(
+                    t_project_user_association.c.project_id
+                    == project_user["project_id"]
+                )
+            )
+            users_to_create[project_user_tuple] = project_user
+        else:
+            project_user_combinations.append(project_user_tuple)
+
+    for user in users_to_create.values():
+        LOGGER.info("Recreating user: %s", user)
+        bind.execute(
+            t_project_user_association.insert().values(
+                user_id=user["user_id"],
+                project_id=user["project_id"],
+                role=user["role"],
+                permission=user["permission"],
+            )
+        )
+
+    LOGGER.info("Creating primary key 'project_user_association_pkey'")
+    op.create_primary_key(
+        "project_user_association_pkey",
+        "project_user_association",
+        ["user_id", "project_id"],
+    )

--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -48,8 +48,12 @@ def get_common_projects_for_users(
     user1: users_models.DatabaseUser,
     user2: users_models.DatabaseUser,
 ) -> abc.Sequence[models.DatabaseProject]:
-    user1_table = orm.aliased(project_users_models.ProjectUserAssociation)
-    user2_table = orm.aliased(project_users_models.ProjectUserAssociation)
+    user1_table = orm.aliased(
+        project_users_models.DatabaseProjectUserAssociation
+    )
+    user2_table = orm.aliased(
+        project_users_models.DatabaseProjectUserAssociation
+    )
 
     return (
         db.execute(

--- a/backend/capellacollab/projects/models.py
+++ b/backend/capellacollab/projects/models.py
@@ -22,7 +22,9 @@ if t.TYPE_CHECKING:
     from capellacollab.projects.tools.models import (
         DatabaseProjectToolAssociation,
     )
-    from capellacollab.projects.users.models import ProjectUserAssociation
+    from capellacollab.projects.users.models import (
+        DatabaseProjectUserAssociation,
+    )
 
 
 class UserMetadata(core_pydantic.BaseModel):
@@ -134,7 +136,7 @@ class DatabaseProject(database.Base):
         default=ProjectType.GENERAL
     )
 
-    users: orm.Mapped[list[ProjectUserAssociation]] = orm.relationship(
+    users: orm.Mapped[list[DatabaseProjectUserAssociation]] = orm.relationship(
         default_factory=list, back_populates="project"
     )
     tokens: orm.Mapped[list[DatabaseProjectPATAssociation]] = orm.relationship(

--- a/backend/capellacollab/projects/permissions/permissions.py
+++ b/backend/capellacollab/projects/permissions/permissions.py
@@ -33,7 +33,7 @@ def inherit_global_permissions(
 
 def derive_project_permissions_from_role(
     project: projects_models.DatabaseProject,
-    project_user: projects_users_models.ProjectUserAssociation | None,
+    project_user: projects_users_models.DatabaseProjectUserAssociation | None,
     user: users_models.DatabaseUser,
 ) -> models.ProjectUserScopes:
     read_only_permissions = models.ProjectUserScopes(

--- a/backend/capellacollab/projects/users/crud.py
+++ b/backend/capellacollab/projects/users/crud.py
@@ -13,11 +13,11 @@ def get_project_user_association_or_raise(
     db: orm.Session,
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
-) -> models.ProjectUserAssociation:
+) -> models.DatabaseProjectUserAssociation:
     return db.execute(
-        sa.select(models.ProjectUserAssociation)
-        .where(models.ProjectUserAssociation.project == project)
-        .where(models.ProjectUserAssociation.user == user)
+        sa.select(models.DatabaseProjectUserAssociation)
+        .where(models.DatabaseProjectUserAssociation.project == project)
+        .where(models.DatabaseProjectUserAssociation.user == user)
     ).scalar_one()
 
 
@@ -25,7 +25,7 @@ def get_project_user_association(
     db: orm.Session,
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
-) -> models.ProjectUserAssociation | None:
+) -> models.DatabaseProjectUserAssociation | None:
     try:
         return get_project_user_association_or_raise(db, project, user)
     except exc.NoResultFound:
@@ -38,8 +38,8 @@ def add_user_to_project(
     user: users_models.DatabaseUser,
     role: models.ProjectUserRole,
     permission: models.ProjectUserPermission,
-) -> models.ProjectUserAssociation:
-    association = models.ProjectUserAssociation(
+) -> models.DatabaseProjectUserAssociation:
+    association = models.DatabaseProjectUserAssociation(
         role=role,
         permission=permission,
         project=project,
@@ -55,7 +55,7 @@ def change_role_of_user_in_project(
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
     role: models.ProjectUserRole,
-) -> models.ProjectUserAssociation:
+) -> models.DatabaseProjectUserAssociation:
     association = get_project_user_association_or_raise(db, project, user)
     association.role = role
     db.commit()
@@ -67,7 +67,7 @@ def change_permission_of_user_in_project(
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
     permission: models.ProjectUserPermission,
-) -> models.ProjectUserAssociation:
+) -> models.DatabaseProjectUserAssociation:
     association = get_project_user_association_or_raise(db, project, user)
     association.permission = permission
     db.commit()
@@ -80,9 +80,9 @@ def delete_user_from_project(
     user: users_models.DatabaseUser,
 ):
     db.execute(
-        sa.delete(models.ProjectUserAssociation)
-        .where(models.ProjectUserAssociation.user == user)
-        .where(models.ProjectUserAssociation.project == project)
+        sa.delete(models.DatabaseProjectUserAssociation)
+        .where(models.DatabaseProjectUserAssociation.user == user)
+        .where(models.DatabaseProjectUserAssociation.project == project)
     )
     db.commit()
 
@@ -91,8 +91,8 @@ def delete_users_from_project(
     db: orm.Session, project: projects_models.DatabaseProject
 ):
     db.execute(
-        sa.delete(models.ProjectUserAssociation).where(
-            models.ProjectUserAssociation.project_id == project.id
+        sa.delete(models.DatabaseProjectUserAssociation).where(
+            models.DatabaseProjectUserAssociation.project_id == project.id
         )
     )
     db.commit()
@@ -100,8 +100,8 @@ def delete_users_from_project(
 
 def delete_projects_for_user(db: orm.Session, user_id: int):
     db.execute(
-        sa.delete(models.ProjectUserAssociation).where(
-            models.ProjectUserAssociation.user_id == user_id
+        sa.delete(models.DatabaseProjectUserAssociation).where(
+            models.DatabaseProjectUserAssociation.user_id == user_id
         )
     )
     db.commit()

--- a/backend/capellacollab/projects/users/models.py
+++ b/backend/capellacollab/projects/users/models.py
@@ -54,7 +54,7 @@ class PatchProjectUser(core_pydantic.BaseModel):
     reason: str
 
 
-class ProjectUserAssociation(database.Base):
+class DatabaseProjectUserAssociation(database.Base):
     __tablename__ = "project_user_association"
 
     user_id: orm.Mapped[int] = orm.mapped_column(

--- a/backend/capellacollab/projects/users/routes.py
+++ b/backend/capellacollab/projects/users/routes.py
@@ -33,7 +33,7 @@ router = fastapi.APIRouter()
 def check_user_not_in_project(
     project: projects_models.DatabaseProject, user: users_models.DatabaseUser
 ):
-    if user in project.users:
+    if user in [user.user for user in project.users]:
         raise exceptions.ProjectUserAlreadyExistsError(user.name, project.slug)
 
 
@@ -41,7 +41,7 @@ def get_project_user_association_or_raise(
     db: orm.Session,
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
-) -> models.ProjectUserAssociation | models.ProjectUser:
+) -> models.DatabaseProjectUserAssociation | models.ProjectUser:
     if project_user := crud.get_project_user_association(db, project, user):
         return project_user
 
@@ -66,7 +66,7 @@ def get_current_project_user(
         projects_injectables.get_existing_project
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> models.ProjectUserAssociation | models.ProjectUser:
+) -> models.DatabaseProjectUserAssociation | models.ProjectUser:
     """Get the current project users"""
     if user.role == users_models.Role.ADMIN:
         return models.ProjectUser(
@@ -130,7 +130,7 @@ def add_user_to_project(
         users_injectables.get_own_user
     ),
     db: orm.Session = fastapi.Depends(database.get_db),
-) -> models.ProjectUserAssociation:
+) -> models.DatabaseProjectUserAssociation:
     if not (
         user := users_crud.get_user_by_name(db, post_project_user.username)
     ):

--- a/backend/capellacollab/settings/modelsources/t4c/instance/repositories/crud.py
+++ b/backend/capellacollab/settings/modelsources/t4c/instance/repositories/crud.py
@@ -106,10 +106,12 @@ def _get_user_write_t4c_repositories(
         .where(projects_models.DatabaseProject.is_archived.is_(False))
         .join(projects_models.DatabaseProject.users)
         .where(
-            projects_users_models.ProjectUserAssociation.permission
+            projects_users_models.DatabaseProjectUserAssociation.permission
             == projects_users_models.ProjectUserPermission.WRITE
         )
-        .where(projects_users_models.ProjectUserAssociation.user == user)
+        .where(
+            projects_users_models.DatabaseProjectUserAssociation.user == user
+        )
         .distinct()
     )
 

--- a/backend/capellacollab/users/models.py
+++ b/backend/capellacollab/users/models.py
@@ -17,7 +17,9 @@ from ..permissions import models
 
 if t.TYPE_CHECKING:
     from capellacollab.events.models import DatabaseUserHistoryEvent
-    from capellacollab.projects.users.models import ProjectUserAssociation
+    from capellacollab.projects.users.models import (
+        DatabaseProjectUserAssociation,
+    )
     from capellacollab.sessions.models import DatabaseSession
     from capellacollab.users.tokens.models import DatabaseUserToken
 
@@ -172,8 +174,8 @@ class DatabaseUser(database.Base):
         default=datetime.datetime.now(datetime.UTC)
     )
 
-    projects: orm.Mapped[list[ProjectUserAssociation]] = orm.relationship(
-        default_factory=list, back_populates="user"
+    projects: orm.Mapped[list[DatabaseProjectUserAssociation]] = (
+        orm.relationship(default_factory=list, back_populates="user")
     )
     sessions: orm.Mapped[list[DatabaseSession]] = orm.relationship(
         default_factory=list, back_populates="owner"

--- a/backend/tests/projects/test_projects_permissions.py
+++ b/backend/tests/projects/test_projects_permissions.py
@@ -68,7 +68,7 @@ def test_project_permission_validation_injectable_fails_with_insufficient_permis
 def test_project_permission_validation_injectable_passes(
     id_token: str,
     project: projects_models.DatabaseProject,
-    project_user: projects_users_models.ProjectUserAssociation,
+    project_user: projects_users_models.DatabaseProjectUserAssociation,
 ):
     """Test that the project permission validation passes if permissions are sufficient"""
     project_user.role = projects_users_models.ProjectUserRole.MANAGER

--- a/backend/tests/projects/toolmodels/pipelines/pipeline-runs/conftest.py
+++ b/backend/tests/projects/toolmodels/pipelines/pipeline-runs/conftest.py
@@ -9,20 +9,20 @@ from sqlalchemy import orm
 import capellacollab.projects.toolmodels.backups.models as pipeline_models
 import capellacollab.projects.toolmodels.backups.runs.crud as pipeline_runs_crud
 import capellacollab.projects.toolmodels.backups.runs.models as pipeline_runs_models
-import capellacollab.users.models as users_models
+import capellacollab.projects.users.models as projects_users_models
 
 
 @pytest.fixture(name="pipeline_run")
 def fixture_pipeline_run(
     db: orm.Session,
     pipeline: pipeline_models.DatabaseBackup,
-    project_manager: users_models.DatabaseUser,
+    project_manager: projects_users_models.DatabaseProjectUserAssociation,
 ) -> pipeline_runs_models.DatabasePipelineRun:
     pipeline_run = pipeline_runs_models.DatabasePipelineRun(
         reference_id="undefined",
         status=pipeline_runs_models.PipelineRunStatus.PENDING,
         pipeline=pipeline,
-        triggerer=project_manager,
+        triggerer=project_manager.user,
         trigger_time=datetime.datetime.now(datetime.UTC),
         logs_last_fetched_timestamp=None,
         environment={},

--- a/backend/tests/projects/toolmodels/test_toolmodel_routes.py
+++ b/backend/tests/projects/toolmodels/test_toolmodel_routes.py
@@ -86,7 +86,7 @@ def test_update_toolmodel_order_successful(
 
 def test_move_toolmodel(
     project: projects_models.DatabaseProject,
-    project_manager: users_models.DatabaseUser,
+    project_manager: projects_users_models.DatabaseProjectUserAssociation,
     capella_model: toolmodels_models.ToolModel,
     client: testclient.TestClient,
     db: orm.Session,
@@ -95,7 +95,7 @@ def test_move_toolmodel(
     projects_users_crud.add_user_to_project(
         db,
         project=second_project,
-        user=project_manager,
+        user=project_manager.user,
         role=projects_users_models.ProjectUserRole.MANAGER,
         permission=projects_users_models.ProjectUserPermission.WRITE,
     )

--- a/backend/tests/projects/users/fixtures.py
+++ b/backend/tests/projects/users/fixtures.py
@@ -10,20 +10,19 @@ from capellacollab.projects import models as projects_models
 from capellacollab.users import models as users_models
 
 
-@pytest.fixture
-def project_manager(
+@pytest.fixture(name="project_manager")
+def fixture_project_manager(
     db: orm.Session,
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
-) -> users_models.DatabaseUser:
-    projects_users_crud.add_user_to_project(
+) -> projects_users_models.DatabaseProjectUserAssociation:
+    return projects_users_crud.add_user_to_project(
         db,
         project=project,
         user=user,
         role=projects_users_models.ProjectUserRole.MANAGER,
         permission=projects_users_models.ProjectUserPermission.WRITE,
     )
-    return user
 
 
 @pytest.fixture(name="project_user")
@@ -31,12 +30,11 @@ def fixture_project_user(
     db: orm.Session,
     project: projects_models.DatabaseProject,
     user: users_models.DatabaseUser,
-) -> users_models.DatabaseUser:
-    project_user = projects_users_crud.add_user_to_project(
+) -> projects_users_models.DatabaseProjectUserAssociation:
+    return projects_users_crud.add_user_to_project(
         db,
         project=project,
         user=user,
         role=projects_users_models.ProjectUserRole.USER,
         permission=projects_users_models.ProjectUserPermission.WRITE,
     )
-    return project_user

--- a/backend/tests/sessions/hooks/test_t4c_hook.py
+++ b/backend/tests/sessions/hooks/test_t4c_hook.py
@@ -167,7 +167,7 @@ def test_configuration_hook_as_rw_user(
     db: orm.Session,
     user: users_models.DatabaseUser,
     mock_add_user_to_repository: responses.BaseResponse,
-    project_user: projects_users_models.ProjectUserAssociation,
+    project_user: projects_users_models.DatabaseProjectUserAssociation,
     configuration_hook_request: sessions_hooks_interface.ConfigurationHookRequest,
 ):
     project_user.permission = projects_users_models.ProjectUserPermission.READ

--- a/backend/tests/users/test_tokens.py
+++ b/backend/tests/users/test_tokens.py
@@ -177,7 +177,7 @@ def test_updated_token_scope_on_role_change(
 def test_updated_token_scope_on_project_role_change(
     client: testclient.TestClient,
     project: projects_models.DatabaseProject,
-    project_user: project_users_models.ProjectUserAssociation,
+    project_user: project_users_models.DatabaseProjectUserAssociation,
 ):
     project_user.role = project_users_models.ProjectUserRole.MANAGER
 


### PR DESCRIPTION
_It's weird._ 

In our production database the primary key for the `project_user_association` table was missing. In addition, the check to add users twice didn't work. This led to users being added multiple times to projects. This PR fixes the mess.