### PR TITLE
perf: Improve backend startup time by avoid calling metrics collectors

### DIFF
--- a/backend/capellacollab/core/database/metrics.py
+++ b/backend/capellacollab/core/database/metrics.py
@@ -21,6 +21,12 @@ class DatabasePoolSizeCollector(prometheus_registry.Collector):
 
         yield metric
 
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_pool_size",
+            "SQLAlchemy database connection pool size",
+        )
+
 
 class DatabaseConnectionsInPoolCollector(prometheus_registry.Collector):
     def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
@@ -32,6 +38,12 @@ class DatabaseConnectionsInPoolCollector(prometheus_registry.Collector):
         metric.add_metric([], engine.pool.checkedin())  # type: ignore[attr-defined]
 
         yield metric
+
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_connections_in_pool",
+            "Available database connections in the SQLAlchemy pool",
+        )
 
 
 class DatabaseOverflowCollector(prometheus_registry.Collector):
@@ -45,6 +57,12 @@ class DatabaseOverflowCollector(prometheus_registry.Collector):
 
         yield metric
 
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_pool_overflow",
+            "Overflow of the SQLAlchemy database connection pool",
+        )
+
 
 class DatabaseCheckedOutConnectionsCollector(prometheus_registry.Collector):
     def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
@@ -56,6 +74,12 @@ class DatabaseCheckedOutConnectionsCollector(prometheus_registry.Collector):
         metric.add_metric([], engine.pool.checkedout())  # type: ignore[attr-defined]
 
         yield metric
+
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "sqlalchemy_checked_out_connections",
+            "Checked out SQLAlchemy database connections",
+        )
 
 
 def register() -> None:

--- a/backend/capellacollab/feedback/metrics.py
+++ b/backend/capellacollab/feedback/metrics.py
@@ -33,6 +33,13 @@ class FeedbackCollector(prometheus_registry.Collector):
 
         yield metric
 
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "feedback_count",
+            "Submitted feedback",
+            labels=["rating", "anonymous"],
+        )
+
 
 def register() -> None:
     prometheus_client.REGISTRY.register(FeedbackCollector())

--- a/backend/capellacollab/sessions/metrics.py
+++ b/backend/capellacollab/sessions/metrics.py
@@ -24,6 +24,12 @@ class DatabaseSessionsCollector(prometheus_registry.Collector):
             metric.add_metric([], crud.count_sessions(db))
         yield metric
 
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "backend_database_sessions",
+            "Sessions registered in the backend database",
+        )
+
 
 class DeployedSessionsCollector(prometheus_registry.Collector):
     def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
@@ -46,6 +52,13 @@ class DeployedSessionsCollector(prometheus_registry.Collector):
         for labels, g in itertools.groupby(statuses):
             metric.add_metric(labels, len(list(g)))
         yield metric
+
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "backend_deployed_sessions",
+            "Sessions running in the sessions namespace",
+            labels=("workload", "phase"),
+        )
 
 
 def register() -> None:

--- a/backend/capellacollab/settings/modelsources/t4c/license_server/metrics.py
+++ b/backend/capellacollab/settings/modelsources/t4c/license_server/metrics.py
@@ -40,6 +40,13 @@ class UsedT4CLicensesCollector(prometheus_registry.Collector):
             )
         yield metric
 
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "used_t4c_licenses",
+            "Currently used T4C licenses per registered TeamForCapella license server.",
+            labels=["license_server_name", "license_server_id"],
+        )
+
 
 class TotalT4CLicensesCollector(prometheus_registry.Collector):
     def collect(self) -> t.Iterable[prometheus_client.core.Metric]:
@@ -68,6 +75,13 @@ class TotalT4CLicensesCollector(prometheus_registry.Collector):
                 [license_server.name, str(license_server.id)], total_licenses
             )
         yield metric
+
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "total_t4c_licenses",
+            "Available licenses per registered TeamForCapella license server.",
+            labels=["license_server_name", "license_server_id"],
+        )
 
 
 def register() -> None:

--- a/backend/capellacollab/users/metrics.py
+++ b/backend/capellacollab/users/metrics.py
@@ -28,6 +28,13 @@ class UserCountCollector(prometheus_registry.Collector):
 
         yield metric
 
+    def describe(self) -> t.Iterable[prometheus_client.core.Metric]:
+        yield prometheus_client.core.GaugeMetricFamily(
+            "user_count",
+            "Amount of registered users",
+            labels=["beta"],
+        )
+
 
 def register() -> None:
     prometheus_client.REGISTRY.register(UserCountCollector())


### PR DESCRIPTION
When providing a describe() function on the metric collectors, the collect function is no longer called during startup. This avoids delayed startups due to waiting for I/O (e.g. TeamForCapella Server).