### PR TITLE
fix: Fix issue with copyright in docs when navigating

### DIFF
--- a/docs/copyright_hook.py
+++ b/docs/copyright_hook.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+
+
+def on_config(config, **kwargs):
+    config.copyright = (
+        f"Copyright &copy; 2022-{datetime.datetime.now().year} DB InfraGO AG"
+    )

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,9 @@ theme:
         icon: material/brightness-4
         name: Switch to system preference
 
+hooks:
+  - copyright_hook.py
+
 watch:
   - custom_theme/
 
@@ -200,7 +203,3 @@ extra:
   generator: false
 
 dev_addr: 127.0.0.1:8081
-
-# prettier-ignore
-copyright:
-  'Copyright &copy; 2022-<script>document.write(new Date().getFullYear())</script> DB InfraGO AG'


### PR DESCRIPTION
This is also nice because it means the copyright will always be the year when the image was last re-built.

Closes #2188