### PR TITLE
fix(session-preparation): Remove backup path instead of origin path

### DIFF
--- a/images/session-preparation/clone_repositories.py
+++ b/images/session-preparation/clone_repositories.py
@@ -52,7 +52,7 @@ def _backup_directory_if_exists(path: pathlib.Path) -> None:
 
     if backup_path.exists():
         log.info("Removing existing backup directory %s", backup_path)
-        shutil.rmtree(path)
+        shutil.rmtree(backup_path)
         log.info("Removed existing backup directory %s", backup_path)
 
     path.rename(backup_path)


### PR DESCRIPTION
During session provisioning, the original path was removed if a backup path did exist. Instead, the backup path should have been replaced with the original path.