### PR TITLE
fix: Disable session viewer border in fullscreen-mode

### DIFF
--- a/frontend/src/app/sessions/session/session-iframe/session-iframe.component.html
+++ b/frontend/src/app/sessions/session/session-iframe/session-iframe.component.html
@@ -69,6 +69,8 @@
     allow="clipboard-read; clipboard-write"
     [ngClass]="{
       'pointer-events-none': session.disabled,
+      'border border-slate-200':
+        (fullscreenService.isFullscreen$ | async) === false,
     }"
   >
   </iframe>

--- a/frontend/src/app/sessions/session/session-iframe/session-iframe.component.ts
+++ b/frontend/src/app/sessions/session/session-iframe/session-iframe.component.ts
@@ -2,9 +2,10 @@
  * SPDX-FileCopyrightText: Copyright DB InfraGO AG and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { NgClass } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { AsyncPipe, NgClass } from '@angular/common';
+import { Component, inject, Input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
+import { FullscreenService } from 'src/app/sessions/service/fullscreen.service';
 import { SessionService } from 'src/app/sessions/service/session.service';
 import { ViewerSession } from '../session-viewer.service';
 
@@ -12,10 +13,12 @@ import { ViewerSession } from '../session-viewer.service';
   selector: 'app-session-iframe',
   templateUrl: './session-iframe.component.html',
   styleUrls: ['./session-iframe.component.css'],
-  imports: [NgClass, MatIconModule],
+  imports: [NgClass, MatIconModule, AsyncPipe],
 })
 export class SessionIFrameComponent {
   @Input({ required: true }) session!: ViewerSession;
+
+  public fullscreenService = inject(FullscreenService);
 
   constructor(public sessionService: SessionService) {}
 }

--- a/frontend/src/app/sessions/session/tiling-window-manager/tiling-window-manager.component.html
+++ b/frontend/src/app/sessions/session/tiling-window-manager/tiling-window-manager.component.html
@@ -11,7 +11,7 @@
       [style.width]="session.width + 'px'"
     >
       <div
-        class="flex items-center justify-between gap-2 rounded-t bg-slate-100 p-1"
+        class="flex items-center justify-between gap-2 rounded-t bg-slate-200 p-1"
       >
         <span>
           {{ session.version.tool.name }} {{ session.version.name }},


### PR DESCRIPTION
In fullscreen-mode, the white border looked strange, esp. with applications running in dark mode.