### PR TITLE
feat: Always show session overview sharing button

### DIFF
--- a/frontend/src/app/sessions/session-overview/session-overview.component.html
+++ b/frontend/src/app/sessions/session-overview/session-overview.component.html
@@ -91,15 +91,21 @@
           matTooltip="Open session in Grafana"
           ><mat-icon>monitoring</mat-icon></a
         >
-        @if (element.connection_method.sharing.enabled) {
+        <span
+          [matTooltip]="
+            element.connection_method.sharing.enabled
+              ? 'Connect to Session'
+              : 'Session does not support sharing'
+          "
+        >
           <button
             (click)="openConnectDialog(element)"
             mat-icon-button
-            matTooltip="Connect to Session"
+            [disabled]="!element.connection_method.sharing.enabled"
           >
             <mat-icon>open_in_browser</mat-icon>
           </button>
-        }
+        </span>
 
         <button
           (click)="openSingleDeletionDialog(element)"

--- a/frontend/src/app/sessions/session-overview/session-overview.stories.ts
+++ b/frontend/src/app/sessions/session-overview/session-overview.stories.ts
@@ -16,6 +16,7 @@ import {
   mockReadonlySession,
 } from 'src/storybook/session';
 import { mockUser } from 'src/storybook/user';
+import { mockHttpConnectionMethod } from '../../../storybook/tool';
 import { SessionOverviewComponent } from './session-overview.component';
 
 const meta: Meta<SessionOverviewComponent> = {
@@ -54,6 +55,16 @@ export const NoSessions: Story = {
 const sessions = [
   mockPersistentSession,
   { ...mockReadonlySession, id: 'vjmczglcgeltbfcronujtelwx' },
+  {
+    ...mockReadonlySession,
+    connection_method: {
+      ...mockHttpConnectionMethod,
+      sharing: {
+        enabled: true,
+      },
+    },
+    id: 'afgbrmirzwxpjwfkxszemtlde',
+  },
   {
     ...mockPersistentSession,
     created_at: '2024-04-30T12:00:00Z',


### PR DESCRIPTION
Disable it with a tooltip if session sharing is not enabled