### PR TITLE
fix: Clean up overview table to prevent overflows

### DIFF
--- a/frontend/src/app/sessions/session-overview/session-overview.component.html
+++ b/frontend/src/app/sessions/session-overview/session-overview.component.html
@@ -2,29 +2,15 @@
  ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
-<mat-checkbox
-  class="ml-4"
-  [ngModel]="getAllSessionsSelected()"
-  (change)="selectAllSessions($event.checked)"
-  [disabled]="!sessions?.length"
->
-  <span data-testid="select-all-sessions">Select all sessions</span>
-</mat-checkbox>
-<form
-  [formGroup]="deletionFormGroup"
-  class="max-w-[100vw] overflow-y-auto shadow-lg"
->
+<div class="max-w-[100vw] overflow-y-auto shadow-lg">
   <table mat-table [dataSource]="sessions ?? []">
-    <ng-container matColumnDef="checkbox">
-      <th mat-header-cell *matHeaderCellDef class="w-[72px]"></th>
-      <td mat-cell *matCellDef="let element">
-        <mat-checkbox [formControlName]="element.id"></mat-checkbox>
-      </td>
-    </ng-container>
-
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef class="w-[212px]">ID</th>
-      <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+      <td mat-cell *matCellDef="let element">
+        <span class="select-all font-mono">
+          {{ element.id }}
+        </span>
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="user">
@@ -33,21 +19,21 @@
     </ng-container>
 
     <ng-container matColumnDef="created_at">
-      <th mat-header-cell *matHeaderCellDef>Creation date</th>
+      <th mat-header-cell *matHeaderCellDef>Created</th>
       <td mat-cell *matCellDef="let element">
         <app-relative-time [date]="element.created_at" />
       </td>
     </ng-container>
 
     <ng-container matColumnDef="preparation_state">
-      <th mat-header-cell *matHeaderCellDef>Session Preparation</th>
+      <th mat-header-cell *matHeaderCellDef>Preparation</th>
       <td mat-cell *matCellDef="let element">
         {{ element.preparation_state }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="state">
-      <th mat-header-cell *matHeaderCellDef>Session State</th>
+      <th mat-header-cell *matHeaderCellDef>State</th>
       <td mat-cell *matCellDef="let element">{{ element.state }}</td>
     </ng-container>
 
@@ -74,19 +60,13 @@
     <ng-container matColumnDef="tool">
       <th mat-header-cell *matHeaderCellDef>Tool</th>
       <td mat-cell *matCellDef="let element">
-        {{ element.version?.tool?.name }} ({{ element.version?.name }})
-      </td>
-    </ng-container>
-
-    <ng-container matColumnDef="connection_method">
-      <th mat-header-cell *matHeaderCellDef>Connection method</th>
-      <td mat-cell *matCellDef="let element">
+        {{ element.version?.tool?.name }} ({{ element.version?.name }}) via
         {{ element.connection_method?.name }}
       </td>
     </ng-container>
 
     <ng-container matColumnDef="type">
-      <th mat-header-cell *matHeaderCellDef>Session type</th>
+      <th mat-header-cell *matHeaderCellDef>Type</th>
       <td mat-cell *matCellDef="let element">
         {{ element.type }}
       </td>
@@ -153,14 +133,14 @@
       <p>No sessions found</p>
     </div>
   }
-</form>
+</div>
 
 <button
   class="mt-4"
   mat-flat-button
-  color="primary"
+  color="warn"
   (click)="openMultiDeletionDialog()"
-  [disabled]="!getAnySessionSelected()"
+  [disabled]="sessions ? sessions.length < 1 : true"
 >
-  Terminate selected sessions
+  Terminate all sessions
 </button>

--- a/frontend/src/app/sessions/session-overview/session-overview.component.ts
+++ b/frontend/src/app/sessions/session-overview/session-overview.component.ts
@@ -4,17 +4,10 @@
  */
 import { Component, OnInit } from '@angular/core';
 import {
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
   MatButton,
   MatIconAnchor,
   MatIconButton,
 } from '@angular/material/button';
