### PR TITLE
fix: Always show at least one skeleton loader

### DIFF
--- a/.github/workflows/storybook-diff.yml
+++ b/.github/workflows/storybook-diff.yml
@@ -23,7 +23,8 @@ jobs:
         working-directory: ./frontend
       - name: Capture screenshots
         run:
-          npx storycap --serverCmd "npx http-server storybook-static -p 9001" http://localhost:9001
+          npx storycap --serverCmd "npx http-server storybook-static -p 9001"
+          http://localhost:9001
         working-directory: ./frontend
       - uses: reg-viz/reg-actions@v2
         with:

--- a/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-skeleton-loader/mat-card-overview-skeleton-loader.component.html
+++ b/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-skeleton-loader/mat-card-overview-skeleton-loader.component.html
@@ -4,7 +4,7 @@
  -->
 
 @for (_ of _cardNumbersArray; track $index) {
-  <div class="h-[250px]">
+  <div class="h-[250px] max-w-full">
     <ngx-skeleton-loader
       count="1"
       appearance="circle"
@@ -12,6 +12,7 @@
         'border-radius': '5px',
         height: '100%',
         width: '400px',
+        'max-width': '100%',
         border: '1px solid white',
         margin: 0,
       }"

--- a/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-skeleton-loader/mat-card-overview-skeleton-loader.component.ts
+++ b/frontend/src/app/helpers/skeleton-loaders/mat-card-overview-skeleton-loader/mat-card-overview-skeleton-loader.component.ts
@@ -38,7 +38,9 @@ export class MatCardOverviewSkeletonLoaderComponent implements OnInit {
     const cardsPerColumn = this.rows ? this.rows : (0.98 * height - 120) / 275;
     const cardsPerRow = (0.98 * width) / 425;
 
-    this.cardsNumber =
-      Math.trunc(cardsPerColumn) * Math.trunc(cardsPerRow) - this.reservedCards;
+    this.cardsNumber = Math.max(
+      Math.trunc(cardsPerColumn) * Math.trunc(cardsPerRow) - this.reservedCards,
+      1,
+    );
   }
 }


### PR DESCRIPTION
On mobile devices, the mat-card-overview-skeleton-loader was not displayed.

Resolves https://github.com/DSD-DBS/capella-collab-manager/issues/1814