### PR TITLE
perf: Include token id in personal access token

### DIFF
--- a/backend/capellacollab/core/logging/injectables.py
+++ b/backend/capellacollab/core/logging/injectables.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import typing as t
+
+import fastapi
+
+from capellacollab.configuration.app import config
+
+
+class _LogAdapter(logging.LoggerAdapter):
+    def process(self, msg: str, kwargs):
+        extra: dict = self.extra | kwargs.get("extra", {})
+
+        msg = (
+            " ".join([f'{key}="{value}"' for key, value in extra.items()])
+            + f' message="{msg}"'
+        )
+        return (msg, kwargs)
+
+
+def _get_log_args(request: fastapi.Request) -> dict[str, t.Any]:
+    log_args = {}
+    if client := request.client:
+        log_args["client"] = client.host + ":" + str(client.port)
+    if hasattr(request.state, "user_name"):
+        log_args["user"] = request.state.user_name
+    return log_args | {
+        "trace_id": request.state.trace_id,
+        "method": request.method,
+        "path": request.url.path,
+        "query_params": request.url.query,
+    }
+
+
+def get_request_logger(request: fastapi.Request) -> logging.LoggerAdapter:
+    logger: logging.Logger = logging.getLogger("capellacollab.request")
+    logger.setLevel(config.logging.level)
+
+    return _LogAdapter(logger, _get_log_args(request))

--- a/backend/capellacollab/feedback/routes.py
+++ b/backend/capellacollab/feedback/routes.py
@@ -10,7 +10,7 @@ import fastapi
 from sqlalchemy import orm
 
 from capellacollab.core import database
-from capellacollab.core import logging as log
+from capellacollab.core.logging import injectables as logging_injectables
 from capellacollab.permissions import injectables as permissions_injectables
 from capellacollab.permissions import models as permissions_models
 from capellacollab.users import injectables as user_injectables
@@ -45,7 +45,8 @@ def submit_feedback(
     ],
     db: t.Annotated[orm.Session, fastapi.Depends(database.get_db)],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
     user_agent: t.Annotated[str | None, fastapi.Header()] = None,
 ):

--- a/backend/capellacollab/permissions/routes.py
+++ b/backend/capellacollab/permissions/routes.py
@@ -7,8 +7,8 @@ import typing as t
 import fastapi
 import pydantic
 
-from capellacollab.core import logging as core_logging
 from capellacollab.core import responses
+from capellacollab.core.logging import injectables as logging_injectables
 from capellacollab.users import injectables as users_injectables
 from capellacollab.users import models as users_models
 
