### PR TITLE
Revert "fix: Pin click to '<8.2.0' due to incompatible breaking change"

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   "aiohttp",
   "argon2-cffi",
   "typer",
-  "click<8.2.0", # https://github.com/fastapi/typer/discussions/1215
   "lxml",
   "valkey[libvalkey]",
   "cryptography",


### PR DESCRIPTION
This reverts commit 4586d6f8efa1294643514a12cbfac54e725bffa2.

No longer needed, fixed by https://github.com/fastapi/typer/releases/tag/0.15.4