-import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
 import {
@@ -42,9 +35,6 @@ import { ConnectionDialogComponent } from '../user-sessions-wrapper/active-sessi
   selector: 'app-session-overview',
   templateUrl: './session-overview.component.html',
   imports: [
-    MatCheckbox,
-    FormsModule,
-    ReactiveFormsModule,
     MatTable,
     MatColumnDef,
     MatHeaderCellDef,
@@ -70,11 +60,8 @@ export class SessionOverviewComponent implements OnInit {
     private dialog: MatDialog,
   ) {}
 
-  deletionFormGroup = new FormGroup({});
-
   sessions: Session[] | undefined = undefined;
   displayedColumns = [
-    'checkbox',
     'id',
     'user',
     'created_at',
@@ -82,7 +69,6 @@ export class SessionOverviewComponent implements OnInit {
     'state',
     'last_seen',
     'tool',
-    'connection_method',
     'type',
     'actions',
   ];
@@ -94,22 +80,13 @@ export class SessionOverviewComponent implements OnInit {
   refreshSessions() {
     this.sessionsService.getAllSessions().subscribe((res: Session[]) => {
       this.sessions = res;
-      for (const id in this.deletionFormGroup.controls) {
-        this.deletionFormGroup.removeControl(id);
-      }
-      this.sessions.forEach((session: Session) => {
-        this.deletionFormGroup.addControl(session.id, new FormControl(false));
-      });
     });
   }
 
   openMultiDeletionDialog(): void {
-    const sessions = this.sessions?.filter(
-      (session: Session) => this.deletionFormGroup.get(session.id)?.value,
-    );
-
+    if (!this.sessions) return;
     const dialogRef = this.dialog.open(DeleteSessionDialogComponent, {
-      data: sessions,
+      data: this.sessions,
     });
 
     dialogRef.afterClosed().subscribe((_) => {
@@ -131,32 +108,6 @@ export class SessionOverviewComponent implements OnInit {
     this.dialog.open(ConnectionDialogComponent, {
       data: session,
     });
-  }
-
-  selectAllSessions(checked: boolean): void {
-    for (const id in this.deletionFormGroup.controls) {
-      this.deletionFormGroup.get(id)?.setValue(checked);
-    }
-  }
-
-  getAllSessionsSelected(): boolean {
-    for (const id in this.deletionFormGroup.controls) {
-      if (!this.deletionFormGroup.get(id)?.value) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  getAnySessionSelected(): boolean {
-    for (const id in this.deletionFormGroup.controls) {
-      if (this.deletionFormGroup.get(id)?.value) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   protected readonly subMinutes = subMinutes;

--- a/frontend/src/app/sessions/session-overview/session-overview.stories.ts
+++ b/frontend/src/app/sessions/session-overview/session-overview.stories.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { userEvent, within } from '@storybook/test';
 import MockDate from 'mockdate';
 import { of } from 'rxjs';
 import {
@@ -57,6 +56,7 @@ const sessions = [
   { ...mockReadonlySession, id: 'vjmczglcgeltbfcronujtelwx' },
   {
     ...mockPersistentSession,
+    created_at: '2024-04-30T12:00:00Z',
     preparation_state: SessionPreparationState.Failed,
     state: SessionState.Pending,
     owner: {
@@ -79,23 +79,4 @@ export const Overview: Story = {
       ],
     }),
   ],
-};
-
-export const AllSelected: Story = {
-  args: {},
-  decorators: [
-    moduleMetadata({
-      providers: [
-        {
-          provide: SessionsService,
-          useValue: new MockSessionsService(sessions),
-        },
-      ],
-    }),
-  ],
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const checkbox = canvas.getByTestId('select-all-sessions');
-    await userEvent.click(checkbox);
-  },
 };


### PR DESCRIPTION
Remove the checkbox for terminating multiple sessions, shorten some table headers, and combine some columns. This should prevent ugly overflows.