### PR TITLE
ci: Disable caching of pip-dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,8 +45,6 @@ jobs:
           node-version: 22
       - uses: actions/setup-python@v5
         with:
-          cache: pip
-          cache-dependency-path: ./backend/pyproject.toml
           python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          cache: pip
-          cache-dependency-path: ./backend/pyproject.toml
           python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -61,8 +59,6 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          cache: pip
-          cache-dependency-path: ./backend/pyproject.toml
           python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          cache: pip
-          cache-dependency-path: ./backend/pyproject.toml
           python-version: '3.12'
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
It doesn't work properly, frequently we have failing pipelines due to errors in the "Post Install Python" step, which is out of our control.