### PR TITLE
build: Disable Guacamole in local environments by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ options can be changed at any time later:
 > Currently, we only provide amd64 images. If you want to run the
 > application on arm64, you need to build the images yourself (option 3 or 4).
 
+<!-- prettier-ignore -->
+> [!NOTE]
+> Since version v4.21.0, Guacamole is no longer deployed by default in local environments.
+> If you want to use Guacamole, you need to set the environment variable `DEPLOY_GUACAMOLE=1`.
+
 1. Fetch management portal and session images from GitHub (without
    TeamForCapella support). This option is recommended for the first
    deployment.

--- a/helm/templates/guacamole/guacamole-postgres.configmap.yaml
+++ b/helm/templates/guacamole/guacamole-postgres.configmap.yaml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.database.guacamole.deploy }}
+{{ if and .Values.database.guacamole.deploy .Values.guacamole.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/guacamole/guacamole-postgres.deployment.yaml
+++ b/helm/templates/guacamole/guacamole-postgres.deployment.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.database.guacamole.deploy }}
+{{ if and .Values.database.guacamole.deploy .Values.guacamole.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/guacamole/guacamole-postgres.disruptionbudget.yml
+++ b/helm/templates/guacamole/guacamole-postgres.disruptionbudget.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if and .Values.database.guacamole.deploy .Values.guacamole.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,3 +11,4 @@ spec:
   selector:
     matchLabels:
       id: {{ .Release.Name }}-deployment-guacamole-postgres
+{{ end }}

--- a/helm/templates/guacamole/guacamole-postgres.service.yaml
+++ b/helm/templates/guacamole/guacamole-postgres.service.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.database.guacamole.deploy }}
+{{ if and .Values.database.guacamole.deploy .Values.guacamole.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/templates/guacamole/guacamole-postgres.volume.yaml
+++ b/helm/templates/guacamole/guacamole-postgres.volume.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.database.guacamole.deploy }}
+{{ if and .Values.database.guacamole.deploy .Values.guacamole.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/templates/guacamole/guacamole-postgres.vpa.yaml
+++ b/helm/templates/guacamole/guacamole-postgres.vpa.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if and .Values.cluster.vpa.enabled .Values.database.guacamole.deploy }}
+{{ if and .Values.cluster.vpa.enabled .Values.database.guacamole.deploy .Values.guacamole.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/templates/guacamole/guacamole.deployment.yaml
+++ b/helm/templates/guacamole/guacamole.deployment.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.guacamole.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -134,3 +135,4 @@ spec:
             - name: logs
               mountPath: /var/log/guacamole
         {{ end }}
+{{ end }}

--- a/helm/templates/guacamole/guacamole.disruptionbudget.yml
+++ b/helm/templates/guacamole/guacamole.disruptionbudget.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.guacamole.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,3 +11,4 @@ spec:
   selector:
     matchLabels:
       id: {{ .Release.Name }}-deployment-guacamole-guacamole
+{{ end }}

--- a/helm/templates/guacamole/guacamole.service.yaml
+++ b/helm/templates/guacamole/guacamole.service.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.guacamole.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+{{ end }}

--- a/helm/templates/guacamole/guacamole.volume.yaml
+++ b/helm/templates/guacamole/guacamole.volume.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.loki.enabled }}
+{{ if and .Values.loki.enabled .Values.guacamole.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/templates/guacamole/guacamole.vpa.yaml
+++ b/helm/templates/guacamole/guacamole.vpa.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.cluster.vpa.enabled }}
+{{ if and .Values.cluster.vpa.enabled .Values.guacamole.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/templates/guacamole/guacd.deployment.yaml
+++ b/helm/templates/guacamole/guacd.deployment.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.guacamole.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -106,3 +107,4 @@ spec:
             - name: logs
               mountPath: /var/log/guacd
         {{ end }}
+{{ end }}

--- a/helm/templates/guacamole/guacd.disruptionbudget.yml
+++ b/helm/templates/guacamole/guacd.disruptionbudget.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.guacamole.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,3 +11,4 @@ spec:
   selector:
     matchLabels:
       id: {{ .Release.Name }}-deployment-guacamole-guacd
+{{ end }}

--- a/helm/templates/guacamole/guacd.service.yaml
+++ b/helm/templates/guacamole/guacd.service.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{ if .Values.guacamole.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
       targetPort: guacd
       protocol: TCP
       name: guacd
+{{ end }}

--- a/helm/templates/guacamole/guacd.volume.yaml
+++ b/helm/templates/guacamole/guacd.volume.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.loki.enabled }}
+{{ if and .Values.loki.enabled .Values.guacamole.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/templates/guacamole/guacd.vpa.yaml
+++ b/helm/templates/guacamole/guacd.vpa.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.cluster.vpa.enabled }}
+{{ if and .Values.cluster.vpa.enabled .Values.guacamole.enabled }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -183,6 +183,7 @@ backend:
   profiling: false
 
 guacamole:
+  enabled: true
   username: guacadmin
   password: guacadmin
 


### PR DESCRIPTION
In many cases, Guacamole is not required when developing locally. To improve the startup process & time, it's disabled by default, but can be enabled at any time via the environment `DEPLOY_GUACAMOLE=1`