### PR TITLE
feat: Include Grafana time range in feedback emails

### DIFF
--- a/backend/capellacollab/feedback/email.jinja
+++ b/backend/capellacollab/feedback/email.jinja
@@ -38,13 +38,15 @@
         {% endif %}
     </div>
 
+    {% set current_unix_timestamp = (datetime.datetime.now(datetime.UTC).timestamp() | int) * 1000 %}
     {% if feedback.sessions %}
     <div>
         <p><strong>Sessions:</strong></p>
         {% for session in feedback.sessions %}
         <pre>{{ session.model_dump_json(indent=2) }}</pre>
-        {% set grafana_url
-        = ccm_url ~ '/grafana/d/individual-session/individual-session?orgId=1&var-session_id=' ~ session.id %}
+        {% set session_created_at_unix = (session.created_at.timestamp() | int) * 1000 %}
+        {% set grafana_url = ccm_url ~ '/grafana/d/individual-session/individual-session?orgId=1&var-session_id=' ~
+        session.id ~ '&from=' ~ session_created_at_unix ~ '&to=' ~ current_unix_timestamp ~ '&timezone=UTC' %}
         <p>Get more insights in our Grafana dashboard: <a href="{{ grafana_url }}">{{ grafana_url }}</a></p>
         {% endfor %}
     </div>

--- a/backend/capellacollab/feedback/util.py
+++ b/backend/capellacollab/feedback/util.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
 import logging
 import pathlib
 
@@ -62,7 +63,11 @@ def format_email(
     ccm_url = f"{config.general.scheme}://{config.general.host}:{config.general.port}"
 
     html_content = template.render(
-        feedback=feedback, user=user, user_agent=user_agent, ccm_url=ccm_url
+        feedback=feedback,
+        user=user,
+        user_agent=user_agent,
+        ccm_url=ccm_url,
+        datetime=datetime,
     )
 
     if feedback.sessions:


### PR DESCRIPTION
The dashboard will use the creation date of the session as from timestamp and the time where the email is sent as to timestamp.