### PR TITLE
fix: Revert to old image registry format for Grafana Loki

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -271,7 +271,8 @@ grafana:
 loki:
   enabled: true
   global:
-    imageRegistry: *externalRegistry
+    image:
+      registry: *externalRegistry
     dnsService: kube-dns # dns-default for OpenShift
     dnsNamespace: kube-system # openshift-dns for OpenShift
   loki:


### PR DESCRIPTION
It was not changed even though it was stated so in the docs.