### PR TITLE
ci: Downgrade reg-actions to v2 (again)

### DIFF
--- a/.github/workflows/storybook-diff.yml
+++ b/.github/workflows/storybook-diff.yml
@@ -25,7 +25,7 @@ jobs:
         run:
           npx storycap --serverCmd "npx http-server storybook-static -p 9001" http://localhost:9001
         working-directory: ./frontend
-      - uses: reg-viz/reg-actions@v3
+      - uses: reg-viz/reg-actions@v2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           image-directory-path: './frontend/__screenshots__'


### PR DESCRIPTION
We thought the issue is fixed, but the pipeline still fails sporadically.