### PR TITLE
perf: Replace custom timezone validation with official one

### DIFF
--- a/backend/capellacollab/configuration/models.py
+++ b/backend/capellacollab/configuration/models.py
@@ -4,11 +4,11 @@
 import abc
 import enum
 import typing as t
-import zoneinfo
 from collections import abc as collections_abc
 
 import pydantic
 from croniter import croniter
+from pydantic_extra_types import timezone_name
 from sqlalchemy import orm
 
 from capellacollab import core
@@ -236,7 +236,7 @@ class PipelineConfiguration(core_pydantic.BaseModelStrict):
     @pydantic.field_validator("timezone")
     @classmethod
     def validate_timezone(cls, v: str) -> str:
-        if v in zoneinfo.available_timezones():
+        if v in timezone_name.get_timezones():
             return v
 
         raise ValueError(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
   "croniter",
   "pyinstrument",
   "Jinja2",
+  "pydantic-extra-types>=2.10.2",
 ]
 
 [project.urls]
@@ -124,7 +125,8 @@ module = [
   "websocket.*",
   "testcontainers.*",
   "valkey.*",
-  "jinja2.*"
+  "jinja2.*",
+  "pydantic_extra_types.*"
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Our custom validator used zoneinfo to load the list of timezones every time. The python docs say this is bad for performance, and from some profiling it looks like this was taking a decent amount of time. The official validator seems to cache the list and performs a lot better.