### PR TITLE
fix: Revoke T4C session tokens for initial repositories

### DIFF
--- a/backend/capellacollab/sessions/hooks/interface.py
+++ b/backend/capellacollab/sessions/hooks/interface.py
@@ -49,6 +49,8 @@ class ConfigurationHookRequest:
         Personal access token if used for authentication
     global_scope: permissions_models.GlobalScopes
         Global permission scope of the user
+    logger: logging.LoggerAdapter
+        Logger for the specific request
     """
 
     db: orm.Session
@@ -63,6 +65,7 @@ class ConfigurationHookRequest:
     session_id: str
     pat: tokens_models.DatabaseUserToken | None
     global_scope: permissions_models.GlobalScopes
+    logger: logging.LoggerAdapter
 
 
 class ConfigurationHookResult(t.TypedDict):
@@ -201,6 +204,8 @@ class PreSessionTerminationHookRequest:
         Connection method of the session
     global_scope: permissions_models.GlobalScopes
         Global permission scope of the user
+    logger: logging.LoggerAdapter
+        Logger for the specific request
     """
 
     db: orm.Session
@@ -208,6 +213,7 @@ class PreSessionTerminationHookRequest:
     session: sessions_models.DatabaseSession
     connection_method: tools_models.ToolSessionConnectionMethod
     global_scope: permissions_models.GlobalScopes
+    logger: logging.LoggerAdapter
 
 
 class PreSessionTerminationHookResult(t.TypedDict):

--- a/backend/capellacollab/sessions/idletimeout.py
+++ b/backend/capellacollab/sessions/idletimeout.py
@@ -42,6 +42,7 @@ def terminate_idle_session():
                         permissions_injectables.get_scope(
                             (session.owner, None)
                         ),
+                        logging.LoggerAdapter(log),
                     )
                 else:
                     log.error(

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -166,6 +166,7 @@ async def request_session(
         project_scope=project_scope,
         pat=authentication_information[1],
         global_scope=global_scope,
+        logger=logger,
     )
 
     for hook_result in await util.schedule_configuration_hooks(
@@ -544,8 +545,11 @@ def terminate_session(
         permissions_models.GlobalScopes,
         fastapi.Depends(permissions_injectables.get_scope),
     ],
+    logger: t.Annotated[
+        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+    ],
 ):
-    util.terminate_session(db, session, operator, global_scope)
+    util.terminate_session(db, session, operator, global_scope, logger)
 
 
 router.include_router(router=files_routes.router, prefix="/{session_id}/files")

--- a/backend/capellacollab/sessions/util.py
+++ b/backend/capellacollab/sessions/util.py
@@ -29,6 +29,7 @@ def terminate_session(
     session: models.DatabaseSession,
     operator: k8s.KubernetesOperator,
     global_scope: permissions_models.GlobalScopes,
+    logger: logging.LoggerAdapter,
 ):
     connection_method = get_connection_method(
         session.tool, session.connection_method_id
@@ -41,6 +42,7 @@ def terminate_session(
                 operator=operator,
                 connection_method=connection_method,
                 global_scope=global_scope,
+                logger=logger,
             )
         )
 

--- a/backend/tests/sessions/hooks/conftest.py
+++ b/backend/tests/sessions/hooks/conftest.py
@@ -21,6 +21,7 @@ def fixture_configuration_hook_request(
     user: users_models.DatabaseUser,
     capella_tool: tools_models.DatabaseTool,
     capella_tool_version: tools_models.DatabaseVersion,
+    logger: logging.LoggerAdapter,
 ) -> hooks_interface.ConfigurationHookRequest:
     return hooks_interface.ConfigurationHookRequest(
         db=db,
@@ -35,6 +36,7 @@ def fixture_configuration_hook_request(
         project_scope=None,
         pat=None,
         global_scope=permissions_injectables.get_scope((user, None)),
+        logger=logger,
     )
 
 
@@ -83,6 +85,7 @@ def fixture_pre_session_termination_hook_request(
     db: orm.Session,
     user: users_models.DatabaseUser,
     session: sessions_models.DatabaseSession,
+    logger: logging.LoggerAdapter,
 ) -> hooks_interface.PreSessionTerminationHookRequest:
     return hooks_interface.PreSessionTerminationHookRequest(
         db=db,
@@ -90,4 +93,5 @@ def fixture_pre_session_termination_hook_request(
         operator=k8s_operator.KubernetesOperator(),
         session=session,
         global_scope=permissions_injectables.get_scope((user, None)),
+        logger=logger,
     )

--- a/backend/tests/sessions/test_session_hooks.py
+++ b/backend/tests/sessions/test_session_hooks.py
@@ -175,6 +175,7 @@ def test_hook_calls_during_session_termination(
     db: orm.Session,
     session: sessions_models.DatabaseSession,
     user: users_models.DatabaseUser,
+    logger: logging.LoggerAdapter,
 ):
     monkeypatch.setattr(
         sessions_crud,
@@ -187,4 +188,5 @@ def test_hook_calls_during_session_termination(
         session,
         mockoperator,  # type: ignore
         permissions_injectables.get_scope((user, None)),
+        logger,
     )


### PR DESCRIPTION
Instead of evaluating the repository list during termination again, save the repositories with issued tokens in the database and revoke the tokens for exactly the same repositories.