@@ -51,7 +51,8 @@ def validate_permissions(
         models.GlobalScopes, fastapi.Depends(injectables.get_scope)
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(core_logging.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
 ):
     """Validate permissions against required scopes"""

--- a/backend/capellacollab/projects/toolmodels/diagrams/routes.py
+++ b/backend/capellacollab/projects/toolmodels/diagrams/routes.py
@@ -13,8 +13,8 @@ import fastapi
 import requests
 
 import capellacollab.projects.toolmodels.modelsources.git.injectables as git_injectables
-from capellacollab.core import logging as log
 from capellacollab.core import responses
+from capellacollab.core.logging import injectables as logging_injectables
 from capellacollab.permissions import models as permissions_models
 from capellacollab.projects.permissions import (
     injectables as projects_permissions_injectables,
@@ -51,7 +51,8 @@ async def get_diagram_metadata(
         fastapi.Depends(git_injectables.get_git_handler),
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
 ):
     (
@@ -92,7 +93,8 @@ async def get_diagram(
         fastapi.Depends(git_injectables.get_git_handler),
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
     job_id: str | None = None,
 ):

--- a/backend/capellacollab/projects/toolmodels/modelbadge/routes.py
+++ b/backend/capellacollab/projects/toolmodels/modelbadge/routes.py
@@ -9,8 +9,8 @@ import typing as t
 import fastapi
 
 import capellacollab.projects.toolmodels.modelsources.git.injectables as git_injectables
-from capellacollab.core import logging as log
 from capellacollab.core import responses
+from capellacollab.core.logging import injectables as logging_injectables
 from capellacollab.permissions import models as permissions_models
 from capellacollab.projects.permissions import (
     injectables as projects_permissions_injectables,
@@ -44,7 +44,8 @@ async def get_model_complexity_badge(
         handler.GitHandler, fastapi.Depends(git_injectables.get_git_handler)
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
 ):
     try:

--- a/backend/capellacollab/projects/toolmodels/readme/routes.py
+++ b/backend/capellacollab/projects/toolmodels/readme/routes.py
@@ -9,8 +9,8 @@ import typing as t
 import fastapi
 
 import capellacollab.projects.toolmodels.modelsources.git.injectables as git_injectables
-from capellacollab.core import logging as log
 from capellacollab.core import responses
+from capellacollab.core.logging import injectables as logging_injectables
 from capellacollab.permissions import models as permissions_models
 from capellacollab.projects.permissions import (
     injectables as projects_permissions_injectables,
@@ -42,7 +42,8 @@ async def get_readme(
         handler.GitHandler, fastapi.Depends(git_injectables.get_git_handler)
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
 ):
     _, file = await git_handler.get_file("README.md", logger, None)

--- a/backend/capellacollab/sessions/routes.py
+++ b/backend/capellacollab/sessions/routes.py
@@ -13,10 +13,10 @@ from fastapi import status
 from sqlalchemy import orm
 
 from capellacollab.core import database, responses
-from capellacollab.core import logging as log
 from capellacollab.core import models as core_models
 from capellacollab.core.authentication import exceptions as auth_exceptions
 from capellacollab.core.authentication import injectables as auth_injectables
+from capellacollab.core.logging import injectables as logging_injectables
 from capellacollab.permissions import injectables as permissions_injectables
 from capellacollab.permissions import models as permissions_models
 from capellacollab.projects import injectables as projects_injectables
@@ -87,7 +87,8 @@ async def request_session(
         k8s.KubernetesOperator, fastapi.Depends(operators.get_operator)
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
     authentication_information: t.Annotated[
         tuple[
@@ -433,7 +434,8 @@ def get_session_connection_information(
         fastapi.Depends(users_injectables.get_own_user),
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
 ):
     connection_method = util.get_connection_method(
@@ -551,7 +553,8 @@ def terminate_session(
         fastapi.Depends(permissions_injectables.get_scope),
     ],
     logger: t.Annotated[
-        logging.LoggerAdapter, fastapi.Depends(log.get_request_logger)
+        logging.LoggerAdapter,
+        fastapi.Depends(logging_injectables.get_request_logger),
     ],
 ):
     util.terminate_session(db, session, operator, global_scope, logger)

--- a/backend/capellacollab/users/tokens/injectables.py
+++ b/backend/capellacollab/users/tokens/injectables.py
@@ -20,7 +20,7 @@ def get_own_user_tokens(
         fastapi.Depends(user_injectables.get_own_user),
     ],
 ) -> abc.Sequence[models.DatabaseUserToken]:
-    return crud.get_token_by_user(db, user.id)
+    return crud.get_all_tokens_for_user(db, user.id)
 
 
 def get_exisiting_own_user_token(

--- a/backend/tests/core/authentication/test_basic_auth.py
+++ b/backend/tests/core/authentication/test_basic_auth.py
@@ -1,11 +1,49 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import datetime
 
+import pytest
 from fastapi import testclient
+from sqlalchemy import orm
 
+from capellacollab.__main__ import app
+from capellacollab.permissions import models as permissions_models
+from capellacollab.users import models as users_models
+from capellacollab.users.tokens import crud as tokens_crud
 from capellacollab.users.tokens import models as tokens_models
+
+
+@pytest.fixture(name="pat_legacy")
+def fixture_pat_legacy(
+    db: orm.Session,
+    user: users_models.DatabaseUser,
+) -> tuple[tokens_models.DatabaseUserToken, str]:
+    return tokens_crud.create_token(
+        db,
+        user,
+        scope=permissions_models.GlobalScopes(),
+        title="test",
+        description="",
+        expiration_date=None,
+        source="test",
+        legacy=True,
+    )
+
+
+@pytest.fixture(name="client_pat_legacy")
+def fixture_client_pat_legacy(
+    user: users_models.DatabaseUser,
+    pat_legacy: tuple[tokens_models.DatabaseUserToken, str],
+) -> testclient.TestClient:
+    encoded_credentials = base64.b64encode(
+        f"{user.name}:{pat_legacy[1]}".encode()
+    ).decode()
+
+    return testclient.TestClient(
+        app, headers={"Authorization": f"Basic {encoded_credentials}"}
+    )
 
 
 def test_invalid_basic_auth_unknown_user(
@@ -17,6 +55,127 @@ def test_invalid_basic_auth_unknown_user(
 
     assert response.status_code == 401
     assert response.json()["detail"]["err_code"] == "BASIC_TOKEN_INVALID"
+
+
+def test_use_pat(
+    client_pat: testclient.TestClient,
+):
+    """Test to use a PAT as authentication against the API"""
+    response = client_pat.get(
+        "/api/v1/projects",
+    )
+
+    assert response.status_code == 200
+
+
+def test_auth_with_invalid_pat(
+    user: users_models.DatabaseUser,
+    pat: tuple[tokens_models.DatabaseUserToken, str],
+) -> None:
+    """Try to authenticate with invalid PAT"""
+
+    tmp_pat = pat[1].split("_")
+    tmp_pat[1] = "invalid"
+    modified_pat = "_".join(tmp_pat)
+
+    encoded_credentials = base64.b64encode(
+        f"{user.name}:{modified_pat}".encode()
+    ).decode()
+
+    client = testclient.TestClient(
+        app, headers={"Authorization": f"Basic {encoded_credentials}"}
+    )
+    response = client.get(
+        "/api/v1/projects",
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["err_code"] == "BASIC_TOKEN_INVALID"
+
+
+def test_auth_with_token_not_found(
+    user: users_models.DatabaseUser,
+) -> None:
+    """Try to authenticate with non-existent PAT"""
+
+    encoded_credentials = base64.b64encode(
+        f"{user.name}:capellacollab_invalid_-1".encode()
+    ).decode()
+
+    client = testclient.TestClient(
+        app, headers={"Authorization": f"Basic {encoded_credentials}"}
+    )
+    response = client.get(
+        "/api/v1/projects",
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"]["err_code"] == "BASIC_TOKEN_INVALID"
+
+
+@pytest.mark.usefixtures("pat_legacy")
+def test_auth_with_pat_legacy(
+    db: orm.Session,
+    user: users_models.DatabaseUser,
+) -> None:
+    """Try to use a legacy PAT (without token id)
+
+    The legacy PAT iterates over the tokens;
+    in this case we check that the second token is valid.
+    """
+    _, password = tokens_crud.create_token(
+        db,
+        user,
+        scope=permissions_models.GlobalScopes(),
+        title="test",
+        description="",
+        expiration_date=None,
+        source="test",
+        legacy=True,
+    )
+
+    encoded_credentials = base64.b64encode(
+        f"{user.name}:{password}".encode()
+    ).decode()
+
+    client = testclient.TestClient(
+        app, headers={"Authorization": f"Basic {encoded_credentials}"}
+    )
+    response = client.get(
+        "/api/v1/projects",
+    )
+    assert response.status_code == 200
+
+
+def test_auth_with_invalid_pat_legacy_token(
+    user: users_models.DatabaseUser,
+) -> None:
+    """Try to authenticate with invalid PAT legacy token"""
+    encoded_credentials = base64.b64encode(
+        f"{user.name}:collabmanager_D5Sqm6rnE5S2fPMU58QmuLLLO1P7a5Wx".encode()
+    ).decode()
+
+    client = testclient.TestClient(
+        app, headers={"Authorization": f"Basic {encoded_credentials}"}
+    )
+    response = client.get(
+        "/api/v1/projects",
+    )
+    assert response.status_code == 401
+
+
+def test_auth_with_invalid_structured_pat(
+    user: users_models.DatabaseUser,
+) -> None:
+    encoded_credentials = base64.b64encode(
+        f"{user.name}:some-randomly-structured-token".encode()
+    ).decode()
+
+    client = testclient.TestClient(
+        app, headers={"Authorization": f"Basic {encoded_credentials}"}
+    )
+    response = client.get(
+        "/api/v1/projects",
+    )
+    assert response.status_code == 401
 
 
 def test_invalid_basic_auth_expired_token(

--- a/backend/tests/core/fixtures.py
+++ b/backend/tests/core/fixtures.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import fastapi
+import pytest
+
+from capellacollab.core.logging import injectables as logging_injectables
+
+
+@pytest.fixture(name="mock_router")
+def fixture_mock_router() -> fastapi.FastAPI:
+    return fastapi.FastAPI()
+
+
+@pytest.fixture(name="mock_request_logger")
+def fixture_mock_request_logger(mock_router: fastapi.FastAPI):
+    logger = logging.LoggerAdapter(logger=logging.getLogger())
+
+    def mock_get_request_logger() -> logging.LoggerAdapter:
+        return logger
+
+    mock_router.dependency_overrides[
+        logging_injectables.get_request_logger
+    ] = mock_get_request_logger
+
+    yield mock_router
+
+    del mock_router.dependency_overrides[
+        logging_injectables.get_request_logger
+    ]

--- a/backend/tests/users/test_tokens.py
+++ b/backend/tests/users/test_tokens.py
@@ -67,17 +67,6 @@ def test_get_pat_of_user(client: testclient.TestClient):
     assert response.status_code == 200
 
 
-def test_use_pat(
-    client_pat: testclient.TestClient,
-):
-    """Test to use a PAT as authentication against the API"""
-    response = client_pat.get(
-        "/api/v1/projects",
-    )
-
-    assert response.status_code == 200
-
-
 def test_use_invalid_pat(unauthenticated_user: users_models.User):
     """Test that an invalid PAT is declined for authentication against the API"""
     client = testclient.TestClient(app)


### PR DESCRIPTION
Instead of iterating over all personal access tokens, reference the token by ID. This speeds up the validation.

Legacy tokens remain valid, but new tokens will benefit from better performance.