### PR TITLE
fix: Encode query parameters in Grafana & Prometheus auth redirects

### DIFF
--- a/backend/capellacollab/__main__.py
+++ b/backend/capellacollab/__main__.py
@@ -25,7 +25,7 @@ from capellacollab.routes import router
 from capellacollab.sessions import auth as sessions_auth
 from capellacollab.sessions import idletimeout, operators
 
-from . import __version__, metrics
+from . import __version__, metrics, redirects
 
 stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(core_logging.CustomFormatter())
@@ -160,6 +160,7 @@ async def healthcheck():
 
 app.add_route("/metrics", starlette_prometheus.metrics)
 app.include_router(router, prefix="/api/v1")
+app.include_router(redirects.router)
 
 
 def custom_openapi():

--- a/backend/capellacollab/redirects.py
+++ b/backend/capellacollab/redirects.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from urllib import parse as urllib_parse
+
+import fastapi
+from fastapi import responses
+
+router = fastapi.APIRouter()
+
+
+@router.get("/grafana{_:path}", include_in_schema=False)
+@router.get("/prometheus{_:path}", include_in_schema=False)
+def redirect_unauthorized_grafana_requests(request: fastapi.Request):
+    path = f"{request.url.path}"
+    if request.url.query:
+        path += f"?{request.url.query}"
+
+    return responses.RedirectResponse(
+        url=f"/auth?auto=true&redirectTo={urllib_parse.quote(path)}"
+    )

--- a/helm/config/nginx-grafana.conf
+++ b/helm/config/nginx-grafana.conf
@@ -34,8 +34,8 @@ http {
         }
 
         location @error401 {
-            absolute_redirect off;
-            return 302 /auth?auto=true&redirectTo=$request_uri;
+            # Pass request to backend to handle redirect
+            proxy_pass http://{{ .Release.Name }}-backend:80$request_uri;
         }
 
         location /auth {

--- a/helm/config/nginx-prometheus.conf
+++ b/helm/config/nginx-prometheus.conf
@@ -29,8 +29,8 @@ http {
         }
 
         location @error401 {
-            absolute_redirect off;
-            return 302 /auth?auto=true&redirectTo=$request_uri;
+            # Pass request to backend to handle redirect
+            proxy_pass http://{{ .Release.Name }}-backend:80;
         }
 
         location /auth {


### PR DESCRIPTION
The full URL is passed to the redirectTo query parameter in the frontend. If the full URL contains a `&`, it was treated as additional argument.

nginx doesn't provide the option to URLencode out of the box. Therefore, a small helper has been added to the backend.