### PR TITLE
fix: Pin click to '<8.2.0' due to incompatible breaking change

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "aiohttp",
   "argon2-cffi",
   "typer",
+  "click<8.2.0", # https://github.com/fastapi/typer/discussions/1215
   "lxml",
   "valkey[libvalkey]",
   "cryptography",

--- a/frontend/src/app/settings/core/tags/tags.component.html
+++ b/frontend/src/app/settings/core/tags/tags.component.html
@@ -47,6 +47,7 @@
           data-testid="hex-color-input"
           formControlName="hex_color"
           placeholder="#ffffff"
+          spellcheck="false"
         />
         @if (newTagForm.get("hex_color")?.errors?.["pattern"]) {
           <mat-error>
@@ -64,6 +65,7 @@
           data-testid="icon-input"
           formControlName="icon"
           placeholder="Icon name of Google Material Icons"
+          spellcheck="false"
         />
       </mat-form-field>
     </div>


### PR DESCRIPTION
https://github.com/fastapi/typer/discussions/1215