### PR TITLE
fix: Handle fast scrolling of project overview tags

### DIFF
--- a/frontend/src/app/projects/project-overview/project-overview.component.ts
+++ b/frontend/src/app/projects/project-overview/project-overview.component.ts
@@ -149,7 +149,7 @@ export class ProjectOverviewComponent implements OnInit {
     if (!this.isScrollable(project, distance > 0 ? 'right' : 'left')) return;
     this.scrollPosition[project.id] += distance;
     tagsWidget.nativeElement.scrollTo({
-      left: tagsWidget.nativeElement.scrollLeft + distance,
+      left: this.scrollPosition[project.id] + distance,
       behavior: 'smooth',
     });
   }


### PR DESCRIPTION
When clicking the scroll button too quickly,
the scrolling used the actual instead of the target scroll position.