### PR TITLE
fix: Handle planned but not executed termination of sessions

### DIFF
--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/session-card/session-card.component.html
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/session-card/session-card.component.html
@@ -68,12 +68,17 @@
       >
         <mat-icon class="shrink-0">warning</mat-icon>
         <div>
-          This session will automatically terminate
-          <app-relative-time
-            [date]="addMinutes(Date.now(), remainingMinutes)"
-            dateFormat="PPp"
-          />
-          if you do not interact with it.
+          @if (remainingMinutes > 0) {
+            This session will automatically terminate
+            <app-relative-time
+              [date]="addMinutes(Date.now(), remainingMinutes)"
+              dateFormat="PPp"
+            />
+            if you do not interact with it.
+          } @else {
+            This session has been marked for termination due to inactivity. It
+            will be terminated soon.
+          }
         </div>
       </div>
     }

--- a/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/session-card/session-card.stories.ts
+++ b/frontend/src/app/sessions/user-sessions-wrapper/active-sessions/session-card/session-card.stories.ts
@@ -105,6 +105,23 @@ export const SessionTerminatingSoon: Story = {
   },
 };
 
+export const SessionTerminatingNow: Story = {
+  args: {
+    session: {
+      selected: false,
+      ...mockPersistentSession,
+      preparation_state: SessionPreparationState.Completed,
+      state: SessionState.Running,
+      idle_state: {
+        available: true,
+        terminate_after_minutes: 90,
+        idle_for_minutes: 91,
+        unavailable_reason: null,
+      },
+    },
+  },
+};
+
 export const SessionTerminatedState: Story = {
   args: {
     session: {


### PR DESCRIPTION
If a session is marked for termination, but the termination didn't happen (yet), the termination message on the session card was confusing. It said "The session will terminate in X minutes ago", which doesn't make much sense.

This case is handled and a new message is displayed.