### PR TITLE
build: Bump Grafana Loki to latest Helm Chart

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: loki
   repository: https://grafana.github.io/helm-charts/
-  version: 5.30.0
+  version: 6.27.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.21.0
-digest: sha256:78da5915214a0d59b1d90c8e269f98b904028ecf7e167600c817717568cc85fd
-generated: "2024-07-19T11:32:45.833191+02:00"
+digest: sha256:a7e758c41a20fa45804c18a9985cb9dc7065047166dfab27ba2691cb5b5bbeb1
+generated: "2025-02-18T14:02:49.123894+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
   - name: loki
     alias: loki
     condition: loki.enabled
-    version: 5.30.0
+    version: 6.27.0
     repository: https://grafana.github.io/helm-charts/
   - name: kube-state-metrics
     version: 5.21.0

--- a/helm/config/backend.yaml
+++ b/helm/config/backend.yaml
@@ -29,7 +29,7 @@ k8s:
 
   promtail:
     lokiEnabled: {{ .Values.loki.enabled }}
-    lokiURL: http://loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local/loki/api/v1
+    lokiURL: http://{{.Release.Name}}-loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local/loki/api/v1
     lokiUsername: {{ .Values.loki.gateway.basicAuth.username }}
     lokiPassword: {{ .Values.loki.gateway.basicAuth.password }}
     serverPort: 3101

--- a/helm/config/grafana/dashboards/management-portal-logs.json
+++ b/helm/config/grafana/dashboards/management-portal-logs.json
@@ -1,0 +1,130 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 10,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki_ccm"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 29,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki_ccm"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{deployment=~\".*-deployment-backend\"} |= `` | logfmt",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki_ccm"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 29,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki_ccm"
+          },
+          "direction": "backward",
+          "editorMode": "code",
+          "expr": "{deployment=~\".*-deployment-frontend\"} |= ``",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Frontend Logs",
+      "type": "logs"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Management Portal Logs",
+  "uid": "management-portal-logs",
+  "version": 3,
+  "weekStart": ""
+}

--- a/helm/config/grafana/dashboards/management-portal-logs.json.license
+++ b/helm/config/grafana/dashboards/management-portal-logs.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+SPDX-License-Identifier: Apache-2.0

--- a/helm/templates/grafana/grafana.configmap.yaml
+++ b/helm/templates/grafana/grafana.configmap.yaml
@@ -62,12 +62,12 @@ data:
         uid: loki_ccm
         access: proxy
         orgId: 1
-        url: http://loki-gateway.{{ .Release.Namespace }}.svc.cluster.local
+        url: http://{{.Release.Name}}-loki-gateway.{{ .Release.Namespace }}.svc.cluster.local
         basicAuth: true
         basicAuthUser: {{ .Values.loki.gateway.basicAuth.username }}
         secureJsonData:
           basicAuthPassword: {{ .Values.loki.gateway.basicAuth.password | required ".Values.loki.gateway.basicAuth.password is required. Please generate a random password and set it in the values.yaml." }}
-        version: 1
+        version: 2
         editable: false
       {{ end }}
       - name: Prometheus (Capella Collaboration Manager)
@@ -76,6 +76,10 @@ data:
         uid: prometheus_ccm
         version: 1
         editable: false
+    prune: true
+    deleteDatasources:
+      # Removed in https://github.com/DSD-DBS/capella-collab-manager/commit/9db351feb659a9cace46791a2a4954ddc727a895
+      - name: 'Loki (Capella Collaboration Manager)'
   dashboards.yaml: |
     apiVersion: 1
 

--- a/helm/templates/promtail/_promtail.tpl
+++ b/helm/templates/promtail/_promtail.tpl
@@ -3,7 +3,7 @@
 
 {{- define "capellacollab.promtail.default.config" }}
 clients:
-  - url: http://loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local/loki/api/v1/push
+  - url: http://{{.Release.Name}}-loki-gateway.{{- .Release.Namespace -}}.svc.cluster.local/loki/api/v1/push
     basic_auth:
       username: {{ .Values.loki.gateway.basicAuth.username }}
       password: {{ .Values.loki.gateway.basicAuth.password }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -271,14 +271,22 @@ grafana:
 loki:
   enabled: true
   global:
-    image:
-      registry: *externalRegistry
+    imageRegistry: *externalRegistry
     dnsService: kube-dns # dns-default for OpenShift
     dnsNamespace: kube-system # openshift-dns for OpenShift
   loki:
     # Disabled X-Scope-OrgID authentication
     auth_enabled: False
     podSecurityContext: *podSecurityContext
+    schemaConfig:
+      configs:
+        - from: 2023-01-01
+          store: tsdb
+          object_store: s3
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
   gateway:
     basicAuth:
       enabled: True
@@ -293,28 +301,28 @@ loki:
         cpu: '0.03'
         memory: 5Mi
         ephemeral-storage: '1Gi'
-    affinity: ''
+    affinity: null
     podSecurityContext: *podSecurityContext
   read:
     # Minimum 2 is required
     replicas: 2
 
     # We don't want to limit to specific nodes
-    affinity: ''
+    affinity: null
     resources: *resourcesLoki
   write:
     # Minimum 2 is required
     replicas: 2
 
     # We don't want to limit to specific nodes
-    affinity: ''
+    affinity: null
     resources: *resourcesLoki
   backend:
     # Minimum 2 is required
     replicas: 2
 
     # We don't want to limit to specific nodes
-    affinity: ''
+    affinity: null
     resources: *resourcesLoki
   sidecar:
     rules:


### PR DESCRIPTION
> [!IMPORTANT]
> Due to a switch in the Grafana Loki schema to TSDB, existing logs may longer be readable after the update. If you still need access to those logs, export them before the update.

In addition, add a dashboard for backend and frontend logs and prune old data sources.