### PR TITLE
fix: Clear background color for mat-trees

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -106,6 +106,7 @@ table {
   --field-padding: 0.75em;
   --section-card-width: 32em;
   --mat-sidenav-container-width: "fit-content";
+  --mat-tree-container-background-color: "transparent";
 }
 
 .expansion-panel > .mat-content {


### PR DESCRIPTION
A new background color was introduced with Material 3, but it doesn't fit in our design. Let's remove it again.