### PR TITLE
chore: Replace usages of executor_name fixture with user/admin fixture

### DIFF
--- a/backend/tests/projects/test_projects_routes.py
+++ b/backend/tests/projects/test_projects_routes.py
@@ -12,7 +12,6 @@ import capellacollab.projects.crud as projects_crud
 import capellacollab.projects.models as projects_models
 import capellacollab.projects.users.crud as projects_users_crud
 import capellacollab.projects.users.models as projects_users_models
-import capellacollab.users.crud as users_crud
 import capellacollab.users.models as users_models
 from capellacollab.permissions import models as permissions_models
 from capellacollab.projects.permissions import (
@@ -24,15 +23,10 @@ from capellacollab.projects.toolmodels.backups import (
 )
 
 
+@pytest.mark.usefixtures("user")
 def test_get_internal_default_project_as_user(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
-    )
-
     response = client.get("/api/v1/projects/melody-model-test")
 
     assert response.status_code == 200
@@ -41,15 +35,10 @@ def test_get_internal_default_project_as_user(
     assert response.json()["slug"] == "melody-model-test"
 
 
+@pytest.mark.usefixtures("user")
 def test_get_projects_as_user_only_shows_default_internal_project(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
-    )
-
     response = client.get("/api/v1/projects")
 
     assert response.status_code == 200
@@ -79,18 +68,15 @@ def test_get_projects_as_user_with_project(
     assert data[-1]["visibility"] == "private"
 
 
+@pytest.mark.usefixtures("admin")
 def test_get_projects_as_admin(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
 ):
     project = projects_crud.create_project(
         db,
         "test project",
         visibility=projects_models.ProjectVisibility.PRIVATE,
-    )
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
     )
 
     response = client.get("/api/v1/projects")
@@ -104,18 +90,15 @@ def test_get_projects_as_admin(
     assert data[-1]["visibility"] == "private"
 
 
+@pytest.mark.usefixtures("user")
 def test_get_internal_projects_as_user(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
 ):
     project = projects_crud.create_project(
         db,
         "test project",
         visibility=projects_models.ProjectVisibility.INTERNAL,
-    )
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
     )
 
     response = client.get("/api/v1/projects")
@@ -132,11 +115,8 @@ def test_get_internal_projects_as_user(
 def test_get_internal_projects_as_user_without_duplicates(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
+    user: users_models.DatabaseUser,
 ):
-    user = users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
-    )
     project = projects_crud.create_project(
         db,
         "test project",
@@ -167,15 +147,10 @@ def test_get_internal_projects_as_user_without_duplicates(
     assert data[-1]["users"]["contributors"] == 1
 
 
+@pytest.mark.usefixtures("admin")
 def test_create_private_project_as_admin(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.post(
         "/api/v1/projects/",
         json={
@@ -192,15 +167,11 @@ def test_create_private_project_as_admin(
     assert data["visibility"] == "private"
 
 
+@pytest.mark.usefixtures("admin")
 def test_create_internal_project_as_admin(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.post(
         "/api/v1/projects/",
         json={
@@ -218,14 +189,11 @@ def test_create_internal_project_as_admin(
     assert data["visibility"] == "internal"
 
 
+@pytest.mark.usefixtures("admin")
 def test_update_project_as_admin(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
     project = projects_crud.create_project(db, "new project")
 
     assert project.slug == "new-project"
@@ -318,15 +286,10 @@ def test_get_project_per_role_manager(
     assert len(response.json()) > 0
 
 
+@pytest.mark.usefixtures("admin")
 def test_get_project_per_role_admin(
     client: testclient.TestClient,
-    executor_name: str,
-    db: orm.Session,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.get("/api/v1/projects/?minimum_role=administrator")
     assert response.status_code == 200
     assert len(response.json()) > 0

--- a/backend/tests/projects/test_projects_users_routes.py
+++ b/backend/tests/projects/test_projects_users_routes.py
@@ -109,10 +109,10 @@ def test_http_exception_when_updating_permission_of_manager(
     )
 
 
+@pytest.mark.usefixtures("user")
 def test_current_user_rights_for_internal_project(
     db: orm.Session,
     client: testclient.TestClient,
-    executor_name: str,
     project: projects_models.DatabaseProject,
 ):
     projects_crud.update_project(
@@ -121,9 +121,6 @@ def test_current_user_rights_for_internal_project(
         projects_models.PatchProject(
             visibility=projects_models.ProjectVisibility.INTERNAL
         ),
-    )
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
     )
 
     response = client.get(
@@ -135,10 +132,10 @@ def test_current_user_rights_for_internal_project(
     assert response.json()["permission"] == "read"
 
 
+@pytest.mark.usefixtures("user")
 def test_no_user_rights_on_internal_permissions(
     db: orm.Session,
     client: testclient.TestClient,
-    executor_name: str,
     project: projects_models.DatabaseProject,
 ):
     projects_crud.update_project(
@@ -147,9 +144,6 @@ def test_no_user_rights_on_internal_permissions(
         projects_models.PatchProject(
             visibility=projects_models.ProjectVisibility.PRIVATE
         ),
-    )
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
     )
 
     response = client.get(

--- a/backend/tests/projects/toolmodels/pipelines/pipeline-runs/test_pipeline_runs.py
+++ b/backend/tests/projects/toolmodels/pipelines/pipeline-runs/test_pipeline_runs.py
@@ -20,8 +20,6 @@ from capellacollab.core.logging import loki
 from capellacollab.projects.toolmodels.backups.runs import (
     injectables as runs_injectables,
 )
-from capellacollab.users import crud as users_crud
-from capellacollab.users import models as users_models
 
 
 @pytest.fixture(name="unix_time_in_ns")
@@ -214,17 +212,13 @@ def fixture_override_get_existing_pipeline_run_dependency(
 
 
 @mock.patch("capellacollab.core.logging.loki.fetch_logs_from_loki")
-@pytest.mark.usefixtures("override_get_existing_pipeline_run_dependency")
+@pytest.mark.usefixtures(
+    "override_get_existing_pipeline_run_dependency", "admin"
+)
 def test_mask_logs(
     mock_fetch_logs: mock.Mock,
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     mock_fetch_logs.return_value = [
         {
             "values": [

--- a/backend/tests/projects/toolmodels/test_toolmodel_routes.py
+++ b/backend/tests/projects/toolmodels/test_toolmodel_routes.py
@@ -15,21 +15,14 @@ from capellacollab.projects import models as projects_models
 from capellacollab.projects.toolmodels import models as toolmodels_models
 from capellacollab.tools import crud as tools_crud
 from capellacollab.tools import models as tools_models
-from capellacollab.users import crud as users_crud
-from capellacollab.users import models as users_models
 
 
+@pytest.mark.usefixtures("admin")
 def test_rename_toolmodel_successful(
     capella_model: toolmodels_models.DatabaseToolModel,
     project: projects_models.DatabaseProject,
     client: testclient.TestClient,
-    executor_name: str,
-    db: orm.Session,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.patch(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}",
         json={
@@ -43,18 +36,13 @@ def test_rename_toolmodel_successful(
     assert "new-name" in response.text
 
 
+@pytest.mark.usefixtures("admin")
 def test_rename_toolmodel_where_name_already_exists(
     client: testclient.TestClient,
     project: projects_models.DatabaseProject,
     capella_model: toolmodels_models.DatabaseToolModel,
     jupyter_model: toolmodels_models.DatabaseToolModel,
-    executor_name: str,
-    db: orm.Session,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.patch(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}",
         json={"name": jupyter_model.name, "version_id": -1, "nature_id": -1},
@@ -64,17 +52,12 @@ def test_rename_toolmodel_where_name_already_exists(
     assert response.json()["detail"]["err_code"] == "TOOLMODEL_ALREADY_EXISTS"
 
 
+@pytest.mark.usefixtures("admin")
 def test_update_toolmodel_order_successful(
     capella_model: toolmodels_models.DatabaseToolModel,
     project: projects_models.DatabaseProject,
     client: testclient.TestClient,
-    executor_name: str,
-    db: orm.Session,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.patch(
         f"/api/v1/projects/{project.slug}/models/{capella_model.slug}",
         json={"display_order": 1},
@@ -169,17 +152,12 @@ def training_tool(db: orm.Session) -> tools_models.DatabaseTool:
     return tools_crud.create_tool(db, tool)
 
 
+@pytest.mark.usefixtures("admin")
 def test_create_training_toolmodel(
     training_project: projects_models.DatabaseProject,
     client: testclient.TestClient,
     training_tool: tools_models.DatabaseTool,
-    executor_name: str,
-    db: orm.Session,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.post(
         f"/api/v1/projects/{training_project.slug}/models",
         json={
@@ -193,17 +171,12 @@ def test_create_training_toolmodel(
     assert "Valid Training Toolmodel" in response.text
 
 
+@pytest.mark.usefixtures("admin")
 def test_create_toolmodel_project_type_not_allowed(
     project: projects_models.DatabaseProject,
     client: testclient.TestClient,
     training_tool: tools_models.DatabaseTool,
-    executor_name: str,
-    db: orm.Session,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.post(
         f"/api/v1/projects/{project.slug}/models",
         json={

--- a/backend/tests/settings/teamforcapella/test_t4c_instances.py
+++ b/backend/tests/settings/teamforcapella/test_t4c_instances.py
@@ -27,8 +27,6 @@ from capellacollab.settings.modelsources.t4c.license_server import (
     models as t4c_license_server_models,
 )
 from capellacollab.tools import models as tools_models
-from capellacollab.users import crud as users_crud
-from capellacollab.users import models as users_models
 
 
 @pytest.mark.usefixtures("admin")
@@ -99,16 +97,10 @@ def test_create_t4c_instance_already_existing_name(
     assert "name already used" in detail["title"]
 
 
-@pytest.mark.usefixtures("t4c_instance")
+@pytest.mark.usefixtures("t4c_instance", "admin")
 def test_get_t4c_instances(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.get(
         "/api/v1/settings/modelsources/t4c/instances",
     )
@@ -120,16 +112,11 @@ def test_get_t4c_instances(
     assert "password" not in response.json()[1]
 
 
+@pytest.mark.usefixtures("admin")
 def test_get_t4c_instance(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
     t4c_instance: t4c_instance_models.DatabaseT4CInstance,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.get(
         f"/api/v1/settings/modelsources/t4c/instances/{t4c_instance.id}",
     )
@@ -140,16 +127,12 @@ def test_get_t4c_instance(
     assert "password" not in response.json()
 
 
+@pytest.mark.usefixtures("admin")
 def test_patch_t4c_instance(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
     t4c_instance: t4c_instance_models.DatabaseT4CInstance,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.patch(
         f"/api/v1/settings/modelsources/t4c/instances/{t4c_instance.id}",
         json={
@@ -171,16 +154,12 @@ def test_patch_t4c_instance(
     assert updated_t4c_instance.host == "localhost"
 
 
+@pytest.mark.usefixtures("admin")
 def test_patch_archived_t4c_instance_error(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
     t4c_instance: t4c_instance_models.DatabaseT4CInstance,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     t4c_instance_crud.update_t4c_instance(
         db,
         t4c_instance,
@@ -197,16 +176,12 @@ def test_patch_archived_t4c_instance_error(
     assert response.status_code == 400
 
 
+@pytest.mark.usefixtures("admin")
 def test_unarchive_t4c_instance(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
     t4c_instance: t4c_instance_models.DatabaseT4CInstance,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     t4c_instance_crud.update_t4c_instance(
         db,
         t4c_instance,
@@ -295,15 +270,11 @@ def test_delete_t4c_instance(
     assert models_t4c_crud.get_t4c_model_by_id(db, t4c_model.id) is None
 
 
+@pytest.mark.usefixtures("admin")
 def test_injectables_raise_when_archived_instance(
     db: orm.Session,
-    executor_name: str,
     t4c_instance: t4c_instance_models.DatabaseT4CInstance,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     t4c_instance_crud.update_t4c_instance(
         db,
         t4c_instance,
@@ -316,16 +287,12 @@ def test_injectables_raise_when_archived_instance(
         )
 
 
+@pytest.mark.usefixtures("admin")
 def test_update_t4c_instance_password_empty_string(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
     t4c_instance: t4c_instance_models.DatabaseT4CInstance,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     expected_password = t4c_instance.password
 
     response = client.patch(

--- a/backend/tests/settings/teamforcapella/test_t4c_license_servers.py
+++ b/backend/tests/settings/teamforcapella/test_t4c_license_servers.py
@@ -12,7 +12,6 @@ from capellacollab.settings.modelsources.t4c.license_server import (
 from capellacollab.settings.modelsources.t4c.license_server import (
     models as license_server_models,
 )
-from capellacollab.users import crud as users_crud
 from capellacollab.users import models as users_models
 
 
@@ -62,16 +61,10 @@ def test_create_t4c_license_server_already_existing_name(
     )
 
 
-@pytest.mark.usefixtures("t4c_license_server")
+@pytest.mark.usefixtures("t4c_license_server", "admin")
 def test_get_t4c_license_servers_admin(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.get(
         "/api/v1/settings/modelsources/t4c/license-servers",
     )
@@ -83,17 +76,11 @@ def test_get_t4c_license_servers_admin(
     assert response.json()[-1]["usage_api"] == "http://localhost:8086"
 
 
-@pytest.mark.usefixtures("t4c_license_server")
+@pytest.mark.usefixtures("t4c_license_server", "user")
 def test_get_t4c_license_servers(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
 ):
     """Test that the license server data is anonymized without permissions"""
-
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.USER
-    )
 
     response = client.get(
         "/api/v1/settings/modelsources/t4c/license-servers",
@@ -106,16 +93,11 @@ def test_get_t4c_license_servers(
     assert response.json()[-1]["usage_api"] == ""
 
 
+@pytest.mark.usefixtures("admin")
 def test_get_t4c_license_server(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
     t4c_license_server: license_server_models.DatabaseT4CLicenseServer,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.get(
         f"/api/v1/settings/modelsources/t4c/license-servers/{t4c_license_server.id}",
     )
@@ -123,16 +105,12 @@ def test_get_t4c_license_server(
     assert response.json()["name"] == "test license server"
 
 
+@pytest.mark.usefixtures("admin")
 def test_patch_t4c_license_server(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
     t4c_license_server: license_server_models.DatabaseT4CLicenseServer,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
-
     response = client.patch(
         f"/api/v1/settings/modelsources/t4c/license-servers/{t4c_license_server.id}",
         json={
@@ -204,16 +182,11 @@ def test_delete_t4c_license_server(
     )
 
 
-@pytest.mark.usefixtures("mock_license_server")
+@pytest.mark.usefixtures("mock_license_server", "admin")
 def test_get_t4c_license_server_usage(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
     t4c_license_server: license_server_models.DatabaseT4CLicenseServer,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
     response = client.get(
         f"/api/v1/settings/modelsources/t4c/license-servers/{t4c_license_server.id}/usage",
     )
@@ -226,13 +199,9 @@ def test_get_t4c_license_server_usage(
 @responses.activate
 def test_get_t4c_license_usage_no_status(
     client: testclient.TestClient,
-    db: orm.Session,
-    executor_name: str,
+    admin: users_models.DatabaseUser,
     t4c_license_server: license_server_models.DatabaseT4CLicenseServer,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
     responses.get(
         "http://localhost:8086/status/json",
         status=status.HTTP_200_OK,

--- a/backend/tests/settings/test_global_configuration.py
+++ b/backend/tests/settings/test_global_configuration.py
@@ -45,7 +45,7 @@ def test_get_general_configuration(
     )
 
 
-@pytest.mark.usefixtures("executor_name")
+@pytest.mark.usefixtures("user")
 def test_get_configuration_schema(client: testclient.TestClient):
     response = client.get("/api/v1/configurations/global/schema")
 

--- a/backend/tests/users/test_users.py
+++ b/backend/tests/users/test_users.py
@@ -19,14 +19,11 @@ from capellacollab.users.workspaces import crud as user_workspace_crud
 from capellacollab.users.workspaces import models as user_workspace_models
 
 
+@pytest.mark.usefixtures("admin")
 def test_get_user_by_id_admin(
     client: testclient.TestClient,
     db: orm.Session,
-    executor_name: str,
 ):
-    users_crud.create_user(
-        db, executor_name, executor_name, None, users_models.Role.ADMIN
-    )
     user = users_crud.create_user(db, "test_user", "test_user")
     response = client.get(f"/api/v1/users/{user.id}")
 


### PR DESCRIPTION
Some uses remain where I wasn't sure, plus alerts because those got reworked anyway.

Closes #2159