### PR TITLE
ci: Run Codecov on pull requests only

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,3 +6,4 @@ coverage:
     project:
       default:
         threshold: 2%
+        only_pulls: true


### PR DESCRIPTION
When a patch coverage is not met, but we decide that it's sufficient and merge the PR, the check fails on main. This will be avoided with this commit.