### PR TITLE
feat: Make slugs of projects and tool models immutable

### DIFF
--- a/backend/capellacollab/projects/crud.py
+++ b/backend/capellacollab/projects/crud.py
@@ -33,6 +33,16 @@ def get_internal_projects(
     )
 
 
+def get_project_by_name(
+    db: orm.Session, name: str
+) -> models.DatabaseProject | None:
+    return db.execute(
+        sa.select(models.DatabaseProject).where(
+            models.DatabaseProject.name == name
+        )
+    ).scalar_one_or_none()
+
+
 def get_project_by_slug(
     db: orm.Session, slug: str
 ) -> models.DatabaseProject | None:
@@ -80,9 +90,6 @@ def update_project(
     project: models.DatabaseProject,
     patch_project: models.PatchProject,
 ) -> models.DatabaseProject:
-    if patch_project.name:
-        project.slug = slugify.slugify(patch_project.name)
-
     database.patch_database_with_pydantic_object(project, patch_project)
 
     db.commit()

--- a/backend/capellacollab/projects/exceptions.py
+++ b/backend/capellacollab/projects/exceptions.py
@@ -22,6 +22,20 @@ class ProjectNotFoundError(core_exceptions.BaseError):
         return cls("test")
 
 
+class ProjectNameAlreadyExistsError(core_exceptions.BaseError):
+    def __init__(self, project_name: str):
+        super().__init__(
+            status_code=status.HTTP_409_CONFLICT,
+            title="Project already exists",
+            reason=f"The project with the name '{project_name}' already exists.",
+            err_code="PROJECT_NAME_ALREADY_EXISTS",
+        )
+
+    @classmethod
+    def openapi_example(cls) -> "ProjectNameAlreadyExistsError":
+        return cls("Coffee Machine")
+
+
 class ProjectAlreadyExistsError(core_exceptions.BaseError):
     def __init__(self, project_slug: str):
         super().__init__(

--- a/backend/capellacollab/projects/toolmodels/crud.py
+++ b/backend/capellacollab/projects/toolmodels/crud.py
@@ -143,7 +143,6 @@ def update_model(
         model.description = description
     if name:
         model.name = name
-        model.slug = slugify.slugify(name)
     if display_order:
         model.display_order = display_order
     db.commit()

--- a/frontend/src/app/openapi/api/projects-models.service.ts
+++ b/frontend/src/app/openapi/api/projects-models.service.ts
@@ -430,7 +430,7 @@ export class ProjectsModelsService {
 
     /**
      * Patch Tool Model
-     * Update or move a tool model.  A model can be moved to another project by patching the project_slug attribute.  If a model is moved to another project, the &#x60;tool_models:create&#x60; permission is required in the target project.&lt;br /&gt;&lt;br /&gt;This route requires the following permissions in the corresponding project: &#x60;tool_models:update&#x60;
+     * Update or move a tool model.  A model can be moved to another project by patching the project_slug attribute.  If a model is moved to another project, the &#x60;tool_models:delete&#x60; permission in the source project and the &#x60;tool_models:create&#x60; permission in the target project are required.&lt;br /&gt;&lt;br /&gt;This route requires the following permissions in the corresponding project: &#x60;tool_models:update&#x60;
      * @param projectSlug 
      * @param modelSlug 
      * @param patchToolModel 

--- a/frontend/src/app/openapi/api/projects.service.ts
+++ b/frontend/src/app/openapi/api/projects.service.ts
@@ -201,7 +201,7 @@ export class ProjectsService {
 
     /**
      * Create Project
-     * This route requires the following permissions: &#x60;user.projects:create&#x60;
+     * Create a new project.  The project slug is auto-generated from the project name and can\&#39;t be changed.&lt;br /&gt;&lt;br /&gt;This route requires the following permissions: &#x60;user.projects:create&#x60;
      * @param postProjectRequest 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -853,7 +853,7 @@ export class ProjectsService {
 
     /**
      * Update Project
-     * Update a project\&#39;s metadata.  An update of the name will also change the slug. This will break existing API routes and the project provisioning. Be careful with project renames.  If the project is archived, all pipelines will be deleted.&lt;br /&gt;&lt;br /&gt;This route requires the following permissions in the corresponding project: &#x60;root:update&#x60;
+     * Update a project\&#39;s metadata.  If the project is archived, all pipelines will be deleted.&lt;br /&gt;&lt;br /&gt;This route requires the following permissions in the corresponding project: &#x60;root:update&#x60;
      * @param projectSlug 
      * @param patchProject 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.html
@@ -3,68 +3,60 @@
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 <div class="wrapper">
-  <div id="metadata-card" class="collab-card w-fit">
-    <form [formGroup]="form">
-      <div>
-        <mat-form-field appearance="fill" class="w-full max-w-lg">
-          <mat-label>Name</mat-label>
-          <input matInput formControlName="name" data-testid="name-input" />
-          @if (form.controls.name.errors?.required) {
-            <mat-error>The project name is required.</mat-error>
-          } @else if (form.controls.name.errors?.uniqueSlug) {
-            <mat-error>A project with a similar name already exists.</mat-error>
-          } @else if (project?.slug !== newSlug && form.controls.name.valid) {
-            <mat-hint
-              >If you proceed, the project slug will be changed to
-              <i>{{ newSlug }}</i> - Please make sure to update all
-              references.</mat-hint
-            >
-          }
-        </mat-form-field>
+  <div id="metadata-card" class="collab-card flex w-fit flex-col gap-4">
+    <form [formGroup]="form" class="flex flex-col gap-4">
+      <mat-form-field
+        appearance="fill"
+        class="w-full max-w-lg"
+        subscriptSizing="dynamic"
+      >
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name" data-testid="name-input" />
+        @if (form.controls.name.errors?.required) {
+          <mat-error>The project name is required.</mat-error>
+        } @else if (form.controls.name.errors?.uniqueSlug) {
+          <mat-error>A project with a similar name already exists.</mat-error>
+        }
+      </mat-form-field>
+      <mat-form-field
+        appearance="fill"
+        class="w-full max-w-lg"
+        subscriptSizing="dynamic"
+      >
+        <mat-label>Description</mat-label>
+        <textarea
+          formControlName="description"
+          matInput
+          rows="3"
+          style="resize: none"
+          [placeholder]="
+            'This is the description of the project ' + project?.name
+          "
+        ></textarea>
+      </mat-form-field>
+      <div class="flex flex-col">
+        <h3>Project visibility</h3>
+        <mat-radio-group formControlName="visibility" class="flex flex-col">
+          <mat-radio-button
+            *ngFor="let visibility of projectService.getAvailableVisibilities()"
+            [value]="visibility"
+          >
+            {{ projectService.getProjectVisibilityDescription(visibility) }}
+          </mat-radio-button>
+        </mat-radio-group>
       </div>
-      <div>
-        <mat-form-field appearance="fill" class="w-full max-w-lg">
-          <mat-label>Description</mat-label>
-          <textarea
-            formControlName="description"
-            matInput
-            rows="3"
-            style="resize: none"
-            [placeholder]="
-              'This is the description of the project ' + project?.name
+      <div class="flex flex-col">
+        <h3>Project type</h3>
+        <mat-radio-group formControlName="type" class="flex flex-col">
+          <mat-radio-button
+            *ngFor="
+              let projectType of projectService.getAvailableProjectTypes()
             "
-          ></textarea>
-        </mat-form-field>
-      </div>
-      <div>
-        <div class="flex flex-col">
-          <h3>Project visibility</h3>
-          <mat-radio-group formControlName="visibility" class="flex flex-col">
-            <mat-radio-button
-              *ngFor="
-                let visibility of projectService.getAvailableVisibilities()
-              "
-              [value]="visibility"
-            >
-              {{ projectService.getProjectVisibilityDescription(visibility) }}
-            </mat-radio-button>
-          </mat-radio-group>
-        </div>
-      </div>
-      <div>
-        <div class="flex flex-col">
-          <h3>Project type</h3>
-          <mat-radio-group formControlName="type" class="flex flex-col">
-            <mat-radio-button
-              *ngFor="
-                let projectType of projectService.getAvailableProjectTypes()
-              "
-              [value]="projectType"
-            >
-              {{ projectService.getProjectTypeDescription(projectType) }}
-            </mat-radio-button>
-          </mat-radio-group>
-        </div>
+            [value]="projectType"
+          >
+            {{ projectService.getProjectTypeDescription(projectType) }}
+          </mat-radio-button>
+        </mat-radio-group>
       </div>
     </form>
     <div class="flex justify-between">

--- a/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.ts
+++ b/frontend/src/app/projects/project-detail/edit-project-metadata/edit-project-metadata.component.ts
@@ -12,19 +12,13 @@ import {
   ReactiveFormsModule,
 } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
-import {
-  MatFormField,
-  MatLabel,
-  MatError,
-  MatHint,
-} from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { MatTooltip } from '@angular/material/tooltip';
 import { Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { filter } from 'rxjs';
-import slugify from 'slugify';
 import { ToastService } from 'src/app/helpers/toast/toast.service';
 import { PatchProject, Project } from 'src/app/openapi';
 import { ProjectUserService } from 'src/app/projects/project-detail/project-users/service/project-user.service';
@@ -41,7 +35,6 @@ import { ProjectWrapperService } from '../../service/project.service';
     MatLabel,
     MatInput,
     MatError,
-    MatHint,
     MatRadioGroup,
     NgFor,
     MatRadioButton,
@@ -99,11 +92,5 @@ export class EditProjectMetadataComponent implements OnInit, OnChanges {
           );
         });
     }
-  }
-
-  get newSlug(): string | null {
-    return this.form.value.name
-      ? slugify(this.form.value.name, { lower: true })
-      : null;
   }
 }


### PR DESCRIPTION
Before, the slug was auto-updated when the name of a project or tool model was changed. However, the relevance of the slug grew over time and a change can break many parts, in particual:

- The slugs are used for the file-paths of the training provisioning
- The slugs are used as unique identifier for the API; existing script may break after an update.

It's indended to add another feature to update the slug individually in the future. Until then, a new project can be created and all models can be moved to the new project.