### PR TITLE
refactor: Use Valibot instead of Zod to decrease bundle size

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,9 +44,9 @@
     "storycap": "^5.0.1",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0",
+    "valibot": "^1.1.0",
     "vscode-uri": "^3.1.0",
     "yaml": "^2.8.0",
-    "zod": "^3.25.57",
     "zone.js": "^0.15.1"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -107,15 +107,15 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
       vscode-uri:
         specifier: ^3.1.0
         version: 3.1.0
       yaml:
         specifier: ^2.8.0
         version: 2.8.0
-      zod:
-        specifier: ^3.25.57
-        version: 3.25.57
       zone.js:
         specifier: ^0.15.1
         version: 0.15.1
@@ -6993,6 +6993,14 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -11120,7 +11128,7 @@ snapshots:
       postcss-modules-scope: 3.2.1(postcss@8.5.4)
       postcss-modules-values: 4.0.0(postcss@8.5.4)
       postcss-value-parser: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
     optionalDependencies:
       webpack: 5.98.0(esbuild@0.25.4)
 
@@ -13605,7 +13613,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
       postcss: 8.5.2
-      semver: 7.7.1
+      semver: 7.7.2
     optionalDependencies:
       webpack: 5.98.0(esbuild@0.25.4)
     transitivePeerDependencies:
@@ -14918,6 +14926,10 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
My original plan was to migrate this project to Zod v4 mini (which has a similarly small bundle size), but as this requires certain tsconfig options that don't work with Angular, I decided to replace Zod with Valibot. This also fixes a bug where an invalid session history would be permanently corrupted instead of automatically resetting itself.