### PR TITLE
perf: Increase frontend resources

### DIFF
--- a/helm/templates/frontend/frontend.deployment.yaml
+++ b/helm/templates/frontend/frontend.deployment.yaml
@@ -55,11 +55,11 @@ spec:
               port: http
           resources:
             requests:
-              cpu: "5m"
+              cpu: "75m"
               memory: 5Mi
               ephemeral-storage: "1Gi"
             limits:
-              cpu: "12m"
+              cpu: "200m"
               memory: 100Mi
               ephemeral-storage: "2Gi"
           volumeMounts:


### PR DESCRIPTION
They were reduced because usually the frontend doesn't need much resources. However, there are some spikes (hard to measure) which slow down gzip compression.