### PR TITLE
fix(monitoring): Tolerate unavailable data sources

### DIFF
--- a/helm/config/grafana/alerting/rules.yaml
+++ b/helm/config/grafana/alerting/rules.yaml
@@ -36,7 +36,7 @@ groups:
               range: false
               refId: A
         noDataState: OK
-        execErrState: Error
+        execErrState: OK
         for: 10m
         annotations:
           description: A session container is in an unexpected state.
@@ -69,7 +69,7 @@ groups:
               range: false
               refId: A
         noDataState: OK
-        execErrState: Error
+        execErrState: OK
         for: 5m
         annotations:
           summary: A job has failed


### PR DESCRIPTION
Prometheus can become unavailable due to updates, restarts, etc. Since we don't consider it as essential component, this is normal behaviour. No longer send alerts if Prometheus is not reachable.